### PR TITLE
Changed Default World Generator version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -220,8 +220,8 @@
       "required": true
     },
     {
-      "projectID": 241140,
-      "fileID": 2499252,
+      "projectID": 490698,
+      "fileID": 3337685,
       "required": true
     },
     {


### PR DESCRIPTION
Changed DWG to version that no longer prompts when setting up a server. This allows Lost Cities world types to be anything you want instead of just default.