### PR TITLE
Cleanup JEI

### DIFF
--- a/overrides/scripts/JEICleanup.zs
+++ b/overrides/scripts/JEICleanup.zs
@@ -1,0 +1,33 @@
+#priority -9998
+
+import crafttweaker.item.IIngredient;
+import crafttweaker.item.IItemDefinition;
+import crafttweaker.item.IItemStack;
+import crafttweaker.liquid.ILiquidDefinition;
+import crafttweaker.liquid.ILiquidStack;
+import crafttweaker.mods.IMod;
+import crafttweaker.oredict.IOreDict;
+import crafttweaker.oredict.IOreDictEntry;
+
+
+/* Hide all of AE2's facades (can still be crafted, just hiding from JEI) */
+val ae2 as IMod = loadedMods["appliedenergistics2"];
+if(!isNull(ae2)) {
+    val ae2Items as IItemStack[] = ae2.items;
+
+    for item in ae2Items {
+        if(item.displayName has "Cable Facade") {
+            if(item.displayName has "Block of Neutronium") {
+                item.addTooltip(format.darkAqua("Facades can be crafted from most blocks, but are hidden from JEI to reduce clutter"));
+            }
+            else {
+               mods.jei.JEI.hide(item); 
+            }
+        }
+    }
+}
+
+//Adding a tooltop to the GTCEu facade
+<gregtech:meta_item_1:330>.withTag({Facade: {id: "minecraft:stone", Count: 1 as byte, Damage: 0 as short}}).addTooltip(format.darkAqua("GTCEu Cable facades can be made from most non-tile-entites, and craft into different amounts based on the metal used."));
+
+

--- a/overrides/scripts/expertmode.zs
+++ b/overrides/scripts/expertmode.zs
@@ -13,6 +13,8 @@ import mods.gregtech.recipe.RecipeMap;
 import mods.gregtech.recipe.functions.IRunOverclockingLogicFunction;
 import mods.gregtech.recipe.IRecipeLogic;
 import mods.gregtech.recipe.IRecipe;
+import crafttweaker.mods.IMod;
+import crafttweaker.item.IItemStack;
 
 import scripts.common.makeExtremeRecipe5 as makeExtremeRecipe5;
 import scripts.common.makeExtremeRecipe7 as makeExtremeRecipe7;
@@ -615,13 +617,25 @@ recipes.remove(<minecraft:chest> * 4);
 
 // Removals
 mods.jei.JEI.removeAndHide(<thermalexpansion:augment:640>);
-mods.jei.JEI.removeAndHide(<deepmoblearning:simulation_chamber>);
-mods.jei.JEI.removeAndHide(<deepmoblearning:extraction_chamber>);
-mods.jei.JEI.removeAndHide(<deepmoblearning:data_model_blank>);
-mods.jei.JEI.removeAndHide(<deepmoblearning:living_matter_overworldian>);
-mods.jei.JEI.removeAndHide(<deepmoblearning:living_matter_hellish>);
-mods.jei.JEI.removeAndHide(<deepmoblearning:living_matter_extraterrestrial>);
-mods.jei.JEI.removeAndHide(<deepmoblearning:polymer_clay>);
-mods.jei.JEI.hideCategory("deepmoblearning.simulation_chamber");
-mods.jei.JEI.hideCategory("deepmoblearning.extraction_chamber");
-mods.jei.JEI.hideCategory("deepmoblearning.trial_keystone");
+
+
+
+val dml as IMod = loadedMods["deepmoblearning"];
+
+if(!isNull(dml)) {
+    val dmlItems as IItemStack[] = dml.items;
+	
+	mods.jei.JEI.hideCategory("deepmoblearning.simulation_chamber");
+	mods.jei.JEI.hideCategory("deepmoblearning.extraction_chamber");
+	mods.jei.JEI.hideCategory("deepmoblearning.trial_keystone");
+
+	//remove everything
+    for item in dmlItems {
+        mods.jei.JEI.removeAndHide(item);
+    }
+	
+	// remove book
+	mods.jei.JEI.removeAndHide(<patchouli:guide_book>.withTag({"patchouli:book": "deepmoblearning:book"}));
+	// remove spawnegg
+	mods.jei.JEI.removeAndHide(<minecraft:spawn_egg>.withTag({EntityTag: {id: "deepmoblearning:glitch"}}));
+}


### PR DESCRIPTION
Removes all AE2 cable facades and leaves in 1 (block of neutronium) with a note on how to craft the others.
Adds a note to the GTCEu facade on how it make more
Removes all DML recipes in hard mode.