### PR TITLE
Fix Microversium Ingot Quest

### DIFF
--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -30707,9 +30707,9 @@
           "autoConsume:1": 0,
           "requiredItems:9": {
             "0:10": {
-              "id:8": "gregtech:meta_item_1",
+              "id:8": "gregtech:meta_ingot",
               "Count:3": 64,
-              "Damage:2": 10976,
+              "Damage:2": 32027,
               "OreDict:8": ""
             }
           },


### PR DESCRIPTION
Showed as invalid item in hard mode's version of the quest book.