### PR TITLE
Make AA crate hand-craftable

### DIFF
--- a/overrides/scripts/expertmode.zs
+++ b/overrides/scripts/expertmode.zs
@@ -322,6 +322,10 @@ assembler.recipeBuilder()
     .inputs(<ore:chestWood> * 4, <metaitem:frameTreatedWood> * 4, <metaitem:crate.steel>)
     .outputs(<actuallyadditions:block_giant_chest>)
     .duration(100).EUt(7).buildAndRegister();
+recipes.addShaped(<actuallyadditions:block_giant_chest>, [
+    [<ore:chestWood>, <metaitem:frameTreatedWood>, <ore:chestWood>],
+    [<metaitem:frameTreatedWood>, <metaitem:crate.steel>, <metaitem:frameTreatedWood>],
+    [<ore:chestWood>, <metaitem:frameTreatedWood>, <ore:chestWood>]]);
 
 // Drawer Upgrades
 recipes.remove(<storagedrawers:upgrade_template>);


### PR DESCRIPTION
AA crate is more of a QoL than important tech progression, it should not really be gated behind assembling machine. Expert mode has a larger demand on ores and raw mats, rendering chests and GT crates (bronze, steel) difficult to organize in early game. (You will need more than one for different ores and potentially forget which one you put in what)

As discussed in the Discord server:

>[ME#6199] does AA crate need to be gated behind assembling machine? To me there's no point since you'll only need crates by super early game for ores and resources. When you get assembling machine, it's not far from AE2 anyways
>is forcing people to use vanilla double chest kind of an unnecessary grind?🤔
>...
>[nullmana#4313] idk give yourself a stack of crates and be done with it
>There's no sensible reason to disable them...
>...
>[insane_dude#8345 (STE all stable MM)] also agree about QoL

__I totally agree with this recipe modification, just making it hand-craftable__