### PR TITLE
Fix CustomMainMenu configuration. 

### DIFF
--- a/overrides/config/CustomMainMenu/mainmenu.json
+++ b/overrides/config/CustomMainMenu/mainmenu.json
@@ -122,20 +122,20 @@
         "displayDuration": 100,
         "fadeDuration": 40,
         "images": [
-          "minecraft:textures/gui/title/background/01_koslow#5221_2020-07-13_18.29.23.jpg",
-          "minecraft:textures/gui/title/background/02_zefenglin#4068_unknown.jpg",
-          "minecraft:textures/gui/title/background/03_koslow#5221_2020-07-15_12.47.13.jpg",
-          "minecraft:textures/gui/title/background/04_twgecko#4094_2020-07-23_23.52.42.jpg",
-          "minecraft:textures/gui/title/background/05_misterpemodder#0404_2020-04-16_00.02.35.jpg",
-          "minecraft:textures/gui/title/background/07_sjihttam#1781_2020-01-16_13.41.00.jpg",
-          "minecraft:textures/gui/title/background/06_koslow#5221_2020-07-22_15.51.02.jpg",
-          "minecraft:textures/gui/title/background/08_immow#9906_unknown.jpg",
-          "minecraft:textures/gui/title/background/10_twgecko#4094_2020-07-28_01.02.15.jpg",
-          "minecraft:textures/gui/title/background/09_max the potato#6258_2020-07-14_18.16.47.jpg",
-          "minecraft:textures/gui/title/background/11_thatguy#6588_2020-02-11_23.31.02.jpg",
-          "minecraft:textures/gui/title/background/12_misterpemodder#0404_2020-07-14_00.47.49.jpg"
+          "minecraft:textures/gui/title/background/01_koslow#5221_2020-07-13_18.29.23.png",
+          "minecraft:textures/gui/title/background/02_zefenglin#4068_unknown.png",
+          "minecraft:textures/gui/title/background/03_koslow#5221_2020-07-15_12.47.13.png",
+          "minecraft:textures/gui/title/background/04_twgecko#4094_2020-07-23_23.52.42.png",
+          "minecraft:textures/gui/title/background/05_misterpemodder#0404_2020-04-16_00.02.35.png",
+          "minecraft:textures/gui/title/background/07_sjihttam#1781_2020-01-16_13.41.00.png",
+          "minecraft:textures/gui/title/background/06_koslow#5221_2020-07-22_15.51.02.png",
+          "minecraft:textures/gui/title/background/08_immow#9906_unknown.png",
+          "minecraft:textures/gui/title/background/10_twgecko#4094_2020-07-28_01.02.15.png",
+          "minecraft:textures/gui/title/background/09_max the potato#6258_2020-07-14_18.16.47.png",
+          "minecraft:textures/gui/title/background/11_thatguy#6588_2020-02-11_23.31.02.png",
+          "minecraft:textures/gui/title/background/12_misterpemodder#0404_2020-07-14_00.47.49.png"
         ]
       }
     }
   }
-}
+


### PR DESCRIPTION
The flenames used for the backgrounds of the main menu where changed from "jpg" to "png" about 4 months ago.  However the configuration file for the CustomMainMenu mod was not updated to reflect this change, resulting in the default purple and black texture being used for the background for freshly installed instances of the pack.

This PR corrects the configuration file to reference the correct filename.
