### PR TITLE
Transform expert quests to use language key

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -46703,14 +46703,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "GregTech §7Low Voltage§r Tier: start building a factory!\n\nUnlock access to §bDeep Mob Learning§r, early §bEnderIO§r tech, and §bApplied Energistics 2§r Digital Storage.\n\nBuild an §3Electric Blast Furnace§r for smelting advanced materials and alloys.",
+          "desc:8": "nomifactory.quest.line.0.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 1001,
             "OreDict:8": "",
             "id:8": "gregtech:machine"
           },
-          "name:8": "The Beginning",
+          "name:8": "nomifactory.quest.line.0.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -47158,14 +47158,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "GregTech §bMedium Voltage§r Tier: new machines and rudimentary ore processing.\n\nOrganic Chemistry for §6Plastics§r, and build a §3Distillation Tower§r.\n\n§bApplied Energistics 2§r automation. Explore §bActually Additions§r.",
+          "desc:8": "nomifactory.quest.line.1.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 625,
             "OreDict:8": "",
             "id:8": "gregtech:meta_item_1"
           },
-          "name:8": "Early Game",
+          "name:8": "nomifactory.quest.line.1.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -47935,14 +47935,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "GregTech §6High Voltage§r, §5Extreme Voltage§r, and §1Insane Voltage§r tiers:\n\n§6§3Cryogenic Distillation§r, and petrochemistry for §6Epoxy§r and §9Nitro Diesel§r.\n\nCraft §6Nether Stars§r and unlock §bThermal Expansion§r machines.\n\nBuild a§b NuclearCraft§r fission reactor to obtain new materials.\n\nBuild a Space Station and Warp Core.",
+          "desc:8": "nomifactory.quest.line.2.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 2,
             "OreDict:8": "",
             "id:8": "gregtech:warning_sign"
           },
-          "name:8": "Mid Game",
+          "name:8": "nomifactory.quest.line.2.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -48964,14 +48964,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "It\u0027s always rewarding to take a step forward.\n\nThis tab outlines the progression of various things in §5Nomifactory§r.\n\nCircuits are the primary measure of your progress.",
+          "desc:8": "nomifactory.quest.line.3.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 0,
             "OreDict:8": "",
             "id:8": "questbook:itemquestbook"
           },
-          "name:8": "Progression",
+          "name:8": "nomifactory.quest.line.3.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -49678,14 +49678,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "GregTech §dLuV§r, ZPM, §3UV§r, §4UHV§r tiers:\n\nBuild §3Assembly Lines§r, §3Fusion Reactors§r, and more!\n\nAutomate in style with §bPackagedAuto§r. Climb the tiers of §6Micro Miners§r.\n\n§bDraconic Evolution§r for fusion crafting and energy storage.",
+          "desc:8": "nomifactory.quest.line.4.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 647,
             "OreDict:8": "",
             "id:8": "gregtech:meta_item_1"
           },
-          "name:8": "Late Game",
+          "name:8": "nomifactory.quest.line.4.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -50581,14 +50581,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "You\u0027re in the endgame now...\n\nHarvest entire microverses and unlock the §dCreative Portable Tank§r.\n\nPut your automation to the ultimate test as you progress towards the final goal: the §dCreative Vending Upgrade§r.",
+          "desc:8": "nomifactory.quest.line.5.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 0,
             "OreDict:8": "",
             "id:8": "contenttweaker:heartofauniverse"
           },
-          "name:8": "End Game",
+          "name:8": "nomifactory.quest.line.5.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -51512,14 +51512,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Welcome to §5Nomifactory§r, I\u0027ll be your guide.",
+          "desc:8": "nomifactory.quest.line.6.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 0,
             "OreDict:8": "",
             "id:8": "minecraft:iron_ingot"
           },
-          "name:8": "Genesis",
+          "name:8": "nomifactory.quest.line.6.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -51925,14 +51925,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Get your feet wet with §bExtra Utilities§r and §bExtended Crafting§r.\n\nConquer The End or invest in §bEnderIO §rfor teleportation technologies.\n\nBuild a rocket and go to the Moon (or don\u0027t, but it\u0027s fun).\n\nEither way, it\u0027s time to start mining §emicroverses§r.",
+          "desc:8": "nomifactory.quest.line.7.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 0,
             "OreDict:8": "",
             "id:8": "contenttweaker:tieroneship"
           },
-          "name:8": "Into The Microverse",
+          "name:8": "nomifactory.quest.line.7.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -52338,14 +52338,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Create new elements and power your base with doughnuts!",
+          "desc:8": "nomifactory.quest.line.8.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 1022,
             "OreDict:8": "",
             "id:8": "gregtech:machine"
           },
-          "name:8": "Fun With Fusion",
+          "name:8": "nomifactory.quest.line.8.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -52471,14 +52471,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Convert between matter and energy with §bApplied Energistics§r§r.\n\nAutomate ALL the things! o/",
+          "desc:8": "nomifactory.quest.line.10.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 2,
             "OreDict:8": "",
             "id:8": "chisel:futura"
           },
-          "name:8": "Matter-Energy",
+          "name:8": "nomifactory.quest.line.10.title",
           "visibility:8": "ALWAYS"
         }
       },

--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -1,4 +1,5 @@
 {
+  "build:8": "4.0.2",
   "format:8": "2.0.0",
   "questDatabase:9": {
     "0:10": {
@@ -9,7 +10,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The main purpose for this device is to turn §6Activated Certus Quartz Crystal§r into §6Charged Certus Quartz Crystal§r.\n\nThis device can be powered with RF via energy conduits or use AE energy from a network via ME conduits or cables.\n\nIt accepts power from two sides. Which two sides? It\u0027s pretty easy to guess.\n\n\n\n\n\n\n\n\nOk, ok. It\u0027s the top and bottom.\n\n",
+          "desc:8": "nomifactory.quest.db.0.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20,7 +21,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Charging Quartz",
+          "name:8": "nomifactory.quest.db.0.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -73,7 +74,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Crystal Growth Chamber§r allows you to perform §bApplied Energistics§r\u0027s world crafting recipes inside of a machine. Hooray, you never have to drop more things in water again!\n\nIt is used for growing §6Crystal Seeds§r into §6Pure Crystals§r, and also for creating §6Fluix Crystals§r.\n\nJEI doesn\u0027t show the Chamber\u0027s recipes directly, so we\u0027ll explain it here:\n\nSeeds are made by pulverizing any of the three crystal types and mixing the dust with sand. A seed grows into the corresponding Pure Crystal, which is substitutable for the original crystal in most recipes. Using Pure Crystals lets you effectively double your material efficiency, which is nice. And no, you can\u0027t grind down Pure Crystals to further multiply your resources. Sorry.\n\nFluix Crystals you\u0027ve already had to make in a pool of water by now, and it\u0027s the same ingredients here: insert one each of a §6Redstone Dust§r, §6Charged Certus Quartz Crystal§r, and a §6Nether Quartz§r to produce two Fluix Crystals.",
+          "desc:8": "nomifactory.quest.db.1.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -84,7 +85,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crystal Growth Chamber",
+          "name:8": "nomifactory.quest.db.1.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -170,7 +171,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts both LV and MV Canning Machines.\n\n§aLV Batteries§r were very simple to make, but more effective forms of power storage will be more complex to build, so we\u0027ll need to lay the groundwork now.\n\nPut your §3Centrifuge§r to work for the §6Antimony§r you\u0027ll need, which comes in tiny piles from processing §6Tetrahedrite Ore§r and §6Stibnite Ore§r.\n\n",
+          "desc:8": "nomifactory.quest.db.2.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -181,7 +182,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Canning Machine and Assorted Stuff",
+          "name:8": "nomifactory.quest.db.2.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -232,7 +233,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Welcome to §5Nomifactory§f §2GTCEu-§cSTE§r!\n\nThis pack is intended to be played in a §bLost Cities / Overworld dimension§f.\n\nIf you\u0027re playing with friends, don\u0027t forget to invite them to the §equestbook party§f.\n\n§fIf you wish to build your base in a skyblock world, place the §6Void World Cake§f down on the ground, and eat a slice to be sent to the void. Please note that you\u0027ll still need to return to the Lost Cities / Overworld dimension to mine, but you can freely build in complete safety in the §eVoid World§f.\n\nFeatures new to §2CEu§r and quests with new content will be highlighted in §2dark green (colour 2)§r.",
+          "desc:8": "nomifactory.quest.db.3.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -243,7 +244,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§cSTE-§2Genesis",
+          "name:8": "nomifactory.quest.db.3.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -314,7 +315,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§c§rOres in §5Nomifactory§f exist in large clusters, or \u0027§eveins§f\u0027. These veins are scattered around the world, and are relatively common. §2The upgraded HV Electric Prospector\u0027s Scanner you were given will tell you the types of ores you can find within a 7x7 chunk area!\n§r\nWhile the Scanner requires energy to work, you are unlikely to deplete its battery. That said, the quest book will later guide you towards making §2an HV Battery§r to charge §aHV tools §rin your inventory.\n\nIn order to proceed, you\u0027ll need to locate a source of §6Iron§f. You have a few options. §6Magnetite§f veins are higher up and contain large amounts of iron, as well as some §6Vanadium§f and §6Gold§f. Another good source of iron is §6Limonite§f veins, which contain several types of iron. Finally, §6Pyrite§f can be found paired with §6Copper§f in several types of veins.\n\n§6Wrought Iron§f is obtained simply by §esmelting Iron §cNuggets§e a second time§f. It has more durability than Iron, so it is better for making tools, but §cdo not convert your entire Iron supply over to Wrought Iron§f. The two materials are not interchangeable and you\u0027ll need Iron or Wrought Iron as demanded by various recipes.",
+          "desc:8": "nomifactory.quest.db.4.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -325,7 +326,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Iron Supply",
+          "name:8": "nomifactory.quest.db.4.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -372,7 +373,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aMining Hammers§r offer a relatively cheap way to mine out areas much faster. They clear a 3x3 of blocks and mine quickly, so they\u0027re absolutely worth investing your first few ingots of metal into§..\n\n§2GTCEu now has Mining Hammers natively! You can craft them with any GT tool material.",
+          "desc:8": "nomifactory.quest.db.5.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -388,7 +389,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mining Hammers",
+          "name:8": "nomifactory.quest.db.5.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -416,7 +417,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Before you continue, you\u0027ll need access to some more materials. \n\n§6Redstone§f: Found only deep in the world, in massive veins paired with §6Cinnabar§f and §6Ruby§f.\n\n§6Copper§f: Two primary sources. §6Tetrahedrite§f veins are higher up, while §6Chalcopyrite§f veins are lower, paired with some small amounts of §6Iron§f. You\u0027ll also find §6Malachite§f inside of Iron veins, this is another type of copper ore.\n\n§6Tin§f: Found essentially at ground level. §6Cassiterite§f is another type of tin ore, and they\u0027re always found together. If you cannot find a vein of tin, there are small amounts of tin inside veins of §6Aluminium§f and §6Rock Salt§f, which might be enough to hold you over until you find a proper tin vein.\n\n§6Coal§f: Found in relatively shallow depths. §6Lignite Coal§f is §2removed.\n\n§6Gold§f: Found inside of §6Magnetite§f veins, close to the surface.",
+          "desc:8": "nomifactory.quest.db.6.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -427,7 +428,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2More Materials",
+          "name:8": "nomifactory.quest.db.6.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -494,7 +495,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The most basic cables, such as these §6Red Alloy Cables§f, can be wrapped in their §6Rubber§f insulation by hand.\n\nMore advanced types of cables will require an §3Assembling Machine§f and liquid §9Rubber§f, but you can do it the simple way for now.\n\n§2GT cables now support RF conversion natively! You can plug an RF machine into an EU cable directly and it will convert the energy.",
+          "desc:8": "nomifactory.quest.db.7.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -505,7 +506,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Cables",
+          "name:8": "nomifactory.quest.db.7.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -607,7 +608,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "In most expert packs, you want to try to process as little ore as possible before you get access to ore doubling. It\u0027s a habit most of us pick up.\n\n§eYou shouldn\u0027t feel any pressure to do that in Nomifactory, though§f. Ore veins are massive, and mining is extremely fast with §aMining Hammers§f. What\u0027s more, even once you get access to §3Macerators§f, they initially process ore slowly and require power to operate.\n\nObvious exceptions would be rare materials §fbecause you can\u0027t find it. Those are worth doubling, if possible.\n\nBut at least for now, you shouldn\u0027t feel any guilt about smelting the more common ores without doubling them! §eOre doubling can be safely ignored until you have Medium Voltage machines or even later.§r",
+          "desc:8": "nomifactory.quest.db.9.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -618,7 +619,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ore Doubling?",
+          "name:8": "nomifactory.quest.db.9.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -647,7 +648,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Second Micro Miner!\n\nThis uses an §bExtended Crafting§r table so it\u0027s not possible to automate the Miner itself with §bApplied Energistics 2§r just yet (this requires more advanced technology not easy to access until the Tier Four Micro Miner). You can make it semi-automatically by prestocking the components you need, and filling up the Extended Crafting Table with §bJEI§r!\n\nThis Micro Miner can get you:§6\n* Bauxite Ore\n§2* Pyrochlore Ore§6\n§c* Tantalite Ore§2\n* Copper Ore\n* Tungstate Ore\n* Scheelite Ore\n* Cassiterite Ore\n* Radium Salt§r\n\nAs well as the §6Stellar Creation Data§r, which will be useful much, much later.",
+          "desc:8": "nomifactory.quest.db.10.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -658,7 +659,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Two Micro Miner",
+          "name:8": "nomifactory.quest.db.10.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -701,7 +702,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A \"§esubstrate§f\" is the \"board\" part of a circuit board... the backing that the circuit components and wires are laid into. A good substrate needs to not conduct electricity, for obvious reasons. §6Wood§r coated in §6Sticky Resin§r is a primitive but effective material to use as your first substrate.\n\n§2CEu circuit progression means you also have to put wires on your substrates for them to be usable. In this case, use some Copper Wires.§r\n\nYou\u0027ll also need to make §6Vacuum Tubes§f, as well as some primitive §6Resistors§r. §6Paper§r will work as a material for these, for now.\n\nMake sure to code these recipes into a §3Crafting Station§r... you\u0027ll be making a LOT of these things.",
+          "desc:8": "nomifactory.quest.db.11.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -712,7 +713,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Electronics Subcomponents",
+          "name:8": "nomifactory.quest.db.11.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -765,7 +766,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "One of the eccentricities of the pack you\u0027ll need to get used to is the way the tools are displayed. Most tools can be made out of nearly any metal, and §bJEI§f will display a huge number of options... every combination of every tool with every material. However, the pattern to make the tool is always identical, so §ejust arrange the plates and ingots in the same manner as the examples, ignoring whatever material it says§f. Rods where rods go, plates where plates, etc. The only restriction is that tools §emust be made from all of the same material§f... you cannot mix and match different metals in a single item.\n\nRecipes will default to showing a §6Neutronium tool §rof the appropriate type if a tool is required, but the correct type of tool made out of any metal will work. Just ignore the tool\u0027s material in the recipes: it can be whatever you\u0027d like.\n\nFor now, make a §aHammer§f (not a §aMining Hammer§f, mind you... six ingots, not five). Hammers can be used to turn §etwo ingots into one plate§f. §6Plates§f can make a §aFile§f, Files can make §6Rods§f, etc. Use JEI to work your way down the list of tools.\n\n§6Wrought Iron§f is probably your best bet for a tool material right now, but better materials will become available as you progress.",
+          "desc:8": "nomifactory.quest.db.12.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -781,7 +782,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Some Starter Tools",
+          "name:8": "nomifactory.quest.db.12.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -893,7 +894,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "If you try to craft each item only when you need it, you\u0027ll go insane. It is far more effective to §ebatch-craft§f frequently used items so you don\u0027t have to do it as often. It is very satisfying to get all the ingredients together then craft §ea stack of items§f all at once.\n\n§3Crafting Stations§f are an indispensable tool for batch-crafting. They can save recipes for all the steps in production chains for things like tools, circuits, machine casings, and more. You will want to §emake several of them§r§r for the convenience they offer.\n\nEach Crafting Station comes with some inventory space for general items, as well as a dedicated row specifically for holding §bGregTech§r tools. In addition, Crafting Stations can §einteract with adjacent inventories§r, so you can keep common materials in a container between them. This includes access points to large virtual inventories, like a §aDrawer Controller§r§r, which you will be able to make later.\n\nTo use the Crafting Station, you must either manually set up a recipe in the pattern area, or click-in a table recipe from §bJEI§r. Place the ingredients inside the Crafting Station or an adjacent container, then you can click the resulting item to craft it. Once an item is crafted, the recipe will appear on the top-right in the history pane. As usual, Shift-clicking the output item will craft up to a stack of it.\n\nEach Crafting Station will remember §eup to the last nine recipes§r you made in them, which can be recalled by clicking the item in the top-right recipe history pane. Old recipes will be cycled out, so if you want to ensure a recipe doesn\u0027t ever get replaced by a different one, §eShift-click the recipe in the history pane to lock it§r.\n\nThe available ingredients from neighboring inventories are visible through the §eStorage§r tab on the Crafting Station, and you can also place items into this tab to send them to available neighboring inventories.",
+          "desc:8": "nomifactory.quest.db.13.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -904,7 +905,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Batch Crafting In Style",
+          "name:8": "nomifactory.quest.db.13.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -945,7 +946,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Iron Furnaces§f can smelt an item in §a150 ticks§f, which is somewhat faster than a vanilla §6Furnace§f, which takes §a200 ticks§f. The fuel efficiency remains the same for all furnaces.",
+          "desc:8": "nomifactory.quest.db.14.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -956,7 +957,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v2.0",
+          "name:8": "nomifactory.quest.db.14.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -997,7 +998,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Copper Furnaces§f are another step up in speed, taking §a100 ticks§f to smelt an item.",
+          "desc:8": "nomifactory.quest.db.15.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1008,7 +1009,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v3.0",
+          "name:8": "nomifactory.quest.db.15.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1049,7 +1050,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Silver Furnaces§f are another step up in speed, taking a mere §a60 ticks§f to smelt an item.",
+          "desc:8": "nomifactory.quest.db.16.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1060,7 +1061,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v4.0",
+          "name:8": "nomifactory.quest.db.16.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1101,7 +1102,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Gold Furnaces§f are yet another step up in speed, taking only §a40 ticks§f to smelt an item.",
+          "desc:8": "nomifactory.quest.db.17.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1112,7 +1113,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v5.0",
+          "name:8": "nomifactory.quest.db.17.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1153,7 +1154,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "While §3Obsidian Furnaces§f are the same speed as §3Diamond Furnaces§f, they have twice the throughput since they can §esmelt two items at once§f.\n\nYou may find that Diamond Furnaces suit your needs better than Obsidian, but they\u0027ll both be crafting ingredients in various machines soon enough, so crafting one is not a waste, even if you don\u0027t use it.",
+          "desc:8": "nomifactory.quest.db.18.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1164,7 +1165,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v7.0",
+          "name:8": "nomifactory.quest.db.18.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1206,7 +1207,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Benzene§r is a common reagent which can be obtained from §9Wood Tar§r or §9Oil§r. Apart from that, it is a potent fuel which generates §d352 EU/mB§r in a §3Gas Turbine§r.\n\nLater, you can use an HV §3Chemical Reactor§r to upgrade it to §9Nitrobenzene§r, which has a greatly improved fuel density.",
+          "desc:8": "nomifactory.quest.db.19.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1221,7 +1222,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Benzene",
+          "name:8": "nomifactory.quest.db.19.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -1258,7 +1259,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Diamond Furnaces§f are the fastest available, taking only §a25 ticks§f to smelt an item.",
+          "desc:8": "nomifactory.quest.db.20.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1269,7 +1270,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v6.0",
+          "name:8": "nomifactory.quest.db.20.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1310,7 +1311,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You already have §6Steel§r, but it can be made much faster in the §3Blast Furnace§r, at the cost of EU and §9Oxygen§r.",
+          "desc:8": "nomifactory.quest.db.21.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1321,7 +1322,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Steel",
+          "name:8": "nomifactory.quest.db.21.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1362,7 +1363,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The main function of this oven is to increase the fuel values of your wood and coal while also recovering some of the various potentially useful waste products.\n\nTurning §6Coal§r into §6Coal Coke§r will not only make it more useful as fuel, but will also produce §9Phenol§r, which you\u0027ll need for circuits.\n\nThe Pyrolyse Oven is also the source of several other fluids that can be distilled for useful ingredients.\n\nYou can §6sneak-right click§r the controller to enable the in-world preview.\n\n§2As stated in the tooltip, higher tier coils will make this faster.\n",
+          "desc:8": "nomifactory.quest.db.22.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1373,7 +1374,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Pyrolyse Oven",
+          "name:8": "nomifactory.quest.db.22.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1468,7 +1469,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need §6Obsidian§r to make §6Dark Steel§r. Most of the tools you can make cannot mine Obsidian, but you do have a few potential options for ones that will work. The options you\u0027re most likely to have access to at this point are:\n\n1) A §aDiamond Pickaxe§r or §aDiamond Mining Hammer§r.\n\n2) A §aPlatinum Mining Hammer§r (not pickaxe though).",
+          "desc:8": "nomifactory.quest.db.23.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1479,7 +1480,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Obsidian",
+          "name:8": "nomifactory.quest.db.23.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1521,7 +1522,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your first major crafting project!\n\nYou\u0027ll need a small bit of §6Silver§f for this dynamo. You won\u0027t need a ton of silver and lead just yet, so it won\u0027t bankrupt you.\n\nKeep in mind that §eDynamos only output power when burning through fuel, and only the block attached directly to the coil will get provided with power§f.",
+          "desc:8": "nomifactory.quest.db.24.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1538,7 +1539,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Steam Dynamo",
+          "name:8": "nomifactory.quest.db.24.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1585,7 +1586,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This quest is repeatable once per hour and gives you a free cake to the Void World or Overworld. You can also refill your cakes with the items indicated in their tooltips.",
+          "desc:8": "nomifactory.quest.db.25.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1596,7 +1597,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Cake Based Dimensional Transit",
+          "name:8": "nomifactory.quest.db.25.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1648,7 +1649,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Steel§r alloyed with §6Obsidian§r makes §6Dark Steel§r, which is needed for many of the machines in §bEnderIO§r and §bApplied Energistics§r.\n\nLater, you can use §6Void Crystal§r instead of Obsidian.",
+          "desc:8": "nomifactory.quest.db.26.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1659,7 +1660,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dark Steel",
+          "name:8": "nomifactory.quest.db.26.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1700,7 +1701,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The place for your very first chemical reactions, namely making some improved substrates.",
+          "desc:8": "nomifactory.quest.db.27.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1711,7 +1712,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Chemical Reactor",
+          "name:8": "nomifactory.quest.db.27.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1752,7 +1753,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Pulsating Dust§r is a mysterious magical material that taps into the power of Ender. It has all sorts of strange and potentially dangerous applications, including the ability to make §6Pulsating Ingots§r and §6Ender Pearls§r.\n\nYour first source of Pulsating Dust is §6Uraninite§r, which you can get from §6Uraninite Ore§r. Later on, you\u0027ll be able to produce Pulsating Dust by smelting §6Resonant Clathrates§r.\n\n§cPlease note that the Enderpearl Dust electrolysis recipe requires an EV Electrolyzer, and is most likely not worth it.§r",
+          "desc:8": "nomifactory.quest.db.28.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1763,7 +1764,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pulsating Dust",
+          "name:8": "nomifactory.quest.db.28.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1810,7 +1811,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §bEnder IO§r alloy.\n\nMade from §6Pulsating Dust§r and an §6Iron Ingot§r.\n\nIf you can\u0027t find one otherwise, §6Ender Pearls§r can be crafted using Pulsating Dust and a §6Diamond§r in an §3Alloy Smelter§r.",
+          "desc:8": "nomifactory.quest.db.29.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1821,7 +1822,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pulsating Iron and Ender Pearls",
+          "name:8": "nomifactory.quest.db.29.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1869,7 +1870,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §bEnderIO§r alloy, made from §6Silicon Dust§r and a §6Steel Ingot§r.\n\nThis material is frequently used in electronics and digital equipment.",
+          "desc:8": "nomifactory.quest.db.30.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1880,7 +1881,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Electrical Steel",
+          "name:8": "nomifactory.quest.db.30.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1922,7 +1923,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Two §aAdvanced Capacitor Banks§r can be grafted together with a §6Vibrant Crystal§r and §6Vibrant Alloy Plates§r to create a §aVibrant Capacitor Bank§r, which stores five times as much RF as the advanced bank, for a total of twenty-five times as much as the basic bank.",
+          "desc:8": "nomifactory.quest.db.31.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1936,7 +1937,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vibrant Capacitor Bank",
+          "name:8": "nomifactory.quest.db.31.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1978,7 +1979,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Two §aCapacitor Banks§r can be grafted together with a §6Double-Layer Capacitor§r and §6Electrical Steel§r to create an §aAdvanced Capacitor Bank§r, which stores five times as much RF as the basic bank.",
+          "desc:8": "nomifactory.quest.db.32.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1992,7 +1993,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Capacitor Bank",
+          "name:8": "nomifactory.quest.db.32.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2033,7 +2034,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Expandable multi-block storage for RF power.\n\nThis first tier isn\u0027t much, but you can upgrade them over time to hold substantial amounts of power.",
+          "desc:8": "nomifactory.quest.db.33.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2047,7 +2048,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basic Capacitor Bank",
+          "name:8": "nomifactory.quest.db.33.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2089,7 +2090,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §bEnderIO§r alloy, made from §2mixing§r §22 Gold Dust, 1 Redstone Dust, and 1 Glowstone Dust§r §2and putting it §rin your new §3Electric Blast Furnace§r.\n\nThrow §2the prepared dust into the input bus§r and in twenty seconds your §6Energetic Alloy Ingot§r will be in the output bus.\n\n§2In EV Age, you can build an Alloy Blast Smelter which doubles the yield.",
+          "desc:8": "nomifactory.quest.db.34.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2100,7 +2101,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Energetic Alloy",
+          "name:8": "nomifactory.quest.db.34.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2141,7 +2142,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An EnderIO alloy.\n\n§2In EV Age, you can build an Alloy Blast Smelter which doubles the yield.",
+          "desc:8": "nomifactory.quest.db.35.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2152,7 +2153,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Vibrant Alloy",
+          "name:8": "nomifactory.quest.db.35.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2230,7 +2231,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Going out in search of a §6Rubber Tree§f is a viable option for sure. However, if this isn\u0027t appealing, you can also §eshear leaves§f and make §6Plantballs§f out of them. Plantballs smelt into §6Slime§f, and Slime smelts into §6Sticky Resin§r.\n\nYou\u0027ll want to transition to Rubber Trees at some point, though, since the §eratio of leaves to rubber is quite poor§f.\n\nUse the §3Steam Extractor§r to extract §6Raw Rubber Pulp§r from the resin, then \"alloy\" with §6Sulfur§r for the §6Rubber§r. It\u0027s quite inefficient to do it this way, but such is the life of early game §bGregTech§f. At least rubber isn\u0027t particularly hard to come by.",
+          "desc:8": "nomifactory.quest.db.37.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2241,7 +2242,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Rubber Sheets",
+          "name:8": "nomifactory.quest.db.37.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2291,7 +2292,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§oNote: this quest accepts any §2§oLV Energy Converter§r§o.\n\n§r§aRF power§r and §bGregTech§r §aEU power§r is incompatible. With your first §6circuit§r in hand, you are ready to build a §eLow Voltage (LV) §3§2Energy Converter§r.\n\nThe §2Energy Converter§r is a special device that §econverts §2between §aRF power§r and §aEU power§r. They come in §2four sizes: 1A, 4A, 8A, and 16A.\n\n§aRF§r converts into §aEU§r at a §e4 to 1 ratio§r. §a100 RF§r becomes §a25 EU§r, and vice-versa. §2Use a Soft Hammer to change the conversion direction.",
+          "desc:8": "nomifactory.quest.db.38.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2302,7 +2303,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Power",
+          "name:8": "nomifactory.quest.db.38.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2344,7 +2345,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Item conduits are useful for moving items between inventories over moderate distances.\n\nCrafting them in an Assembling Machine instead of by hand gives twice as many conduits.",
+          "desc:8": "nomifactory.quest.db.39.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2355,7 +2356,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Item Conduits",
+          "name:8": "nomifactory.quest.db.39.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2396,7 +2397,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The most basic tier of §aRF§r energy conduits from §bEnderIO§r.\n\nThese can be used to transport energy from your §3Steam Dynamos§r to various destinations.",
+          "desc:8": "nomifactory.quest.db.40.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2407,7 +2408,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Conductive Iron Energy Conduits",
+          "name:8": "nomifactory.quest.db.40.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2448,7 +2449,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have §6Energetic Alloy§r, it\u0027s time to make some better conduits!\n\nEach time you upgrade your conduits, you\u0027ll also get more of them. Neat!\n\nIf you don\u0027t have an §3Assembling Machine§r, you\u0027ll have to make them by hand. This method isn\u0027t as efficient as the machine, but you\u0027ll make one soon enough.",
+          "desc:8": "nomifactory.quest.db.41.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2459,7 +2460,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Energetic Alloy Energy Conduits",
+          "name:8": "nomifactory.quest.db.41.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2501,7 +2502,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Conduits to carry even MORE RF power.\n\nYou\u0027re making these in the §3Assembling Machine§r, right?",
+          "desc:8": "nomifactory.quest.db.42.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2512,7 +2513,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vibrant Alloy Energy Conduits",
+          "name:8": "nomifactory.quest.db.42.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2591,7 +2592,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Combining §6Basic RF Capacitors§r with some §6Coal Dust§r and §6Energetic Alloy§r produces a §6Double-Layer RF Capacitor§r.\n\nThis is a tier two capacitor. Higher tier RF Capacitors will make §bEnderIO§r machines process faster and depending on the machine will expand their capabilities further (like area of effect).",
+          "desc:8": "nomifactory.quest.db.44.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2602,7 +2603,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Double Capacitor",
+          "name:8": "nomifactory.quest.db.44.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2643,7 +2644,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Being able to fly is nice. This is the first jetpack that uses §bEnderIO§r materials.\n\nThere\u0027s also a quest chain for §bThermal Expansion§r material Jetpacks (starting with the §6Leadstone Jetpack§r). Eventually you\u0027ll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really really like flying.\n\nIf the §6Jetpack§r overview and information from §bThe One Probe§r conflict, they can be adjusted through the §bSimply Jetpacks 2§r §eConfiguration file§r or the command §6/topcfg§r respectively.",
+          "desc:8": "nomifactory.quest.db.45.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2658,7 +2659,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ironman",
+          "name:8": "nomifactory.quest.db.45.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2739,7 +2740,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Flying faster, even nicer.",
+          "desc:8": "nomifactory.quest.db.47.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2754,7 +2755,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ironman 3",
+          "name:8": "nomifactory.quest.db.47.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2797,7 +2798,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Flying faster is nice.",
+          "desc:8": "nomifactory.quest.db.48.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2812,7 +2813,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ironman 2",
+          "name:8": "nomifactory.quest.db.48.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2855,7 +2856,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts LV/MV/HV Centrifuge.\n\nCentrifuging air is a reliable way to get §9Nitrogen§r before you have access to §3Cryogenic Distillation§r.\n\n",
+          "desc:8": "nomifactory.quest.db.49.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2866,7 +2867,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Air Centrifuging",
+          "name:8": "nomifactory.quest.db.49.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2907,7 +2908,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§b§2GTCEu Fluid Pipes have been reworked and work much better now. There are also Quadruple and Nonuple pipes for transporting multiple fluid types through the same block. Their advantage over EnderIO Fluid Conduits is their higher throughput - 414 mB/t for a low-tier (Normal Potin) pipe.\n\n§rHowever, EnderIO Fluid Conduits still have the advantage of being EnderIO Conduits, allowing them to fit in the same block as other Conduits. Pick your poison.",
+          "desc:8": "nomifactory.quest.db.50.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2918,7 +2919,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Fluid Transport",
+          "name:8": "nomifactory.quest.db.50.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2961,7 +2962,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Inscribers§r are machines used to make §6inscribed circuits§r for §bApplied Energistics§r.",
+          "desc:8": "nomifactory.quest.db.51.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2972,7 +2973,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Inscriber",
+          "name:8": "nomifactory.quest.db.51.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3011,7 +3012,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Coming soon!",
+          "desc:8": "nomifactory.quest.db.52.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3022,7 +3023,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Cleanroom",
+          "name:8": "nomifactory.quest.db.52.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -3049,7 +3050,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Wiremill§r is a major efficiency boost, giving you a much greater yield of §6wires§r for your ingots. But first, you\u0027ll need to make some §6Motors§r.\n\n§bGregTech§r machines are built from a number of components, many of which are shared between the machines. Motors§r are used in a great number of recipes, even including other components.\n\nMake sure to encode the recipes needed for motors into a §3Crafting Station§r. You\u0027ll need quite a lot of them.\n\nAfter you make the Wiremill, §econsider making a few stacks§r of LV motors. This might sound extreme, but §ebatch crafting§r in this manner is an important habit to pick up. This way you won\u0027t have to craft more for a while, and you §owill §ruse all those motors eventually, so you\u0027re not wasting materials.\n\nAs you get access to more machinery you will no longer need to craft things manually. Instead, you will engineer factories to automate the production for you. It is useful to keep a stockpile of frequently used things like circuits and components crafted so you don\u0027t have to wait for them when you need them.\n\n§2If the machine sounds start to get on your nerves, you can mute GT machines with a GT Hammer.",
+          "desc:8": "nomifactory.quest.db.53.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3060,7 +3061,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Wiremill",
+          "name:8": "nomifactory.quest.db.53.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3107,7 +3108,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "When §6Ender Eyes§r just aren\u0027t creepy enough.\n\nYou\u0027ll need an HV or better §3Chemical Bath§r to make these. The recipe is quite slow, so invest in the highest tier Chemical Baths you can and consider parallelizing the recipe.",
+          "desc:8": "nomifactory.quest.db.54.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3118,7 +3119,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Quantum Eyes",
+          "name:8": "nomifactory.quest.db.54.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3160,7 +3161,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Centrifuges§r provide you with §21 tiny pile§r of additional materials when processing ore dusts (§e9 tiny piles \u003d 1 dust§r). Sometimes it\u0027s the main dust, but often it\u0027s a different useful material that is otherwise unobtainable.\n\nInstead of washing §6impure dusts§r (made from macerating or hammering ores) in a cauldron, you can get more out of each dust by centrifuging it. The same is true of §6pure dusts§r, when you eventually make a §3Washer§r or §3Chemical Bath§r. Note however that pure and impure dusts will usually give different byproducts (always check in §bJEI§r).\n\nCentrifuges also have other uses like unmixing compound dusts and fluids, or getting §6Rubber Pulp§r, which can be chemically reacted with §6Sulfur§r to efficiently make §9liquid Rubber§r.\n\n",
+          "desc:8": "nomifactory.quest.db.55.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3171,7 +3172,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Centrifuge",
+          "name:8": "nomifactory.quest.db.55.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3212,7 +3213,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have everything you need to power your machines, it\u0027s time to put it all together.\n\nYour Steam Dynamo needs burnable fuel (like §6Coal§r) and §9water§r. It will output RF power through the Excitation Coil (the red bit at the top). The orientation of the Steam Dynamo can be adjusted with a §aCrescent Hammer§r, if needed.\n\n§6Energy Conduits§r can be used to transfer that RF power, but the dynamo can also output RF directly into an Energy Converter by making the Excitation Coil touch the Energy Converter.\n\nThe Energy Converter transforms RF power into EU, outputting the resulting EU through the side with a red dot. The orientation can be adjusted using a §aWrench§r. Attach your §6Conductive Iron Cables§r to the output side of the Energy Converter.\n\nNow all you need are some §bGregTech§r machines to hook up to the cables! You can make whatever you want, but its recommended that you get these two first:\n\nThe §6Wiremill§r will make crafting wires much, much easier.\n\nThe §2Metal Bender§r will make Plates from one ingot instead of two.",
+          "desc:8": "nomifactory.quest.db.56.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3223,7 +3224,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Putting It All Together",
+          "name:8": "nomifactory.quest.db.56.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3252,7 +3253,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aEnder Fluid Conduits§r are the most powerful fluid transportation mechanism offered by §bEnderIO§r.\n\nNot only are these faster than §aPressurized Fluid Conduits§r, but because they teleport fluids instead of flowing them in the conduits, it possible to have a large number of fluids moving through a single line.\n\nIn addition to §aFilters§r they also have multiple channels which can be used to direct fluids through the same conduits to various destinations.\n\nIf you don\u0027t want to (or haven\u0027t unlocked access to) routing fluids through §bAE§r, these are your best alternative.",
+          "desc:8": "nomifactory.quest.db.57.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3263,7 +3264,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ender Fluid Conduits",
+          "name:8": "nomifactory.quest.db.57.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3304,7 +3305,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Batteries§r are §bGregTech §rpower storage for §aEU§r energy.\n\nThere are several types of rechargeable batteries you can make; §2Lithium Batteries§r are the best ones, followed by §6Cadmium§r and §6Sodium§r.\n\n§6Lithium§r is possible to find inside of §6Tungsten§r veins, however, they only spawn in §eThe End§r§r. §6Cadmium§r comes from various §6Refined Ores§r, and §6Sodium§r is the easiest - from §6Salt§r, §6Clay§r, and many other minerals.",
+          "desc:8": "nomifactory.quest.db.58.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3318,7 +3319,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Power Storage",
+          "name:8": "nomifactory.quest.db.58.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3359,7 +3360,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Nickel comes from several different ores, including Pentlandite and Garnierite, but they\u0027re all found in the same vein.\n\nNickel is used mostly for several very important alloys, including Invar and Cupronickel.",
+          "desc:8": "nomifactory.quest.db.59.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3370,7 +3371,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Copper... Nickel... Cupronickel?",
+          "name:8": "nomifactory.quest.db.59.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -3425,7 +3426,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Electric Blast Furnace§r is a major, major milestone in your §bGregTech§r career. It has the power to smelt more advanced materials. The first of which, §6Aluminium§r, is going to be important in the immediate future.\n\nThere is a diagram of how to build the EBF in §bJEI§r. The second and third levels must be a 3x3 square shape of Coil Blocks (§6Cupronickel§r is the only type of coil block you have access to for now) with an empty center. You can also §6sneak-right click§r the controller to enable the in-world preview.\n\nHowever, the bottom and top layers are very flexible. The §6EBF Controller§r must be on the §ebottom layer§r of the structure, and on the §emiddle of an outer edge§r; the §6Muffler Hatch§r must be in the §eexact middle of the top layer§r. Otherwise, you can put the hatches and buses wherever you want, filling in all gaps in each layer with §6Heatproof Machine Casings§r. It\u0027s worth noting that you must §euse at least §29§e Heatproof Machine Casings in your layout or the structure will not form§r.\n\nThis quest calls for a §2maintenance hatch§r, two energy hatches, a fluid input and output, and an item input and output, which is a total of 7 positions. Their specific order and placement don\u0027t matter, as long as you can access them. The 8th position is your EBF controller, leaving 9 gaps to be filled by Heatproof Machine Casings. If you did everything right, the structure will form: the colors on its hatches and casings will unify, and the controller will say \"Idling.\"\n\nYou\u0027ll most likely want to locate your power quite near to the EBF. It is very power hungry, and if it cannot get enough energy, progress on the current item smelting will start to regress. Be careful to ensure the EBF has enough power, and keep a Soft Hammer nearby to pause it by tapping the controller if you run out of power.\n\n§2In GTCEu, all hatches except Maintenance can be shared between Multiblocks!",
+          "desc:8": "nomifactory.quest.db.60.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3436,7 +3437,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Blast Furnace Fun",
+          "name:8": "nomifactory.quest.db.60.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3531,7 +3532,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Some Micro Miner missions use a §6Gemstone Sensor§r to scout out gems instead of ores.\n\n§6§2Perfect Gems§r can be obtained from such missions.",
+          "desc:8": "nomifactory.quest.db.61.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3542,7 +3543,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Gemstone Sensor",
+          "name:8": "nomifactory.quest.db.61.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3583,7 +3584,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Access all of your items on a single screen. Soon, anyway.\n\nPlease note that all four variants of §6ME Terminals§r are §emicroparts§r, which means they need to be attached to an §6ME Cable§r (not conduit) to function.",
+          "desc:8": "nomifactory.quest.db.62.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3594,7 +3595,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Terminal",
+          "name:8": "nomifactory.quest.db.62.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3635,7 +3636,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aME Chest§r is somewhat impractical to use on its own, but it\u0027s a necessary ingredient for the much more useful §6ME Drive§r.\n\nThis is a rudimentary digital item storage device. By placing a §6Storage Cell§r inside it, you can access the contents as though you were looking through a chest. You can carry the disk to another location and place it down in a different ME Chest if you want, and the items will come with it.\n\n§cDon\u0027t put Storage Cells inside other portable mod inventories like a Satchel, (or vice-versa) as you risk corrupting the contents of the Satchel and the Storage Cell.§r There\u0027s technical reasons why this happens (NBT overflow), and it\u0027s not unique to these items, but that\u0027s not really worth going into.\n\n",
+          "desc:8": "nomifactory.quest.db.63.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3646,7 +3647,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ME Chest",
+          "name:8": "nomifactory.quest.db.63.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3687,7 +3688,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bApplied Energistics§r uses §6Storage Cells§r as its primary means of digital item and fluid storage.\n\nAll unformatted Storage Cells are limited to at most 63 distinct item types, with the first item of each new type taking up a chunk of the total bytes of cell storage, and subsequent items of existing types taking a small number of bytes thereafter.\n\nA §61k ME Storage Cell§r is the first and smallest cell for storing items. If you are going to be storing many different kinds of items in your network, you will need to make an §6ME Drive§r and fill it with multiple Storage Cells.\n\nThe §64k ME Storage Cell§r is the next size up. With four times the bytes it holds substantially more items per type, but it requires a more advanced technology than you currently have available: AE §6Processors§r made in an §3Inscriber§r.",
+          "desc:8": "nomifactory.quest.db.64.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3699,7 +3700,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Digital Storage At Last",
+          "name:8": "nomifactory.quest.db.64.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3753,7 +3754,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Third Micro Miner.\n\nThis one can get you:\n§6* Tetrahedrite Ore\n* Cassiterite Ore\n* Tungstate Ore\n* Scheelite Ore\n* Redstone Ore\n* Quartz Ore\n* Vanadium Magnetite Ore\n§2* Ilmenite Ore§6\n* Tin Ore\n* Sapphire Ore§r\n§6* Almandine Ore§r\n\nor:\n§6* Dense Magma Block§r\n\nWhen equipped with Gemstone Sensor:\n§6§2* Perfect Emeralds\n* Perfect Diamonds\n* Perfect Rubies\n* Perfect Topaz\n§6* Silver Ore\n* Gold Ore",
+          "desc:8": "nomifactory.quest.db.65.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3764,7 +3765,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Three Micro Miner",
+          "name:8": "nomifactory.quest.db.65.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3806,7 +3807,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Alloy Smelter§f\n\n§3Smelt§f it into ingots, §ahammer§f it into §6Plates§f, and §acut§f them into §6Wires§f.",
+          "desc:8": "nomifactory.quest.db.66.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3817,7 +3818,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "From Dusts To Wires",
+          "name:8": "nomifactory.quest.db.66.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -3883,7 +3884,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A pair of §6Double-Layer RF Capacitors§r combined with some §6Vibrant Alloy§r and §6Glowstone§r creates an §6Octadic RF Capacitor§r, which is a tier three §bEnderIO§r capacitor.",
+          "desc:8": "nomifactory.quest.db.67.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3894,7 +3895,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Octadic Capacitor",
+          "name:8": "nomifactory.quest.db.67.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3936,7 +3937,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Experience Obelisk§r is a mass storage device for player experience in the form of §9Liquid XP§r.\n\nVia the GUI you can insert or extract levels as needed, as well as configure interactions with neighboring blocks (as is typical of §bEnderIO§r machines).\n\nLiquid XP can also be pumped in directly from your automation such as §3Fluid Extractors§r.",
+          "desc:8": "nomifactory.quest.db.68.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3947,7 +3948,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Experience Obelisk",
+          "name:8": "nomifactory.quest.db.68.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3989,7 +3990,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your EBF running, start to create a supply of §6Aluminium Ingots§r. These are crucial ingredients for MV machines, including §bApplied Energistics§r.\n\n§2With LV power, you can only get Aluminium Dust from electrolyzing Sapphire Dust or Green Sapphire Dust. Once you make an MV Electrolyzer, you can get it from a plethora of other raw resources.§r\n\nIf you find your power supply is faltering, you may want to make additional dynamos and turn them into steam boilers and turbines. Upgrading your dynamos is also advisable.\n\nHowever, you\u0027re also about to reach MV. You\u0027re bound to discover a better power source than steam before long.\n\n§2You can cut by a third the smelting time of Aluminium and some other smelting processes with Nitrogen gas. Higher-tier processes may take different gases.",
+          "desc:8": "nomifactory.quest.db.69.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4000,7 +4001,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Aluminium Ingots",
+          "name:8": "nomifactory.quest.db.69.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4042,7 +4043,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aMV Batteries§r function essentially the same as §aLV Batteries§r, only stronger. They also need to be put into an §3MV Machine§r or §3MV Battery Buffer§r.",
+          "desc:8": "nomifactory.quest.db.70.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4056,7 +4057,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Power Storage",
+          "name:8": "nomifactory.quest.db.70.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4098,7 +4099,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §3MV Electrolyzer§r allows you to process recipes that require up to 128 EU/t, and can optionally overclock recipes costing at most 32 EU/t.\n\nThis means you can split more kinds of things for useful products.\n",
+          "desc:8": "nomifactory.quest.db.71.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4109,7 +4110,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Electrolyzer",
+          "name:8": "nomifactory.quest.db.71.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4152,7 +4153,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Assembling Machines come early in CEu! Circuit recipes are handled through a separate machine, the Circuit Assembler. §r\n\nAssembling Machines open up a plethora of §eequal or more efficient recipes that don\u0027t require hand tools§r. §2For example, you can make up to 6 Vacuum Tubes in a single craft! Many of its recipes will require fluids.§r Hand tool recipes also don\u0027t play nice with §bApplied Energistics§r.\n\nTake advantage of Assembling Machines: §cphase out all use of hand tools for crafting items in your automation going forward.§r Once you have all the important machines, you will never need hand tools for crafting.",
+          "desc:8": "nomifactory.quest.db.72.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4163,7 +4164,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Assembling Machine",
+          "name:8": "nomifactory.quest.db.72.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4205,7 +4206,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types. Oh, and they\u0027re relatively cheaper to make.\n\nThe only downside is that §ethey will not connect to §bApplied Energistics§r §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use AE cables like §6Fluix Cable§r for those.",
+          "desc:8": "nomifactory.quest.db.73.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4216,7 +4217,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ME Conduit",
+          "name:8": "nomifactory.quest.db.73.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4257,7 +4258,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Quartzite Ore§r is found in... quartzite veins in the Overworld.\n\n§6Quartzite Dust§r can be electrolyzed into §6Crushed Black Quartz§r, which can be crystallized into §6Black Quartz§r in an §3Autoclave§r.\n\nBlack Quartz and §6Aluminium Plates§r will make §6Aluminium Casings§r, which are used for making machines from §bActually Additions§r.",
+          "desc:8": "nomifactory.quest.db.74.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4268,7 +4269,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Aluminium Casing",
+          "name:8": "nomifactory.quest.db.74.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4315,7 +4316,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Machine Block§r is the first step into a mod called §bExtra Utilities 2§r.",
+          "desc:8": "nomifactory.quest.db.75.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4326,7 +4327,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Machine Block",
+          "name:8": "nomifactory.quest.db.75.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4369,7 +4370,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your first §6Tier Two Circuits§r will require §2two §6Tier One Circuits§r plus §2two §6Diodes§r.\n\nThese are rather expensive... Always be on the lookout for a cheaper way to make your circuits - new sets of recipes become available each time you make a new tier of §2Circuit Assembler§r. Conveniently, this tier of Circuit unlocks one now!",
+          "desc:8": "nomifactory.quest.db.76.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4380,7 +4381,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Two Circuits",
+          "name:8": "nomifactory.quest.db.76.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4422,7 +4423,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Perfect Gems are equivalent to 8 of the base gem.\n\n§211 Perfect Diamonds are used in crafting each Crystal Matrix Ingot.",
+          "desc:8": "nomifactory.quest.db.77.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4433,7 +4434,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Perfect Gems",
+          "name:8": "nomifactory.quest.db.77.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4475,7 +4476,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Initial circuit components are a bit more difficult in CEu, and you need Arsenic in addition to Gallium.§r\n\nFor §dGallium§r, you may, ranged from worst to best:\n\n- §3Electrolyze §aSphalerite§r for a low chance of small dust. Note that you lose on direct smelting value.\n\n-§r Put §aCrushed Bauxite§r in the §3Chemical Bath§r. Note that this requires §9Sodium Persulfate§r. \n\n- Obtain it as a Byproduct of §aSphalerite§r Ore Processing, in the §3Thermal Centrifuge§r or §3Centrifuge§r.\n\n§2For Arsenic, you must centrifuge Realgar Dust, or (more involvedly) flash smelt Cobaltite Dust in the EBF, and electrolyse the resultant Arsenic Trioxide.\n\nCombine both in a Mixer to make Gallium Arsenide.",
+          "desc:8": "nomifactory.quest.db.78.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4486,7 +4487,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Gallium Arsenide",
+          "name:8": "nomifactory.quest.db.78.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4540,7 +4541,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Cuts things up.\n\nThe §3Cutting Machine§r is able to cut wafers, rods, wood, and various other things for you, making it a versatile crafting tool. Cutting blocks into 9 plates is much faster than using a §2Metal Bender §rto make them one at a time.\n\nThis quest accepts the LV or MV version. The LV version can cut §6Silicon Boules§r for easier §6Diodes§r, and can also cut plates and other components. The MV version is required for cutting §6Wafers§r.\n\nThe blade will require you to make §2Cobalt Brass§r (for LV) or §2Vanadiumsteel§r (for MV).\n\nCutting Machines work with plain §9Water§r for all recipes. You can also use §9Distilled Water§r which speeds up the processing somewhat, or §9Lubricant§r that speeds it up greatly (and uses very little per operation). These might be a little tricky to make right now, but are very worthwhile upgrades in the future.\n\nYou might consider waiting until you have §2Integrated Circuits§r before progressing too far down the path of MV machines, since these circuits are much easier to make than §2Electronic Circuits§r.",
+          "desc:8": "nomifactory.quest.db.79.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4551,7 +4552,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Cutting Machine",
+          "name:8": "nomifactory.quest.db.79.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4610,7 +4611,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A hefty amount of §6Silicon Dust§r and a pinch of §2Gallium Arsenide §rcooked in an §3EBF§r will net you a §6Silicon Boule§r, the starting point for §6Circuit Wafers§r.\n\nMake sure your power system is up to the task. These take §27.5 minutes and 1,080,000 EU§r to process.",
+          "desc:8": "nomifactory.quest.db.80.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4621,7 +4622,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Silicon Boules",
+          "name:8": "nomifactory.quest.db.80.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4663,7 +4664,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Wafers§r are thin pieces of silicon cut from a §6Silicon Boule§r.\n\nTheir primary purpose is engraving §6Circuit Wafers§r.\n\nYou\u0027ll be needing huge amounts of these Wafers for circuits. Silicon Boules currently take a very long time to craft, so consider parallelizing the recipe in multiple §3EBF§rs and making a stockpile of them.",
+          "desc:8": "nomifactory.quest.db.81.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4674,7 +4675,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Silicon Wafers",
+          "name:8": "nomifactory.quest.db.81.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4716,7 +4717,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Phenol§r is produced as a byproduct from making §6Coal Coke§r in a §3Pyrolyse Oven§r.\n\nThese boards will enable the next tier of circuits, as well as a much cheaper method of circuit production.",
+          "desc:8": "nomifactory.quest.db.82.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4727,7 +4728,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phenol Coated Substrate",
+          "name:8": "nomifactory.quest.db.82.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4771,7 +4772,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §3Precision Laser Engraver§r is used to engrave circuits onto §6Wafers§r.\n\nThe type of circuit will depend on the kind of wafer used and which §aLens§r is in the machine.",
+          "desc:8": "nomifactory.quest.db.83.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4782,7 +4783,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Precision Laser Engraver",
+          "name:8": "nomifactory.quest.db.83.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4825,7 +4826,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Circuit Wafers§r are batches of integrated circuits engraved onto a wafer of electronics-grade silicon.\n\nYou need to run these through the §3Cutting Machine§r to dice the wafers into individual integrated circuits (called dies).\n\nThese are important components and will be used for making more advanced Circuits.",
+          "desc:8": "nomifactory.quest.db.84.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4836,7 +4837,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Circuit Wafers",
+          "name:8": "nomifactory.quest.db.84.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4921,7 +4922,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Much easier to mass produce than §6Electronic Circuits§r, and they fulfill the same function in nearly all cases.\n\nYou should be batch crafting these.",
+          "desc:8": "nomifactory.quest.db.86.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4932,7 +4933,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier One Circuits",
+          "name:8": "nomifactory.quest.db.86.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4973,7 +4974,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Two Integrated Circuits§r and various other components will create a §2Good Integrated Circuit.",
+          "desc:8": "nomifactory.quest.db.87.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4984,7 +4985,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Two Circuits",
+          "name:8": "nomifactory.quest.db.87.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5026,7 +5027,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need a variety of §alenses§r for use in §3Precision Laser Engravers§r, all of which are made in the §2Lathe§r.\n\nInitially you\u0027ll need a §a§3§2Ruby Lens§r. Soon you will need §2Diamond, Emerald, Topaz, and Sapphire Lenses§r. §2You can choose to use an MV Lathe to get a lens from a plate, or sift for an Exquisite Gem and use an LV Lathe.\n\n",
+          "desc:8": "nomifactory.quest.db.88.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5037,7 +5038,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Lenses",
+          "name:8": "nomifactory.quest.db.88.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5079,7 +5080,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your first tier three circuit, formed from §2two Good Integrated Circuits§r, §6RAM§r, and §6Transistors§r, among other ingredients.\n\nAs you\u0027ll realize is the pattern, it is expensive and unwieldy to make the first forms of each tier of circuits. Fortunately, you don\u0027t have to make many of them.\n\nPrioritize using these circuits to make things needed for unlocking the next theme of circuits, which require more infrastructure but are much cheaper to produce. Eventually each tier through six will have a circuit recipe instead of requiring processors, arrays, or mainframes.",
+          "desc:8": "nomifactory.quest.db.89.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5090,7 +5091,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Three Circuits",
+          "name:8": "nomifactory.quest.db.89.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5132,7 +5133,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With the §3Advanced Circuit Assembling Machine§r, a new theme of Circuits is available.",
+          "desc:8": "nomifactory.quest.db.90.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5143,7 +5144,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2MV Circuit Assembler",
+          "name:8": "nomifactory.quest.db.90.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5184,7 +5185,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Chrome§r is obtained by electrolyzing §6Ruby Dust§r.",
+          "desc:8": "nomifactory.quest.db.91.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5195,7 +5196,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chrome",
+          "name:8": "nomifactory.quest.db.91.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5237,7 +5238,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Farmer§r can be used to automate the planting and gathering of crops, including §6Potatoes§r, §6Canola§r, §6Carrots§r, and §6Beetroot§r.\n\nDoesn\u0027t do trees, though.",
+          "desc:8": "nomifactory.quest.db.92.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5248,7 +5249,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Farmer",
+          "name:8": "nomifactory.quest.db.92.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5290,7 +5291,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6HV Machine Hulls§r made, you\u0027ve made your first step towards §eHigh Voltage (HV)§r power machinery!\n\nWhile you can make these in a crafting table with §6Polyethylene Sheets§r, liquid §9Polyethylene§r can be used to craft these directly in an §3Assembling Machine§r.",
+          "desc:8": "nomifactory.quest.db.93.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5301,7 +5302,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "HV Machine Hulls",
+          "name:8": "nomifactory.quest.db.93.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5343,7 +5344,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Sulfuric Acid is mainly produced in a 3-step process:§r\n-§6 Sulfur§o§r added to §9Oxygen§r to produce §9Sulfur Dioxide§r. §9SO₂§r also can come from treating certain §6Sulfur-containing Dusts§r with §9Oxygen§r in the EBF, or by processing §eNether Air§r.\n- §9Sulfur Dioxide§r added to more §9Oxygen§r, with §cVanadium Pentoxide§r catalyst, to produce §9Sulfur Trioxide§r.\n- §9Sulfur Trioxide§r added to §9Water§r, to produce §eSulfuric Acid§r.\n\nThe shortcut Sulfur + Water reaction is locked behind the Large Chemical Reactor, unlocked at EV.\n\n§rYou\u0027ll need huge amounts of this for a whole range of chemical reactions, as it is a very common ingredient.\n\nSulfur can be electrolyzed from many things, but is also easily available via §bDeep Mob Learning§r\u0027s §aBlaze Model§r.",
+          "desc:8": "nomifactory.quest.db.94.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5358,7 +5359,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Sulfuric Acid",
+          "name:8": "nomifactory.quest.db.94.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -5397,7 +5398,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Ethylene§r is a hydrocarbon made from §2either cracking and distilling Light Fuel, or§r dehydrating §9Ethanol§r with §9Sulfuric Acid§r in a §3Chemical Reactor§r. It is an extremely important chemical in the production of plastics.\n\n§9Polyethylene (PE)§r is the most common category of plastic, made from polymers of §9Ethylene§r. Adding §9Oxygen§r in a §3Chemical Reactor§r recreates (with some artistic license) early accidental synthesis of Polyethylene.\n\nWhen you have large amounts of §6Rutile§r and §6Bauxite§r (probably after you visit the Moon) you can consider using §9Titanium Tetrachloride§r as a catalyst to improve your Polyethylene yields. For now it\u0027s not a great idea, as in addition to its Overworld rarity, you need it for §6Titanium§r.\n\n§cPhthalic Anhydride§r acts as an alternative to §9Titanium Tetrachloride§r for increasing plastic yields.",
+          "desc:8": "nomifactory.quest.db.95.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5412,7 +5413,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Ethylene and Polyethylene",
+          "name:8": "nomifactory.quest.db.95.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -5450,7 +5451,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Form §6Polyethylene Sheets§r using a §3Fluid Solidifier§r and a §aPlate Mold§r for use in crafting electronics components.",
+          "desc:8": "nomifactory.quest.db.96.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5461,7 +5462,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Plastic Sheets",
+          "name:8": "nomifactory.quest.db.96.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5560,7 +5561,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Stainless Steel§r will be your primary material for HV, in the same way that §6Aluminium§r was for MV and §6Wrought Iron§r was for LV.\n\n§6Manganese§r comes from electrolyzing §6Tantalite§r, §6Pyrolusite§r, or §6Spessartine Dusts§r. You already have §6Chrome§r.\n\nMix up a bunch of the dust in a §3Mixer§r and begin processing it through the §3Electric Blast Furnace§r. This may be a good time to reevaluate your power generation and storage infrastructure.",
+          "desc:8": "nomifactory.quest.db.98.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5571,7 +5572,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Stainless Steel",
+          "name:8": "nomifactory.quest.db.98.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5618,7 +5619,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With the §6Stabilized Einsteinium§r you harvested from a microverse, you should now have access to everything you need to synthesize your first §dMote of Omnium§r. §2Compared to the original pack, this requires 20 new elements.§r\n\nYou\u0027re gonna need to make at least 487 of these as you push into the End Game, so make sure your §eautomation is supplying you with a stock of all of the ingredients§r. That\u0027s what those quests in the End Game tab have been about all along!",
+          "desc:8": "nomifactory.quest.db.99.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5629,7 +5630,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Synthesizing Your First Omnium",
+          "name:8": "nomifactory.quest.db.99.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5676,7 +5677,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Engineering Processors§r are made from a §6Diamond Plate§r, a §6Silicon Plate§r, and any tier one circuit.\n\nRun the plates through the respective §3Inscribers§r with §aPresses§r to make the printed plates, then combine the plates and circuit to form the Engineering Processor.",
+          "desc:8": "nomifactory.quest.db.100.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5687,7 +5688,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Engineering Processor",
+          "name:8": "nomifactory.quest.db.100.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5730,7 +5731,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "*Slaps §6ME Drive§r* this bad boy can fit so many §6Storage Cells§r in it!\n\nWith ten slots for Storage Cells, you can store a huge number of items inside this single block, and search through them all with a §6Terminal§r. You just gotta make all those Storage Cells.\n\nIf you somehow run out of room, you can make another ME Drive for even more slots! So many cells, so many items!",
+          "desc:8": "nomifactory.quest.db.101.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5741,7 +5742,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Digital Storage For Days",
+          "name:8": "nomifactory.quest.db.101.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5782,7 +5783,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Logic Processors§r are made from a §6Gold Plate§r, a §6Silicon Plate§r, and any tier one circuit.\n\nRun the plates through the respective §3Inscribers§r with §aPresses§r to make the printed plates, then combine the plates and circuit to form the Logic Processor.",
+          "desc:8": "nomifactory.quest.db.102.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5793,7 +5794,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Logic Processor",
+          "name:8": "nomifactory.quest.db.102.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5835,7 +5836,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aPresses§r are needed for §3Inscribers§r.\n\nIf you like exploring you can find them in meteors with a §aMeteor Compass§r.\n\nIf you don\u0027t want to do that, or are having trouble finding one you need, feel free to etch them yourself with a §3Precision Laser Engraver§r.",
+          "desc:8": "nomifactory.quest.db.103.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5846,7 +5847,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Inscription Plates",
+          "name:8": "nomifactory.quest.db.103.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -5907,7 +5908,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aPatterns§r are used to encode a single crafting table or processing recipe for on-demand automation with §bApplied Energistics§r.\n\nEncode them in a §aPattern Terminal§r.\n\nNote that recipes encoded with Substitutions on will use existing equivalent items, but §ewill only automatically craft the exact item specified in the recipe.§r\n\nIt is also a §cvery bad idea§r to encode recipes that require GregTech hand tools (even worse with Substitutions on). They are not handled gracefully, causing your crafting computations to explode in complexity and memory requirement.\n\nUse recipes that use machines instead!\n\n",
+          "desc:8": "nomifactory.quest.db.104.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5918,7 +5919,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Autocrafting Patterns",
+          "name:8": "nomifactory.quest.db.104.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5959,7 +5960,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Calculation Processors§r are made from a §6Certus Plate§r, a §6Silicon Plate§r, and any §6tier one circuit§r.\n\nRun the plates through the respective §3Inscribers§r with §aPresses§r to make the printed plates, then combine the plates and circuit to form the Calculation Processor.",
+          "desc:8": "nomifactory.quest.db.105.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5970,7 +5971,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Calculation Processor",
+          "name:8": "nomifactory.quest.db.105.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6012,7 +6013,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "As the name suggests, this terminal lets you encode recipes onto §aBlank Patterns§r.\n\nIt\u0027s a micropart, so you need to place it on §6ME Cable§r (not a conduit).",
+          "desc:8": "nomifactory.quest.db.106.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6023,7 +6024,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pattern Terminal",
+          "name:8": "nomifactory.quest.db.106.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6064,7 +6065,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Atomic Reconstructor§r is the cornerstone of §bActually Additions§r, using Crystal Flux (which automatically converts 1:1 with RF) to change items into other items.\n\nThis machine fires a laser out of the front that reconstructs standard materials into special variants.\n\nThe machine itself will give you further instructions on how to configure it.",
+          "desc:8": "nomifactory.quest.db.107.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6075,7 +6076,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Atomic Reconstructor",
+          "name:8": "nomifactory.quest.db.107.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6116,7 +6117,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This handy terminal allows you to see the pattern slots of all §aME Interfaces§r in your network in one place.\n\nThis means you don\u0027t have to run to your ME Interfaces each time you make a new pattern for them.",
+          "desc:8": "nomifactory.quest.db.108.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6127,7 +6128,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Interface Terminal",
+          "name:8": "nomifactory.quest.db.108.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6168,7 +6169,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aME Interfaces§r are extremely important for automation. You\u0027ll be making a lot of these, if you\u0027re playing the pack right.\n\nThese can be filled with encoded §aPatterns§r to perform on-demand autocrafting, and can be configured to stock up to 9 stacks of items for passive autocrafting, Any item pushed into an ME Interface is digitized and placed in your ME Network storage.\n\nWhen adjacent to one or more §aMolecular Assemblers§r, crafting table patterns can be crafted. It will use as many adjacent Molecular Assemblers as possible, restricted by availability and number of §aCo-processors§r in your crafting CPU multiblock.\n\nWhen adjacent to any other block, you can use processing patterns with a machine to insert items into the machine. Processing patterns require that the finished item is inserted back into the ME Network by way of an ME Interface (though it doesn\u0027t need to be the same ME Interface the Pattern is in).\n\nME Interfaces can be wrenched to ensure they only communicate with a particular adjacent block, or can be crafted into a micropart form to fit multiple in the same block space (each micropart only interacting with the adjacent block face).\n\n",
+          "desc:8": "nomifactory.quest.db.109.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6179,7 +6180,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ME Interfaces",
+          "name:8": "nomifactory.quest.db.109.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6222,7 +6223,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Autocrafting at last.\n\nWell, you need patterns too I guess.",
+          "desc:8": "nomifactory.quest.db.110.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6233,7 +6234,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crafting Units",
+          "name:8": "nomifactory.quest.db.110.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6280,7 +6281,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Crafting in a digital grid is heaven after using primitive wooden tables for so long.\n\nIt\u0027s a micropart, so you need to place it on §6ME Cable§r (not a conduit).",
+          "desc:8": "nomifactory.quest.db.111.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6291,7 +6292,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crafting Terminal",
+          "name:8": "nomifactory.quest.db.111.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6332,7 +6333,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "By placing them in the path of an §3Atomic Reconstructor§r\u0027s laser beam, §6Coal§r can be turned into §6Void Crystals§r, and §6Iron Ingots§r into §6Enori Crystals§r.\n\nKeep in mind you can efficiently do this with blocks, splitting them into nine base items as usual.",
+          "desc:8": "nomifactory.quest.db.112.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6343,7 +6344,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reconstruction Of Atoms",
+          "name:8": "nomifactory.quest.db.112.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6390,7 +6391,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Resonator§r is one of the primary crafting machines from §bExtra Utilities 2§r. It requires Grid Power in order to function, and produces special items like §6Stoneburnt§r and §6Red Coal§r.",
+          "desc:8": "nomifactory.quest.db.113.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6401,7 +6402,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Resonator",
+          "name:8": "nomifactory.quest.db.113.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6442,7 +6443,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§eGrid Power§r, or GP for short, is a power system used by §bExtra Utilities§r. It is generated by using a variety of §3Mills§r.\n\nIt deviates from most power systems in that Mills and GP consumers can be placed anywhere. It is globally available. However, Mills of each type incur §cdiminishing returns§r to massively punish excessive spamming of the same kind of Mills. Diversify!\n\nThe first Mill available is the §3Manual Mill§r, which is a hand crank that generates up to 15 GP. This is enough to get started so you can make better Mill types. Place it down and wind it up by holding right-click to generate GP.\n\nIf you are playing in a group, the command §e/xu_powersharing§r may be useful to allow for sharing GP between players. Simply run the command and select which players you want to share your GP with.",
+          "desc:8": "nomifactory.quest.db.114.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6453,7 +6454,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Manual Mill",
+          "name:8": "nomifactory.quest.db.114.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6495,7 +6496,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Red Coal§r is an important ingredient for §6Black Steel Dust§r.\n\nCareful with making an AE2 pattern with this one; due to the way §bExtra Utilities§r item generation works, you\u0027ll have to craft a piece of Red Coal to put into relevant §aPatterns§r manually.",
+          "desc:8": "nomifactory.quest.db.115.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6506,7 +6507,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Red Coal",
+          "name:8": "nomifactory.quest.db.115.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6548,7 +6549,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Black Steel§r will be used to make various items from §bExtended Crafting§r. It will also be the basis of other Steel types later on.",
+          "desc:8": "nomifactory.quest.db.116.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6559,7 +6560,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Black Steel",
+          "name:8": "nomifactory.quest.db.116.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6601,7 +6602,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The first digital fluid storage component, used to make §a1k Fluid Storage Cells§r.\n\nFluid cells can store up to five fluid types, but it\u0027s better to format all your disks to a single fluid each. This avoids the scenario where one fluid fills up a cell, preventing the other fluids from being stocked. Extra types also use up a chunk of storage, resulting in less overall storage per cell.",
+          "desc:8": "nomifactory.quest.db.117.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6612,7 +6613,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "1k Fluid Storage",
+          "name:8": "nomifactory.quest.db.117.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6654,7 +6655,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A component used primarily for making bigger §6Storage Cells§r.\n\nUnformatted disks always have a hard limit of 63 distinct types of items, but each step up has roughly four times the total storage space of the prior disk.",
+          "desc:8": "nomifactory.quest.db.118.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6665,7 +6666,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "4k Item Storage",
+          "name:8": "nomifactory.quest.db.118.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6706,7 +6707,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The penultimate component for AE item §6Storage Cells§r.",
+          "desc:8": "nomifactory.quest.db.119.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6717,7 +6718,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "16k Item Storage",
+          "name:8": "nomifactory.quest.db.119.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6758,7 +6759,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The ultimate item storage component in §bApplied Energistics§r.\n\nUsed for storing really big amounts of things, like in a §664k ME Storage Cell§r.",
+          "desc:8": "nomifactory.quest.db.120.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6769,7 +6770,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "64k Item Storage",
+          "name:8": "nomifactory.quest.db.120.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6810,7 +6811,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This compressor is needed for making §6Signalum Heavy Plating§r.",
+          "desc:8": "nomifactory.quest.db.121.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6821,7 +6822,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "IV Compressor",
+          "name:8": "nomifactory.quest.db.121.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6862,7 +6863,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The second fluid storage component, used for §a4k Fluid Storage Cells§r.",
+          "desc:8": "nomifactory.quest.db.122.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6873,7 +6874,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "4k Fluid Storage",
+          "name:8": "nomifactory.quest.db.122.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6914,7 +6915,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The third fluid storage component, used for §a16k Fluid Storage Cells§r.",
+          "desc:8": "nomifactory.quest.db.123.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6925,7 +6926,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "16k Fluid Storage",
+          "name:8": "nomifactory.quest.db.123.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6966,7 +6967,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The largest fluid storage component, used for §a64k Fluid Storage Cells§r.",
+          "desc:8": "nomifactory.quest.db.124.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6977,7 +6978,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "64k Fluid Storage",
+          "name:8": "nomifactory.quest.db.124.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7018,7 +7019,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Stoneburnt§r is a key ingredient in crafting many things from Extra Utilities.\n\nBesides the Manual Mill, there are multiple ways to generate GP. Look up \"Mill\" in JEI for all possible mills.\n\nNote that the individual generators have been balanced differently than normal, so take that into account before building 16 Water Mills. It is a good idea to use several different kinds due to §bExtra Utilities§r implementing diminishing returns to prevent spamming one kind of Mill.\n\n",
+          "desc:8": "nomifactory.quest.db.125.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7029,7 +7030,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "GP Generation",
+          "name:8": "nomifactory.quest.db.125.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7072,7 +7073,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Surface Mounted Devices§r, or §6SMD§rs for short, are §2more efficient ways to produce the Circuit components you\u0027ve been making. They will be used until the second-to-last theme of circuits.§r\n\nAll SMD components must be produced in at least a §2HV Assembling Machine§r, and they all will require liquid §9Polyethylene§r.\n\nStart off with the §6SMD Transistor§r. These are simply a §6Gallium §2Foil§r and §6Fine Annealed Copper Wire§r.\n\nNext up are §6SMD Resistors§r, which are also simple: §6Carbon Dust§r and §6Fine Electrum Wire§r.\n\nNext up are §6SMD Diodes§r, which are fairly simple. §2Gallium Arsenide Dust§r and §6Fine Platinum Wire§r net you half a stack.§r\n\nThen are §6SMD Capacitors§r. You\u0027ll need sheets of §6Polyvinyl Chloride§r to make these, or they can also be made more slowly with §6Silicone Rubber§r. §2Using Tantalum Foil in place of Aluminium doubles your yield.\n\nFinally, and new to CEu, SMD Inductors. Made with Nickel Zinc Ferrite and Fine Cupronickel Wire.§r\n\nInvest in a robust system of automation for SMD components and all of their ingredients, since you\u0027ll never stop needing them. They will also work in place of the non-SMD versions you\u0027ve been using in all but the simplest of recipes.",
+          "desc:8": "nomifactory.quest.db.126.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7083,7 +7084,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2SMD Components",
+          "name:8": "nomifactory.quest.db.126.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7222,7 +7223,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2An expensive advanced component used in the construction of the MV Precision Laser Engraver and MV Circuit Assembler.\n\nProcess some Emerald Ore in the Sifter to get the Flawless Emerald required to craft this.",
+          "desc:8": "nomifactory.quest.db.129.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7233,7 +7234,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2MV Emitter",
+          "name:8": "nomifactory.quest.db.129.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -7279,7 +7280,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Annealed Copper§r is made §2in an Arc Furnace§r by treating §6Copper§r with §9Oxygen§r. It has less power loss than regular Copper when used as a cable, and is also required for more advanced electronic components.",
+          "desc:8": "nomifactory.quest.db.130.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7290,7 +7291,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Annealed Copper",
+          "name:8": "nomifactory.quest.db.130.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7332,7 +7333,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Vinyl Chloride§r is an industrial chemical made from chlorinating §9Ethylene§r (adding §9Chlorine§r at high temperature) in a §3Chemical Reactor§r. §9Ethane§r can be used as an alternative reagent.\n\nIt is used to create the plastic §9Polyvinyl Chloride§r, most well known as PVC. While it deviates from reality, in GregTech you chemically react Vinyl Chloride and §9Oxygen§r to polymerize it into PVC.\n\nLater, you can use §9Titanium Tetrachloride§r to catalyze this reaction as well for greater yield.\n\n§6PVC Sheets§r are superior to §6Polyethylene Sheets§r for making plastic substrates, producing twice as many §6Plastic Boards§r per craft.\n\n",
+          "desc:8": "nomifactory.quest.db.131.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7343,7 +7344,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Polyvinyl Chloride",
+          "name:8": "nomifactory.quest.db.131.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7385,7 +7386,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the first Tier Four circuit, which is used for EV-tier machinery. Requires some Vibrant Alloy.\n\n§2The HV Circuit Assembler only unlocks one circuit type, the Mainframe. There is no circuit theme associated with the HV Circuit Assembler; instead, the HV (non-Circuit) Assembler unlocks easier Circuit components. The next circuit theme is not until EV.",
+          "desc:8": "nomifactory.quest.db.132.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7396,7 +7397,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Four Circuits",
+          "name:8": "nomifactory.quest.db.132.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7439,7 +7440,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2You can start to churn out Microprocessors§r. These are the best kind of Tier One circuits you can make, and you won\u0027t unlock the better recipes for quite a while.\n\nYou should absolutely automate the production of these circuits, and §ekeep a stockpile automatically crafted§r so you don\u0027t have to wait around for them or bloat your crafting orders making them on-demand through AE.",
+          "desc:8": "nomifactory.quest.db.133.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7450,7 +7451,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third And Final Tier One Circuits",
+          "name:8": "nomifactory.quest.db.133.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7492,7 +7493,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Better substrates. Using §6Polyvinyl Chloride§r (PVC) instead of §6Polyethylene§r (PE) doubles your yield.\n\nThe third §2and fourth material options§r are§r much more difficult to make and probably not worth considering for now.",
+          "desc:8": "nomifactory.quest.db.134.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7503,7 +7504,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Plastic Substrate",
+          "name:8": "nomifactory.quest.db.134.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -7553,7 +7554,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Unique to this tier of Circuit, this MV circuit doesn\u0027t require the previous tier to craft.§r These are the best kind of Tier Two circuits you can make, and you won\u0027t unlock the better recipes for quite a while.\n\nYou should absolutely automate the production of these circuits, and §ekeep a stockpile automatically crafted§r so you don\u0027t have to wait around for them or bloat your crafting orders making them on-demand through AE.",
+          "desc:8": "nomifactory.quest.db.135.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7564,7 +7565,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third And Final Tier Two Circuits",
+          "name:8": "nomifactory.quest.db.135.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7605,7 +7606,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Another electronic component.\n\nMaking it inside an §3Assembling Machine§r is much, much cheaper than by hand, and using §6Nickel Zinc Ferrite§r bolts gives even better returns.",
+          "desc:8": "nomifactory.quest.db.136.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7620,7 +7621,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Small Coils",
+          "name:8": "nomifactory.quest.db.136.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7704,7 +7705,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6§2Rhodium Plated Lumium-Palladium§r,§6 Vanadium-Gallium§r, §2and Polyphenylene Sulfide§r, you can now make hulls for Ludicrous Voltage (LuV) §bGregTech§r machines.",
+          "desc:8": "nomifactory.quest.db.138.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7715,7 +7716,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LuV Machine Hulls",
+          "name:8": "nomifactory.quest.db.138.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7756,7 +7757,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Rare Earth§r comes from either centrifuging certain Impure Dusts, or processing those same Purified Dusts.\n\nThe sources are essentially §6Redstone§r, and everything inside of §6Bastnasite§r veins.",
+          "desc:8": "nomifactory.quest.db.139.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7767,7 +7768,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Rare Earth",
+          "name:8": "nomifactory.quest.db.139.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7808,7 +7809,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Advanced Inscribers§r are much easier to work with for automation purposes, since you can insert more than a single item at a time and you can lock §aPresses§r in place.\n\nYou can automate these nicely with processing patterns in an §aME Interface§r. They don\u0027t auto-eject items though, so you will need to pull the finished items out.",
+          "desc:8": "nomifactory.quest.db.140.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7819,7 +7820,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Inscriber",
+          "name:8": "nomifactory.quest.db.140.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7860,7 +7861,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your initial method of §9Steam§r production, to fuel your first machines. They automatically output Steam on all faces except the bottom.\n\nOnce you get Steel, consider upgrading to HP Solar Boilers.",
+          "desc:8": "nomifactory.quest.db.141.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7871,7 +7872,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Steam Production",
+          "name:8": "nomifactory.quest.db.141.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -8004,7 +8005,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Centrifuge §6Rare Earth§r, and among other useful materials, you\u0027ll get some §6Yttrium§r.\n\nBecause this recipe has chanced outputs, use a §2high tier Centrifuge to increase output chances§r, and §eensure the output slots don\u0027t fill up or excess items will be voided§r.",
+          "desc:8": "nomifactory.quest.db.144.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8015,7 +8016,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Yttrium",
+          "name:8": "nomifactory.quest.db.144.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8056,7 +8057,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A piston is a specialized motor, which is needed to make certain machines.\n\nOne of the more intricate components, as it is made using a motor.",
+          "desc:8": "nomifactory.quest.db.145.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8067,7 +8068,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Pistons",
+          "name:8": "nomifactory.quest.db.145.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8108,7 +8109,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Another common component of any machine that uses fluids. Also usable as a cover for moving fluids between §bGregTech§r machines and adjacent tanks or machines.\n\nYou can use §6Paper Rings§r or §6Rubber Rings§r, but both will require a §aKnife§r to craft. A stick and a piece of flint will make a Knife with low durability, or check the recipe for metal ones.",
+          "desc:8": "nomifactory.quest.db.146.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8119,7 +8120,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Pumps",
+          "name:8": "nomifactory.quest.db.146.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8160,7 +8161,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts both LV and MV Polarizer.\n\nAlthough you could §emagnetize§r §6Iron Ingots§r by hand using §6Redstone§r, doing that consumes considerable amounts of dust and that\u0027s not an option for more advanced materials. This machine will let you magnetize §6Steel Rods§r, as well as even more advanced materials later.\n\n§2Polarizer recipes in GTCEu go up to HV.",
+          "desc:8": "nomifactory.quest.db.147.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8171,7 +8172,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Polarizer",
+          "name:8": "nomifactory.quest.db.147.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8212,7 +8213,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A perfect material for making chopsticks.\n\nAlso the tier material for Extreme Voltage (EV).",
+          "desc:8": "nomifactory.quest.db.148.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8223,7 +8224,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Titanium",
+          "name:8": "nomifactory.quest.db.148.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8265,7 +8266,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Combining §9Titanium Tetrachloride§r with §6Magnesium§r in an §3Electric Blast Furnace§r (approximating the Kroll process) will net you your first Titanium.\n\nUnfortunately, it is super hot. You\u0027ll need to cool it in a §3Vacuum Freezer§r for it to be usable.\n\nIf you are autocrafting on-demand, it\u0027s better to not have your ME network know about this intermediate state. Outputting the §6Hot Titanium Ingot§r directly into a Vacuum Freezer avoids extra computations and item types.\n\nIf you absolutely insist on putting hot ingots in your network, you\u0027ll have to manually encode the §aPattern§r with an ingot that §cdamages you while you hold it§r. Your call.\n\n",
+          "desc:8": "nomifactory.quest.db.149.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8276,7 +8277,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Hot Titanium",
+          "name:8": "nomifactory.quest.db.149.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8304,7 +8305,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Vacuum Freezers§r are primarily used to cool down hot ingots.\n\nThey\u0027re also capable of freezing air into a liquid, and making superconductors.\n\nAt minimum you will need an energy input hatch, an input bus, an output bus, and 22 §6Frost Proof Machine Casings§r for forming the multiblock for processing Hot Ingots.\n\nIf you want to deal with fluids as well, subtract two casings and use a fluid input and fluid output in their place.\n\nBesides the controller placement, as usual the hatches/buses can go anywhere. Use the building guide in §bJEI§r which can be pulled up from the controller block.",
+          "desc:8": "nomifactory.quest.db.150.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8315,7 +8316,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vacuum Freezer",
+          "name:8": "nomifactory.quest.db.150.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8357,7 +8358,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Rutile§r is a §6Titanium§r precursor found in §6Ilmenite Ore§r and §6Bauxite Ore§r, which spawn uncommonly in the Overworld.\n\n§6§rLarger quantities of Ilmenite and Bauxite may be found on the Moon and other planets.\n\n",
+          "desc:8": "nomifactory.quest.db.151.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8368,7 +8369,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Early Rutile",
+          "name:8": "nomifactory.quest.db.151.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -8410,7 +8411,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Rutile§r, §6Carbon§r, and §9Chlorine§r may be chemically reacted to form §9Titanium Tetrachloride§r.\n\nThis fluid is a precursor for metallic §6Titanium§r, as well as a titanium halide useful for catalyzing various polymer reactions (like plastics) for greater yields.",
+          "desc:8": "nomifactory.quest.db.152.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8425,7 +8426,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Titanium Tetrachloride",
+          "name:8": "nomifactory.quest.db.152.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8470,7 +8471,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need an §3HV Chemical Reactor§r for processing §6Titanium§r.",
+          "desc:8": "nomifactory.quest.db.153.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8481,7 +8482,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "HV Chemical Reactor",
+          "name:8": "nomifactory.quest.db.153.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8522,7 +8523,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "It\u0027s time to make a §3Distillation Tower§r, which is the gatekeeper for more advanced plastics like §6Epoxy§r and doing petrochemistry.\n\nThe Distillation Tower is a highly flexible multiblock structure, able to be anywhere from §62 blocks high to up to 13 high§r (12 fluid outputs). The way that it works is that each level of the tower after the first will output an additional fluid from the recipe. §cAny output fluids in excess of available buses are voided§r. \n\nWhat you need the Distillation Tower for initially is to break down §9Biomass§r into §9Ethanol§r and §9Water§r. This recipe only has two outputs, so a §ethree-block-high Distillation Tower§r is just fine (the quest materials are for such a tower; if you want to build it bigger, you will need §ean additional 7 casings and 1 fluid output per floor§r).\n\nAny recipe with more than two fluids (like §9Oil§r) will need a larger tower. Make sure to increase the height of your tower to accommodate all of the outputs you want to keep. Also check the voltage requirements of the recipes, as many Distillation Tower recipes need higher voltages than MV. §eYou can swap out your Energy Input for a higher tier one when that time comes§r.",
+          "desc:8": "nomifactory.quest.db.154.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8533,7 +8534,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Distillation Tower",
+          "name:8": "nomifactory.quest.db.154.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8607,7 +8608,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §6Crystal CPUs§r and the §3LuV Assembling Machine§r crafted, you can make the final type of Tier Five Circuit: the §6Crystal Circuit§r.\n\n§2This is the first Circuit which strictly requires Advanced SMD components. All of them will from now on.§r\n\nAs the best form of Tier Five circuit, these should be automated and stockpiled. The variant recipe requiring §6Crystal System-on-Chip§r won\u0027t be available until you can make a §3ZPM Assembling Machine§r.",
+          "desc:8": "nomifactory.quest.db.155.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8618,7 +8619,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Fourth and Final Tier Five Circuits",
+          "name:8": "nomifactory.quest.db.155.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8660,7 +8661,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Kanthal§r is an alloy of §6Iron§r, §6Aluminium§r, and §6Chrome§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r into a §6Hot Kanthal Ingot§r which will damage you if it is held. To prevent this damage and obtain the desired ingot, the Hot Ingot must be cooled in a §3Vacuum Freezer§r.\n\nIt is best to directly route this Hot Ingot from the §6Output Bus§r of your Blast Furnace to the §6Input Bus§r of your Vacuum Freezer via conduits or an §6Ore Dictionary Filter§r and then retrieve the cooled ingot.",
+          "desc:8": "nomifactory.quest.db.156.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8671,7 +8672,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Kanthal Ingots",
+          "name:8": "nomifactory.quest.db.156.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8712,7 +8713,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Kanthal§r is the second coil material available, increasing your EBF\u0027s operating temperature to 2700K so it can process more advanced materials.\n\n§2In CEu, using higher-tier coils provides some bonuses to their multiblocks.\n- Pyrolyse Oven: Cupronickel Coils are 25% slower, every coil above Kanthal grants +50% additive speed\n- Multi Smelter: Increases number of parallel operations and decreases energy usage\n- Cracking Unit: -5% energy usage per coil above Cupronickel\n- Electric Blast Furnace: The temperature of the EBF is the coil\u0027s temperature, plus 100K for each voltage tier above MV.\nFor every 900K above the recipe temperature, the energy usage is multiplied by 0.95x.\nFor every 1800K above, one overclock becomes 100% efficient - each overclock will 4x the speed instead of 2x.",
+          "desc:8": "nomifactory.quest.db.157.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8723,7 +8724,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Kanthal Coil Blocks",
+          "name:8": "nomifactory.quest.db.157.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8764,7 +8765,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Nichrome§r is an alloy of §6Nickel§r and §6Chrome§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.\n",
+          "desc:8": "nomifactory.quest.db.158.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8775,7 +8776,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nichrome Ingots",
+          "name:8": "nomifactory.quest.db.158.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8816,7 +8817,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Nichrome§r is the third coil material available, increasing your EBF\u0027s operating temperature to 3600K so it can process more advanced materials.\n\n§23600K is now also hot enough to grant a single 100% efficient overclock to 1800K and below recipes. In effect, you will get an additional 2x speed boost by overclocking once. You may wish to use this well to make up for the slower recipes.",
+          "desc:8": "nomifactory.quest.db.159.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8827,7 +8828,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Nichrome Coil Blocks",
+          "name:8": "nomifactory.quest.db.159.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8868,7 +8869,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "First, you need some §9Oil§r. Pick your favorite method: you should engineer a renewable automated source, as you will need large quantities.\n\nStart off by running the Oil through the §3Distillation Tower§r. This will result in §9Sulfuric Heavy Fuel§r, §9Sulfuric Light Fuel§r, §9Sulfuric Naphtha§r, and §9Sulfuric Gas§r.\n\nThese will all need to be hydrodesulfurized using §9Hydrogen§r in a §3Chemical Reactor§r, which produces the non-Sulfuric versions.\n\nAll of these products are useful, so figure out how you want to store the variety and large quantities of fluids.",
+          "desc:8": "nomifactory.quest.db.160.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8883,7 +8884,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Sulfuric Heavy, Light, Naphtha and Gas",
+          "name:8": "nomifactory.quest.db.160.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8933,7 +8934,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Like other petroleum products, §9Sulfuric Gas§r §2or Natural Gas§r is hydrodesulfurized into §9Refinery Gas§r using §9Hydrogen§r in a §3Chemical Reactor§r.\n\nRefinery Gas can be cracked and further distilled for its constituents, but it is also useful as fuel for §3Gas Turbines§r. While it can be burned directly, centrifuging Refinery Gas produces §9LPG§r (Liquefied Petroleum Gas), which is an ideal fuel for Gas Turbines, and §9Methane§r which is a potential suboptimal turbine fuel but is also useful for various chemical reactions.",
+          "desc:8": "nomifactory.quest.db.161.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8948,7 +8949,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Refinery Gas",
+          "name:8": "nomifactory.quest.db.161.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8987,7 +8988,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Canola Press§r is a machine that uses RF power to extract §9Canola Oil§r from §6Canola§r.\n\nCanola Oil can be turned into §9Glycerol§r and §9Bio Diesel§r in a §3Chemical Reactor§r.\n\nRefining, Crystallizing, or Empowering the Canola Oil first allows you to make Glycerol and Bio Diesel more efficiently.",
+          "desc:8": "nomifactory.quest.db.162.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8998,7 +8999,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Canola Press",
+          "name:8": "nomifactory.quest.db.162.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9039,7 +9040,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A whole host of fluids can be used as the feedstock for your §9Bio Diesel§r, including §9Seed Oil§r, §9Fish Oil§r, and the various tiers of §9Canola Oils§r.\n\nFish Oil and Canola Oil are probably the easiest, but it\u0027s up to you to choose.\n\nFish are easiest to get from §aGuardian Models§r from §bDML§r.",
+          "desc:8": "nomifactory.quest.db.163.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9054,7 +9055,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Seed Oil, Fish Oil, Canola Oil",
+          "name:8": "nomifactory.quest.db.163.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -9082,7 +9083,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Heavy Fuel§r is mixed with §9Light Fuel§r to create §9Diesel§r.\n\nSince Diesel requires more Light than Heavy fuel, you should consider Steam-cracking and distilling the excess quantity of Heavy Fuel for its useful constituents.",
+          "desc:8": "nomifactory.quest.db.164.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9097,7 +9098,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Heavy Fuel",
+          "name:8": "nomifactory.quest.db.164.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9135,7 +9136,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Light Fuel\u0027s distillates are now more useful, and it is the only source of Octane for High-Octane Gasoline.\nBut if you choose to produce Diesel, a large proportion of the Light Fuel you produce still has to go into Diesel production.",
+          "desc:8": "nomifactory.quest.db.165.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9150,7 +9151,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Light Fuel",
+          "name:8": "nomifactory.quest.db.165.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9188,7 +9189,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Naphtha§r is best utilized for Steam-Cracking and distilling for its constituents.\n\nNotably it contains §9Light Fuel§r and §9Heavy Fuel§r for making more §9Diesel§r, as well as many other useful chemicals for a variety of purposes.",
+          "desc:8": "nomifactory.quest.db.166.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9203,7 +9204,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naphtha",
+          "name:8": "nomifactory.quest.db.166.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9241,7 +9242,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Hydrogen Sulfide§r is a byproduct of hydrodesulfurization. §2It also comes from distilling Liquid Nether Air.§r\n\nA simple chemical reaction with §9Water§r reprocesses it into the useful §9Sulfuric Acid§r, or it can be electrolyzed for recovering the §9Hydrogen§r.",
+          "desc:8": "nomifactory.quest.db.167.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9256,7 +9257,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Hydrogen Sulfide",
+          "name:8": "nomifactory.quest.db.167.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9295,7 +9296,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Diesel§r is a mixture of §9Light Fuel§r and §9Heavy Fuel§r. Each mB of Diesel generates §d480 EU§r in §3Combustion Generators§r.\n\nOnce you get HV machinery, you can upgrade this to §9Cetane-Boosted Diesel§r.\n\n§2§rIt\u0027s more power efficient to use §3singleblock Distilleries§r over a §3Distillation Tower§r for Oil, due to the overclocking mechanics being different. For Diesel, the correct ratio is §d3 Distilleries for Light Oil and 2 Distilleries for Heavy Oil§r.",
+          "desc:8": "nomifactory.quest.db.168.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9310,7 +9311,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Diesel",
+          "name:8": "nomifactory.quest.db.168.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9348,7 +9349,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§cKapton K§r is now required for preparing §6Wetware Lifesupport Circuit Boards§r.\n\nYou went through §9Polybenzimidazole§r, this should be easy by now.",
+          "desc:8": "nomifactory.quest.db.169.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9359,7 +9360,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Kapton K",
+          "name:8": "nomifactory.quest.db.169.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -9399,7 +9400,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Sodium Hydroxide§r is a strong base, and an ingredient in §9Bio Diesel§r, among other reactions.\n\n§2The only source§r is splitting §9Salt Water§r in an §3Electrolyzer§r - this is also a good source of §9Chlorine§r. You can get §9Salt Water§r from mixing §6Salt§r and §9Water§r (duh), §2dissolving Ghast Tears, or drilling it from Salt Water fluid veins, which only spawn over oceans.",
+          "desc:8": "nomifactory.quest.db.170.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9410,7 +9411,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Sodium Hydroxide",
+          "name:8": "nomifactory.quest.db.170.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -9452,7 +9453,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Air§r can be sent into the §3Vacuum Freezer§r to turn it into §9Liquid Air§r.\n\nLiquid Air can be sent into a §2normal Distillation Tower§r to break it down into its components.\n\n§2Liquid Nether Air and Liquid Ender Air give different useful components.\n",
+          "desc:8": "nomifactory.quest.db.171.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9463,7 +9464,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Cryogenic Air Distillation",
+          "name:8": "nomifactory.quest.db.171.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9502,7 +9503,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The reaction that produces §9Bio Diesel§r is also the only source of §9Glycerol§r, which is an easy way to make §9Epichlorohydrin§r, an important ingredient of §9Epoxy§r.\n\n§9Glycerol§r is also used in the production of §9§9Glyceryl Trinitrate§r, an important step in making §6Dynamite§r, which can be used later in the §9§r§3Implosion Compressor§r.\n\nEven if you\u0027re otherwise going all in on petrochemistry for Epoxy, you\u0027ll probably end up with some Bio Diesel as a result of making Glycerol.\n\nBio Diesel can be used for power, but is probably better to convert to §9Nitro Diesel§r§r.",
+          "desc:8": "nomifactory.quest.db.172.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9517,7 +9518,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Bio Diesel and Glycerol",
+          "name:8": "nomifactory.quest.db.172.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9556,7 +9557,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Nitrogen§r comprises 78% of the atmosphere. Because of this, after the first few processes of §9Liquid Air§r, you\u0027ll probably have more Nitrogen than you know what to do with.\n\nIf you got here centrifuging air, then it\u0027s gonna take you longer to get to that point.\n\nEven so, don\u0027t void it unless you have secured a very large stockpile. Storage is cheap and Nitrogen is used in sizeable quantities for several notable things, one of which you\u0027ll be needing very soon.",
+          "desc:8": "nomifactory.quest.db.173.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9571,7 +9572,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nitrogen",
+          "name:8": "nomifactory.quest.db.173.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -9609,7 +9610,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts LV/MV/HV/EV §3Gas Collectors§r.\n\nA §3Gas Collector§r will suck up air at a decent rate, provided the top side is unobstructed. The collected Air is automatically ejected into an adjacent tank via the output face.\n\n§2Gas Collectors in the Nether and End will collect Nether Air and Ender Air respectively, which yield different products.§r\n\nIV+ air collectors are not part of this quest, but for reference they exist and are called §3Atmosphere Collectors§r.\n\n",
+          "desc:8": "nomifactory.quest.db.174.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9620,7 +9621,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Basic Air Collection",
+          "name:8": "nomifactory.quest.db.174.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9661,7 +9662,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll be needing large quantities of the various Noble Gasses so you should get this automated and running continuously. \n\n§9Argon§r, for example, is important for production of advanced §6Silicon Boules§r.\n\n§2After liquefication, Overworld Air grants Helium and Argon; Nether Air grants Helium-3 and Neon; Ender Air grants Helium, Krypton, Xenon, and Radon.\n\n§2Certain Noble Gases can also boost the speed of EBF processes.",
+          "desc:8": "nomifactory.quest.db.175.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9676,7 +9677,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Noble Gasses",
+          "name:8": "nomifactory.quest.db.175.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9714,7 +9715,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A simple combination of §9Nitrogen§r and §9Oxygen§r, the two most common elements in the air, yet this substance is very toxic. Chemistry is weird.",
+          "desc:8": "nomifactory.quest.db.176.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9729,7 +9730,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nitrogen Dioxide",
+          "name:8": "nomifactory.quest.db.176.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9767,7 +9768,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Don\u0027t let the EPA catch you making this stuff.\n\n§9Nitrogen Dioxide§r, §9Oxygen§r, and §9Water§r will create §9Nitric Acid§r, the next step in your chemical journey.",
+          "desc:8": "nomifactory.quest.db.177.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9782,7 +9783,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Nitric Acid",
+          "name:8": "nomifactory.quest.db.177.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9821,7 +9822,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the additive that will bring our diesel fuel to the next level.\n\nMix §9Nitric Acid§r and §9Ethenone§r in a §3Chemical Reactor§r to make §9Tetranitromethane§r.\n\nIn a newly added route, you can also mix §9Nitric Acid§r and §9Methyl Acetate§r in a §3Chemical Reactor§r.",
+          "desc:8": "nomifactory.quest.db.178.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9836,7 +9837,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tetranitromethane",
+          "name:8": "nomifactory.quest.db.178.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9875,7 +9876,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mixing §9Diesel§r (or less efficiently, §9Bio Diesel§r) with §9Tetranitromethane§r in an §3HV Mixer§r produces §9Nitro Diesel§r, an extremely potent fuel. Burn it in the Large Combustion Engine and Extreme Combustion Engine, producing §2720 EU/mB of fuel.",
+          "desc:8": "nomifactory.quest.db.179.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9890,7 +9891,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2NITRO DIESEL!!",
+          "name:8": "nomifactory.quest.db.179.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9928,7 +9929,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Acetic Acid§r and §9Sulfuric Acid§r make §9Ethenone§r.\n\nOr you can heat §9Acetone§r, or a few other approaches. Check out §bJEI§r for the various options.",
+          "desc:8": "nomifactory.quest.db.180.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9943,7 +9944,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ethenone",
+          "name:8": "nomifactory.quest.db.180.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9981,7 +9982,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "There are several paths to §9Acetic Acid§r... probably the simplest is combining §9Oxygen§r, §9Hydrogen§r, and §6Carbon§r, but one of the several other methods may appeal to you more, especially if you have a §3Distillation Tower§r.\n\nLook through §bJEI§r for the various options.",
+          "desc:8": "nomifactory.quest.db.181.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9996,7 +9997,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Acetic Acid",
+          "name:8": "nomifactory.quest.db.181.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10035,7 +10036,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A colorless liquid with a pungent, garlic-like odor. It\u0027s needed in the production of §9Epoxy§r.\n\n§2You can skip a step making this with the Large Chemical Reactor.",
+          "desc:8": "nomifactory.quest.db.182.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10050,7 +10051,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Epichlorohydrin",
+          "name:8": "nomifactory.quest.db.182.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -10088,7 +10089,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §6Fiber-Reinforced Epoxy Resin Sheet§r is made in a §3Chemical Bath§r, not a §3Chemical Reactor§r. The board itself is made in a Chemical Reactor though.\n\nOther than that, it\u0027s very similar to the other substrates you\u0027ve made so far. This board type unlocks §2Quantum Circuits, which span tiers four through seven.",
+          "desc:8": "nomifactory.quest.db.183.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10099,7 +10100,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Fiber Reinforced Epoxy Substrate",
+          "name:8": "nomifactory.quest.db.183.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10152,7 +10153,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Petrochemistry is the category of organic chemistry pertaining to petroleum, otherwise known as §9Oil§r.\n\n§bGregTech§r\u0027s petrochemistry may seem daunting at first, given the sheer number of chemicals and processing options, but it\u0027s actually easier to get into than you think.\n\nOil is the starting point, and can be found in several variants which you can pump from finite natural wells on the Overworld, as well as coming renewably from §6Oilsands Ore§r and §6Soul Sand§r, and directly in liquid form from a §3Fluid Rig§r.\n\nStart off by distilling the Oil. This will result in §9Sulfuric Heavy Fuel§r, §9Sulfuric Light Fuel§r, §9Sulfuric Naphtha§r, and/or §9Sulfuric Gas§r.\n\nThese will all need to be hydrodesulfurized using §9Hydrogen§r in a §3Chemical Reactor§r or §2Oil Cracking Unit§r, which produces the non-Sulfuric versions.\n\nAll of these products are useful, so figure out how you want to store the variety and large quantities of fluids.\n\nThe upcoming quests will guide you through the basics of petrochemistry. Once you\u0027ve mastered that, feel free to explore further.\n",
+          "desc:8": "nomifactory.quest.db.184.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10167,7 +10168,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Navigating Petrochem",
+          "name:8": "nomifactory.quest.db.184.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -10205,7 +10206,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Finally, §6Epoxy Resin Sheets§r.\n\nThese can be made into circuit boards as a substrate for advanced circuits.",
+          "desc:8": "nomifactory.quest.db.185.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10216,7 +10217,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Epoxy",
+          "name:8": "nomifactory.quest.db.185.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10257,7 +10258,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Carbon Fibers§r are useful for a variety of things.\n\n§2They are made with Carbon Dust and polymers. Higher tier polymers grant higher yields. It\u0027s also not a chanced output anymore.",
+          "desc:8": "nomifactory.quest.db.186.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10268,7 +10269,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Carbon Fibers",
+          "name:8": "nomifactory.quest.db.186.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10309,7 +10310,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Remember to keep the MV area separate from your LV area. §eHooking up an LV machine to MV current will result in the machine being destroyed! Also LV cables will burn up if you put MV current through them§r. That\u0027s why it\u0027s probably best to keep the areas separate until you\u0027re comfortable and confident with voltages. Eventually you can use transformers to switch voltages within a single setup, but don\u0027t feel forced to try that until you\u0027ve got a grasp on the basics.\n\nAll RF power is the same (it has no voltages), so you can use RF conduits to route power from wherever you\u0027re generating and converting to EU with §3Energy Converters§r for each voltage. You don\u0027t have to use this setup, but it\u0027s the most foolproof one for a beginner. And if you\u0027re an expert, well... you don\u0027t need my advice.\n\nFor your MV cables, you can use §6Copper§r to start with. §6Energetic Alloy cables§r are §cless lossy§r though, so consider them if you\u0027re able to mass produce those ingots.",
+          "desc:8": "nomifactory.quest.db.187.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10320,7 +10321,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Energy Converter",
+          "name:8": "nomifactory.quest.db.187.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10361,7 +10362,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Epoxy Circuit Boards§r are a more advanced substrate type that gives you access to §2Nanocircuits, which span tiers three through six.",
+          "desc:8": "nomifactory.quest.db.188.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10372,7 +10373,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Epoxy Substrate",
+          "name:8": "nomifactory.quest.db.188.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10451,7 +10452,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Nano CPUs§r are advanced §6Circuit Wafers§r made from infusing a §6CPU Wafer§r with §6Carbon Fibers§r and §9Energized Glowstone§r in a §3Chemical Reactor§r.\n\nThen, cut the resulting wafer into dies using a §3Cutting Machine§r.",
+          "desc:8": "nomifactory.quest.db.190.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10462,7 +10463,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nano CPUs",
+          "name:8": "nomifactory.quest.db.190.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10504,7 +10505,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Using your new §6Epoxy Circuit Boards§r and some familiar components, you can now make the final form of Tier Two Circuit: the §6Microcircuit§r.\n\nYou craft four of these at once, and they\u0027re pretty cheap. Consider that you used to have to make §6Primitive Processors§r for this tier, and realize how far you\u0027ve come.\n\nAs with the final form of any tier of circuits, be sure to set up automation to stockpile these. You won\u0027t get to the §6System-on-Chip§r variant recipe for a while yet.",
+          "desc:8": "nomifactory.quest.db.191.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10519,7 +10520,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Fourth And Final Tier Two Circuits",
+          "name:8": "nomifactory.quest.db.191.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10565,7 +10566,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The first Mainframe you\u0027ll have to contend with.\n\nThis is the first Tier Five circuit available, and consequently the most expensive to make. as always, invest in the next circuit theme to get to cheaper recipes as soon as possible.",
+          "desc:8": "nomifactory.quest.db.192.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10576,7 +10577,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Five Circuit",
+          "name:8": "nomifactory.quest.db.192.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10654,7 +10655,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A more advanced type of §6Silicon Boule§r, formed by doping the §6Silicon§r crystal lattice with §6Glowstone§r.\n\nThese are made in an §3EBF§r with §6Nichrome§r or better coils, and need §2Nitrogen§r for the process. It needs twice as much Silicon as the basic boules, but also results in twice as many doped Silicon Wafers when sliced.\n\nCircuit Wafers can be made far more efficiently with these doped Silicon Wafers, but they are also needed for some more advanced types of Circuit Wafers that can\u0027t be engraved onto the basic ones.",
+          "desc:8": "nomifactory.quest.db.194.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10665,7 +10666,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Glowstone Doped Silicon Boule",
+          "name:8": "nomifactory.quest.db.194.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10708,7 +10709,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "FUSION!\n\nThis baby can do any fusion recipe, notably giving you access to §6Neutronium§r.\n\nThe multiblock layout is the same as the Mark 1 and Mark 2, with the same hatch and casing substitutions permitted.\n\nObviously though, this one uses §6Fusion Machine Casing Mk §2III§r and only works with §aUV Energy Input Hatches§r.\n\nThe §3Mark 3 Fusion Reactor§r has an energy buffer of §e640M EU§r.",
+          "desc:8": "nomifactory.quest.db.195.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10719,7 +10720,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fusion Reactor MK3",
+          "name:8": "nomifactory.quest.db.195.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10766,7 +10767,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Doesn\u0027t look exactly like Europium anymore.§r\n\nTo make §9Tritanium§r, you first need to make §9Duranium§r. This is done by fusing molten §9Gallium§r and §9Radon§r in a §3Fusion Reactor Mark 1§r or better.\n\nOnce you have Duranium, you can fuse Tritanium in a §3Fusion Reactor Mark 2§r using the Duranium and molten §9Titanium§r.\n\nIf you\u0027re having trouble figuring out the right item and fluid ratios for batching up these processes, consider plugging the relevant recipes into the §aCrafting Calculator§r.",
+          "desc:8": "nomifactory.quest.db.196.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10777,7 +10778,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tritanium Ingot",
+          "name:8": "nomifactory.quest.db.196.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10818,7 +10819,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungstensteel§r is an alloy of §6Tungsten§r and §6Steel§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.\n",
+          "desc:8": "nomifactory.quest.db.197.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10829,7 +10830,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tungstensteel",
+          "name:8": "nomifactory.quest.db.197.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10871,7 +10872,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6Tungstensteel§r achieved, you can now make hulls for Insane Voltage (IV) §bGregTech§r machines.\n\n§2Starting at IV, 16A Energy and Dynamo hatches are available at each tier.",
+          "desc:8": "nomifactory.quest.db.198.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10882,7 +10883,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2IV Machine Hulls",
+          "name:8": "nomifactory.quest.db.198.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10925,7 +10926,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Yttrium Barium Cuprate§r (more accurately, Yttrium Barium Copper Oxide, or YBCO) is, among other things, a high-temperature superconductor material.\n\nThis is used as plates in §bNuclearCraft§r, and will become an important cable material for later tiers of §bGregTech§r components.",
+          "desc:8": "nomifactory.quest.db.199.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10936,7 +10937,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Yttrium Barium Cuprate",
+          "name:8": "nomifactory.quest.db.199.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11014,7 +11015,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer §2and Chemical Bath§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r.\n\nIt is only found from §6Tungstate§r §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then electrolyzed§r to get to the Tungsten, which then needs to be cooked in the EBF for Tungsten ingots.",
+          "desc:8": "nomifactory.quest.db.201.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11025,7 +11026,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tungsten",
+          "name:8": "nomifactory.quest.db.201.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11067,7 +11068,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is one of the simpler rockets you can build. The specifics of the shape don\u0027t really matter, as long as the rocket engines are on the bottom and all the parts are added. It also needs to be inside the edges of the Launch Pad and not taller than the Structure Tower.\n\n§aIn order to progress this quest chain further, you\u0027ll first need to complete the Interdimensional Transport (either Dislocators or Telepad) questline and the Rocket Fuel questline, both of which are nearby on this quest tab.",
+          "desc:8": "nomifactory.quest.db.202.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11078,7 +11079,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Apollo Program",
+          "name:8": "nomifactory.quest.db.202.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11138,7 +11139,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Marginally cheaper to make than §2Advanced Integrated Circuits§r, and also the only way to make the §2Workstation§r, which is the first Tier Four circuit.",
+          "desc:8": "nomifactory.quest.db.203.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11149,7 +11150,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Three Circuits",
+          "name:8": "nomifactory.quest.db.203.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11190,7 +11191,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Making yourself a space suit is the most important step towards your space adventures.\n\nThis suit lets you breathe in space, which is kind of important.",
+          "desc:8": "nomifactory.quest.db.204.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11201,7 +11202,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Space Suit",
+          "name:8": "nomifactory.quest.db.204.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11261,7 +11262,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Suit Workstation is needed to install §6Low Pressure Tanks§r (or a larger tank if you like) onto your Space Suit Chest-Piece.\n\nOnce installed, you can stand on a §aGas Charging Pad§r to fill up the tanks with §9Oxygen§r. Of course, you\u0027ll need to fill the Gas Charging Pad with Oxygen first.",
+          "desc:8": "nomifactory.quest.db.205.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11272,7 +11273,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Suit Workstation",
+          "name:8": "nomifactory.quest.db.205.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11326,7 +11327,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A common component used by §bExtended Crafting§r.",
+          "desc:8": "nomifactory.quest.db.206.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11337,7 +11338,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Component",
+          "name:8": "nomifactory.quest.db.206.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11378,7 +11379,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Combine several components into a catalyst.",
+          "desc:8": "nomifactory.quest.db.207.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11389,7 +11390,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Catalyst",
+          "name:8": "nomifactory.quest.db.207.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11431,7 +11432,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "At some point you might consider venturing into space, like the Moon. While it\u0027s not at all required for the progression, you might find it valuable: to say the least, the Moon contains ore veins which are otherwise very rare to find in the Overworld. And for this, you\u0027ll need a rocket and a whole lot of preparations.\n\nBefore you can build the rocket itself, you\u0027ll need to create a launch pad. The §6Launch Pad§r blocks go in a 3x3 layout flat on the ground to form the platform.\n\nThe Structure Tower§r is formed from a column of §6Structure Tower§r blocks that holds your rocket upright. The first block goes adjacent to any side of the launch pad platform (on the same Y-level as the launch pad blocks).\n\nWith 6 Structure Tower blocks, you can only build a rocket 5 blocks high, since any higher would exceed the height of the tower. To build a taller rocket, you\u0027ll need to build a taller tower using more Structure Tower blocks.\n\nThe §3Rocket Assembling Machine§r needs to be placed next to the launch pad (not on it) 1 block higher than the platform, so that the bottom of the Rocket Assembler is flush with the top of the launch pad. It also needs to be supplied with RF power to function.\n\n",
+          "desc:8": "nomifactory.quest.db.208.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11442,7 +11443,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Launch Pad and Rocket Assembly Machine",
+          "name:8": "nomifactory.quest.db.208.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11495,7 +11496,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With the Extended Crafting Table, you can now craft 5x5 recipes.",
+          "desc:8": "nomifactory.quest.db.209.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11506,7 +11507,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Extended Crafting Table",
+          "name:8": "nomifactory.quest.db.209.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11547,7 +11548,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Even simple rockets demand §6Heavy Plates§r for their construction. In this case, made out of §6Steel§r. ",
+          "desc:8": "nomifactory.quest.db.210.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11558,7 +11559,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Steel Heavy Plates",
+          "name:8": "nomifactory.quest.db.210.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11599,7 +11600,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need this to set the §aGuidance Computer\u0027s§r destination to the Moon (Luna).\n\nIn your assembled Rocket, press the Rocket GUI Hotkey (default is §eC§r but you may need to rebind it). Click the little square that says \"Guidance Computer\" to pull up the Guidance Computer inventory. Then, place the blank chip into the Guidance Computer. Back out of this menu (§eEsc§r or §eE§r) to get back to the main Rocket GUI.\n\nClick the §cSelect Dst§r button, choose Luna, and click the Select button to assign the destination to the chip.\n\n§eNote: if you want to return your rocket to Earth, you will need to change the destination in this manner again to Earth before launching.§r",
+          "desc:8": "nomifactory.quest.db.211.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11610,7 +11611,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Flightplan To The Moon",
+          "name:8": "nomifactory.quest.db.211.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11652,7 +11653,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Fueling Station§r is how rockets get fuel.\n\nFirst, put together your Rocket, then §aScan§r and §cBuild§r the Rocket in the §3Rocket Assembling Machine§r to assemble it (which turns it into an entity). Next, with the §aLinker§r in your hand, right-click the Fueling Station then the Rocket Assembling Machine to link the Fueling Station to the constructed Rocket. \n\nYou\u0027ll get a confirmation message when you do it right, and a little line will appear between the Fueling Station and the rocket.\n\nNow just get §9Rocket Fuel§r into the Fueling Station and it will transfer to the Rocket automatically.\n",
+          "desc:8": "nomifactory.quest.db.212.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11663,7 +11664,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fuel Loading",
+          "name:8": "nomifactory.quest.db.212.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11710,7 +11711,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Holding one of these reveals §aTravel Anchors§r and §aTelepads§r in range.\n\nShift + right-click after aiming to warp to one, or point it anywhere to teleport forward a short distance (works through walls).\n\nThese are powered with RF, and can be further enchanted through §bEnderIO§r\u0027s enchanting mechanics.\n\nThe §6Vibrant Crystal§r will require an §3Autoclave§r.",
+          "desc:8": "nomifactory.quest.db.213.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11727,7 +11728,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Staff of Traveling",
+          "name:8": "nomifactory.quest.db.213.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11774,7 +11775,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Moon is a barren, lifeless rock... So why did you want to come here?\n\nOne major draw is that §6Moon Turf§r, which makes up the surface of the Moon, is an efficient means of obtaining §9Deuterium§r. It will be useful for producing §9Microversium§r, §9Tritium§r, plasmas from fusion, and crystallizing §6Dilithium§r.\n\nThere are also several ores that are rare on the Overworld but exist in abundance on the Moon. Moreover, ores generate more densely on the Moon than in other realms.\n\nIn particular, the Moon contains large quantities of §6Titanium§r (in the form of §6Rutile Ore§r and §6Ilmenite Ore§r), §6Tungsten§r (in the form of §6Scheelite Ore§r and §6Tungstate Ore§r), §6Fluorine§r (in the form of §6Fluorite Ore§r), and §6Molybdenum§r (in the form of §6Wulfenite Ore§r and §6Molybdenite Ore§r).\n\n§2The Moon also contains fluid deposits of Deuterium and Helium-3, which you can harvest with a Fluid Rig. However, you will want to use the second Fluid Rig tier to extract it, as the amount of Deuterium and Helium-3 is too low to be anything appreciable from a first tier Fluid Rig.\n",
+          "desc:8": "nomifactory.quest.db.214.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11785,7 +11786,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Deuterium",
+          "name:8": "nomifactory.quest.db.214.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11826,7 +11827,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Pumps are now available in GT. Useful for gathering Oil or perhaps Lava from the Nether.",
+          "desc:8": "nomifactory.quest.db.215.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11837,7 +11838,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Pumps",
+          "name:8": "nomifactory.quest.db.215.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11881,7 +11882,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is your first §3Microverse Projector§r.\n\nThese structures are used to project §6Micro Miners§r into a §eMicroverse§r to obtain valuable loot such as §6ores§r, §6gems§r, and otherwise unobtainable items§r like §6Radium Salt§r and §6Naquadah Dust§r. §cKeep in mind that Micro Miners are single-use!§r\n\nMicroverse Projectors are §bGregTech§r multiblocks, which means that they\u0027re just as flexible as other machines in terms of the I/O block placement: §epositions of Buses and Hatches can be swapped with any Microverse Projector Casing§r.\n\nA single §6HV Energy Input§r supports missions up to 1024 EU/t. To process the rest, you\u0027ll need to upgrade the multiblock to at least §eEV power§r, which is either §6two HV Energy Inputs§r or §6one EV Energy Input§r. Missions will also overclock, increasing in speed each time the projector\u0027s energy tier increases and available power reaches the next multiple of four times the base mission power.\n\nHover your mouse over the Small Microverse Projector and press §bU§r to see all available missions.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.216.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11892,7 +11893,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Small Microverse Projector",
+          "name:8": "nomifactory.quest.db.216.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11995,7 +11996,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is your first Micro Miner ever.\nYes, not the last: these things aren\u0027t reusable.\n\nThis one can get you:\n§6* Cassiterite Ore\n* Dense Iron Ore\n* Uraninite Ore\n* Redstone Ore\n* Nickel Ore\n§2* Bauxite Ore\n§6* Galena Ore\n* Moon Turf\n* Dilithium\n* Salt Ore§r\n§2* Molybdenum Ore§r\n\nWhen equipped with a Gemstone Sensor (which may currently not be available to you yet):\n§2* Perfect Diamond\n§6* Apatite Ore\n* Tricalcium Phosphate Ore\n* Quartzite Ore§r\n\nCan also be used to bring §bStellar Creation Data§r, but less efficiently than the Tier Two.\n\n",
+          "desc:8": "nomifactory.quest.db.217.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12006,7 +12007,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2First Foray Into The Microverse",
+          "name:8": "nomifactory.quest.db.217.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12084,7 +12085,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Scatter a few around your base, and you can warp to anywhere you please!",
+          "desc:8": "nomifactory.quest.db.219.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12095,7 +12096,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Travel Anchors",
+          "name:8": "nomifactory.quest.db.219.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12136,7 +12137,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mix §9Oxygen§r and §91,1-Dimethylhydrazine§r together to make §9Rocket Fuel§r.\n\nAwesome!\n\nWhen you have stable sourcing for Nitrogen and Oxygen, you can make and use §9Dinitrogen Tetroxide§r in the recipe instead of Oxygen. It doubles the efficiency of your §9UDMH§r when making Rocket Fuel.\n\nLater, when you have access to (non-methylated) §9Hydrazine§r, using that in place of §9N₂O₄ §rcan further increase your Rocket Fuel yield.",
+          "desc:8": "nomifactory.quest.db.220.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12151,7 +12152,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Rocket Fuel",
+          "name:8": "nomifactory.quest.db.220.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12190,7 +12191,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Dimethylamine§r and §9Chloramine§r combine together into §91,1-Dimethylhydrazine§r.",
+          "desc:8": "nomifactory.quest.db.221.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12205,7 +12206,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "1,1-Dimethylhydrazine",
+          "name:8": "nomifactory.quest.db.221.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12244,7 +12245,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Methanol§r and §9Ammonia§r combine together to make §9Dimethylamine§r.\n\nI know you\u0027re expecting a Breaking Bad joke here, but I don\u0027t walt to go for such low hanging fruit.",
+          "desc:8": "nomifactory.quest.db.222.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12259,7 +12260,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dimethylamine",
+          "name:8": "nomifactory.quest.db.222.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12298,7 +12299,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Hypochlorous Acid§r and §9Ammonia§r combine together to make §9Chloramine§r.",
+          "desc:8": "nomifactory.quest.db.223.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12313,7 +12314,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chloramine",
+          "name:8": "nomifactory.quest.db.223.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12351,7 +12352,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Hydrogen§r and §9Nitrogen§r combine together to make §9Ammonia§r.\n\nAn easy way to get Nitrogen is to centrifuge §9Air§r, which will require you to build an §3Air Collector§r. You could also electrolyze §6Saltpeter§r, distill §9Fermented Biomass§r in a §3Distillation Tower§r, or get huge amounts from a §3Cryogenic Air Distillation§r Tower§r.",
+          "desc:8": "nomifactory.quest.db.224.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12366,7 +12367,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ammonia",
+          "name:8": "nomifactory.quest.db.224.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12404,7 +12405,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Oxygen§r, §9Hydrogen§r, and §6Carbon§r combine together in a §3Chemical Reactor§r to make §9Methanol§r.\n\nYou can also use a §3Distillation Tower§r to get Methanol from §9Wood Vinegar§r and §9Fermented Biomass§r.",
+          "desc:8": "nomifactory.quest.db.225.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12419,7 +12420,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Methanol",
+          "name:8": "nomifactory.quest.db.225.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12457,7 +12458,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Water§r and §9Chlorine§r can be combined to make §9Hypochlorous Acid§r. If you add §9Mercury§r to catalyze the reaction, the yield is much better.\n\n§ePlease note that Hypochlorous Acid and Hydrochloric Acid are different things.§r\n\nYou\u0027re already familiar with Chlorine production from your forays into Plastics, but a great source of Mercury is §2centrifuging§4 §6Redstone§r.",
+          "desc:8": "nomifactory.quest.db.226.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12472,7 +12473,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Hypochlorous Acid",
+          "name:8": "nomifactory.quest.db.226.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12510,7 +12511,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Here comes the chemistry.\n\nIt might seem crazy right now, but you\u0027ll want a dedicated §3Chemical Reactor§r for pretty much every chemical you want to process. You probably want to hold off on doing that until you\u0027ve got a solid base of autocrafting though... it stings a lot less when you can just request crafts of Chemical Reactors from your AE2 system.\n",
+          "desc:8": "nomifactory.quest.db.227.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12521,7 +12522,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Chemical Reactor",
+          "name:8": "nomifactory.quest.db.227.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12562,7 +12563,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Yes, Snad.\n\nThis pack has §aSnad§r, which is simply a sand-like block that instantly grows sugar cane/cactus on top of it when it receives either a block update or a redstone update.\n\nThe sugar cane it produces can be used as a fuel for your dynamos, and later you can even brew it for §9Biomass§r.\n\nThis quest calls for a §aRedstone Timer§r, but there are other ways to make snad grow sugar cane even faster (like a vanilla observer clock pointing into the Snad). Make sure to set the timer to pulse as fast as possible.\n\nTo collect the sugar cane, you can use a piston and an observer. Later you can make an §6Auto-Breaker§r from §bActually Additions§r, which works even better and doesn\u0027t spill sugar cane everywhere.\n\nFor now, a §3Vacuum Chest§r should help keep the floor clean, and causes less lag than Hoppers. A §aVoid Upgrade§r in a §6Storage Drawer§r will automatically delete any items that overflow the drawer\u0027s capacity, so it\u0027s a good way to ensure you don\u0027t crash your server from accumulating a massive sugar cane pile before safer block breakers are available to you.",
+          "desc:8": "nomifactory.quest.db.228.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12573,7 +12574,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Snad",
+          "name:8": "nomifactory.quest.db.228.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12632,7 +12633,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "There\u0027s a great deal of interesting content within §bExtra Utilities 2§r, and although most of it is not required for progression, you should still look through what it offers and build what interests you.\n\nIn particular, the §aAngel Ring§r bauble offers creative flight, and although some of the RF generators are not particularly good, others are quite competitive with the Dynamos. And of course, you can aim for the all powerful §aRainbow Generator§r as you work towards endgame. All that and much more await, so explore away!",
+          "desc:8": "nomifactory.quest.db.229.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12643,7 +12644,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Explore Extra Utilities 2",
+          "name:8": "nomifactory.quest.db.229.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12671,7 +12672,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "If you\u0027ve tried to insert or remove a lot of items quickly, you might notice your ME network\n§eflickers offline§r briefly. This is because digitizing and re-materializing items requires energy!\n\nYour network doesn\u0027t naturally store very much energy and the §6Energy Acceptor§r only intermittently refills the network\u0027s power. To keep things stable, you will need to add some energy storage in your network using §6Energy Cells§r.\n\nJust place one anywhere in your network and it will fill up with AE energy received from the Energy Acceptor. Now, you should have enough energy in your network to prevent these power losses. Feel free to add more energy cells, or upgrade to §6Dense Energy Cells§r, if you continue to experience problems.\n\nIf you\u0027ve opted to enable channels in your AE2 configs, you will innately have some energy storage from the §3ME Controller§r, but we assume you know what you\u0027re doing at that point. §eAE2 Channels mechanics are outside the scope of the quest book, and this is the only time it will be mentioned.",
+          "desc:8": "nomifactory.quest.db.230.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12683,7 +12684,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Oops... A Blackout!",
+          "name:8": "nomifactory.quest.db.230.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12725,7 +12726,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Endervoirs are multiblocks formed by at least three Endervoir blocks. You can right-click a block with a wrench to make it output into adjacent machines.\n\nThe maximum transfer rate of an Endervoir is one bucket per second.",
+          "desc:8": "nomifactory.quest.db.231.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12736,7 +12737,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infiniter Water",
+          "name:8": "nomifactory.quest.db.231.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12780,7 +12781,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your Rocket built, fuel loaded, and destination set, it\u0027s time for the prelaunch checklist.\n\n- §eMake sure you\u0027re wearing your Space Suit§r (all four pieces) and that it has a full tank of Oxygen. If you plan to stay on the Moon a while, maybe bring a gas charging pad and Ender Tank (being filled with Oxygen) with you.\n\nTeleportation:\n\n- If you decided to go with §aDislocators§r, make sure you take two with you: one bound to the Overworld, the other ready to bind to the Moon. Also bring along a Pedestal to put the Overworld one on the Moon surface.\n\n- If you decided to go with §aTelepads§r, make sure you\u0027ve constructed a Telepad in the Overworld and that you\u0027re carrying coordinates that lead to it. Make sure to bring your Coordinate Selector, blank Paper, and materials for the second Telepad setup. Bring Dew of the Void and RF power (like a §6Solar Panel§r and a §6Capacitor Bank§r).\n\nIn either case, as soon as you land you will need to prepare the other half of the teleportation route, and chunkload it.\n\nWhen you\u0027re sure you\u0027re prepared, sit in your rocket and press §eSpace§r.\n\nLiftoff!",
+          "desc:8": "nomifactory.quest.db.232.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12791,7 +12792,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fly To The Moon",
+          "name:8": "nomifactory.quest.db.232.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12832,7 +12833,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "There\u0027s a great deal of interesting content within §bActually Additions§r, and although most of it is not strictly required for progression, you should still look through what it offers and build what interests you.\n\nIn particular, the §aDrill§r with all the upgrades is a fantastically powerful mining tool, and the §3Vertical Digger§r is a machine which can be placed to automate mining an entire vein for you.\n\n§3Phantomfaces§r, §3Auto Placers/Breakers§r, §3Lava Factories§r, and much more can be utilized at your discretion to supplement and refine your automation techniques.",
+          "desc:8": "nomifactory.quest.db.233.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12843,7 +12844,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Explore Actually Additions",
+          "name:8": "nomifactory.quest.db.233.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12871,7 +12872,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Barium§r is an element found in §6Barite§r, which may be found as §6Barite Ore§r, inside §6Quartz§r veins.\n\nBarite can also be extracted from other Quartz ores via ore processing.",
+          "desc:8": "nomifactory.quest.db.234.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12882,7 +12883,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Barium",
+          "name:8": "nomifactory.quest.db.234.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12923,7 +12924,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Melting §6Mana Dust§r in a §3Fluid Extractor§r produces §9Primal Mana§r, which is needed for smelting various alloys from §bThermal Expansion§r.",
+          "desc:8": "nomifactory.quest.db.235.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12938,7 +12939,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Primal Mana",
+          "name:8": "nomifactory.quest.db.235.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12977,7 +12978,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Transistors§r are semiconductors that can amplify or switch electrical signals and power. They\u0027re probably one of the most important inventions of the 20th century.\n\nYou\u0027re going to use them as a component for better circuits. This one is a bit pricey, requiring §2PE, Silicon Plates and Fine Tin Wire.",
+          "desc:8": "nomifactory.quest.db.236.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12988,7 +12989,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Transistor",
+          "name:8": "nomifactory.quest.db.236.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13029,7 +13030,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bApplied Energistics§r uses §aPresses§r found in chests at the heart of meteors as templates for §3Inscribers§r to make §6inscribed circuits§r.\n\nThis compass will lead you to the nearest meteor impact. Use your favorite mining tools to smash through the §6Skystone§r shell and get to the juicy center where the §6Skystone Chest§r with the plate is found.\n\nPlease note that while they\u0027re often in a big crater, the meteors might be buried underground; when the compass is spinning wildly, you\u0027re right on top of one.",
+          "desc:8": "nomifactory.quest.db.237.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13040,7 +13041,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Meteorite Hunter",
+          "name:8": "nomifactory.quest.db.237.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13083,7 +13084,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Eighth Micro Miner.\n\nThe main source of §6Chaos Shards§r.\n\nThe other mission gives negligible amounts of §6Neutronium§r and some other moderately useful things, but you\u0027re better off making Neutronium in the §3Fusion Reactor Mark 3§r§r and the other items are otherwise craftable.",
+          "desc:8": "nomifactory.quest.db.238.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13094,7 +13095,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tier Eight Micro Miner",
+          "name:8": "nomifactory.quest.db.238.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13136,7 +13137,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Chaos Shards§r are an endgame component for §bDraconic Evolution§r.\n\nThey are the base material for Chaotic Tier materials and come exclusively from Tier Eight Micro Miners.",
+          "desc:8": "nomifactory.quest.db.239.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13147,7 +13148,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chaos Shards",
+          "name:8": "nomifactory.quest.db.239.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13191,7 +13192,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Ninth Micro Miner.\n\nCombines §bStellar Creation Data§r into the §dUniverse Creation Data§r, which is a crucial component for the Tier Ten Micro Miner mission.\n\nThe alternate mission brings a decent quantity of §6Neutronium§r, but you have to bootstrap it with some Neutronium from the §3Fusion Reactor Mark 3§r anyway. It might be easier to just make all your Neutronium in the reactor, but it\u0027s up to you.",
+          "desc:8": "nomifactory.quest.db.240.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13202,7 +13203,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tier Nine Micro Miner",
+          "name:8": "nomifactory.quest.db.240.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13244,7 +13245,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy plating used exclusively for the Tier Eight Micro Miner. ",
+          "desc:8": "nomifactory.quest.db.241.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13255,7 +13256,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Crystal Matrix Heavy Plating",
+          "name:8": "nomifactory.quest.db.241.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13299,7 +13300,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The most advanced substrate available, prepared for bleeding-edge bioengineering technology.\n\n§6Wetware Circuit Boards§r are the basis of §6Wetware§r circuits, the final theme that spans tiers six through nine.",
+          "desc:8": "nomifactory.quest.db.242.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13310,7 +13311,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Wetware Substrate",
+          "name:8": "nomifactory.quest.db.242.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13355,7 +13356,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "",
+          "desc:8": "nomifactory.quest.db.243.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13366,7 +13367,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Superconducting Coil Block",
+          "name:8": "nomifactory.quest.db.243.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13409,7 +13410,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Awakened Draconium§r, §6Chaos Shards§r, and §6Stabilized Einsteinium§r can be used in a Draconic Tier fusion crafting setup to create a §6Draconic Reactor Core§r.\n\nThis is an important component in the Tier Nine and Tier Ten Micro Miners, as well as some Endgame items.",
+          "desc:8": "nomifactory.quest.db.244.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13420,7 +13421,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconic Reactor Core",
+          "name:8": "nomifactory.quest.db.244.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13461,7 +13462,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy: avoid dropping it on your foot.\n\nThis special plating is used for two things-- §6Tier Two Micro Miners§r and the §3Space Station Assembler§r.",
+          "desc:8": "nomifactory.quest.db.245.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13472,7 +13473,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Titanium Heavy Plating",
+          "name:8": "nomifactory.quest.db.245.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13513,7 +13514,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy Plating for Micro Miners made from §6Tungsten Carbide§r.\n\nYou §2no longer need high tier Compressors to make these.",
+          "desc:8": "nomifactory.quest.db.246.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13524,7 +13525,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tungsten Carbide Heavy Plating",
+          "name:8": "nomifactory.quest.db.246.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13602,7 +13603,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This quest, and the ones that follow it, are §cNOT REQUIRED§r for progression.\n\nOnly do them if you want to be able to explore the various planets offered by Advanced Rocketry and potentially build bases there, or in space.\n\nRefer to the various high quality tutorials on AR available on YouTube for specifics.",
+          "desc:8": "nomifactory.quest.db.248.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13613,7 +13614,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Space Station Assembler",
+          "name:8": "nomifactory.quest.db.248.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13667,7 +13668,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Warp Core§r is a multiblock structure that you can build on the space station. Use the Holo-Projector for a building guide.\n\nWhile it\u0027s not required for the progression, you can spend some resources to travel to distant planets, either to explore them or just to change the background of your space station.\n\nThe Input Hatch must be filled with §6Dilithium§r.",
+          "desc:8": "nomifactory.quest.db.249.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13678,7 +13679,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Warp Core",
+          "name:8": "nomifactory.quest.db.249.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13756,7 +13757,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Dilithium Crystals§r are used to power Warp Cores, and are also a key component in several Micro Miner missions.\n\nThey are made by crystallizing §6Dilithium Dust§r with §9Deuterium§r in an §3Autoclave§r.",
+          "desc:8": "nomifactory.quest.db.250.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13767,7 +13768,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dilithium",
+          "name:8": "nomifactory.quest.db.250.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -13811,7 +13812,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Fourth Micro Miner.\n\nAll of the Tier Four missions require §68 Quantum Flux§r and a stack of §6Petrotheum Dust§r.\n\nThis miner brings §cPlatinum Group Sludge-bearing ores, sources of §6Osmium§r and §6Iridium§r, via a mission requiring §6Wither Realm Data§r.\n\nA §6Composition Sensor§r instead directs the miner to obtain §6Dense Oilsands Ore§r, equivalent to §264§r stacks of §6Oilsands Ore§r.\n\nWhen equipped with a §6Gemstone Sensor§r:\n§6* Dense Redstone Ore\n* Dense Emerald Ore\n* Dense Diamond Ore\n* Dense Lapis Ore\n* Dense Coal Ore§r",
+          "desc:8": "nomifactory.quest.db.251.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13822,7 +13823,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Four Micro Miner",
+          "name:8": "nomifactory.quest.db.251.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13863,7 +13864,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Fifth Micro Miner.\n\nThe only source of §6Naquadah§r, in the form of §cSnowchestite Ore§r. Along with it, § §2Kaemanite Ore§r (for §6Trinium§r).\n\nWhen provided with §6Stabilized Uranium§r, brings:\n§6§2* Uraninite Ore§6\n* Molybdenite Ore\n* Bastnasite Ore\n* Sphalerite Ore\n* Palladium Ore\n* Beryllium Ore\n* Monazite Ore\n§2* Osmiridium 80/20 Ore\n* Realgar Ore§6§r\n§6* Enderpearl Blocks\n* Boron Dust§r",
+          "desc:8": "nomifactory.quest.db.252.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13874,7 +13875,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Five Micro Miner",
+          "name:8": "nomifactory.quest.db.252.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13916,7 +13917,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Iridium§r is an advanced material used for Micro Miner plating, §6§rand for alloying with §6Osmium§r into §6Osmiridium§r.\n\n§6Iridium Ore§r is available renewably from the Tier Four and Tier Six micro miners.",
+          "desc:8": "nomifactory.quest.db.253.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13927,7 +13928,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Iridium",
+          "name:8": "nomifactory.quest.db.253.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -13968,7 +13969,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Sixth Micro Miner.\n\nThe first decent source of §6Dragon Eggs§r and §6Stabilized Einsteinium§r.\n\nIs also useful for:\n§6§2* Uraninite Ore\n§c* Sheldonite Ore\n* Iridosmine 80/20 Ore",
+          "desc:8": "nomifactory.quest.db.254.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13979,7 +13980,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Six Micro Miner",
+          "name:8": "nomifactory.quest.db.254.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14020,7 +14021,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An alloy of equal parts §6Tungsten§r and §6Carbon Dust§r.\n\n§6Tungsten Carbide§r is a very dense, sturdy, and heat-resistant material useful for a variety of applications.",
+          "desc:8": "nomifactory.quest.db.255.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14031,7 +14032,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tungsten Carbide",
+          "name:8": "nomifactory.quest.db.255.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14074,7 +14075,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Seventh Micro Miner.\n\nThe source of §6Dragon Hearts§r and the valuable §6Lair of The Chaos Guardian Data§r.\n\nAs a bonus, brings §6Dragon Eggs, Dragon\u0027s Breath, Ender Dragon Scales§r, §2Americium Blocks§r and a plenty of different precious metals and gems.",
+          "desc:8": "nomifactory.quest.db.256.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14085,7 +14086,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Seven Micro Miner",
+          "name:8": "nomifactory.quest.db.256.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14126,7 +14127,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy plating used exclusively for the Tier Seven Micro Miner. ",
+          "desc:8": "nomifactory.quest.db.257.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14137,7 +14138,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Draconium Heavy Plating",
+          "name:8": "nomifactory.quest.db.257.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14178,7 +14179,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Awakened Draconium§r is a powerful material used for crafting high-grade components, items, and machines from §bDraconic Evolution§r.\n\nFive §6§6Draconium Blocks§r can be processed in a Wyvern Tier fusion crafting setup to create an equal output of five §6Awakened Draconium Blocks§r. At §e24 Billion RF per craft§r, you better have a handle on your power infrastructure.",
+          "desc:8": "nomifactory.quest.db.258.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14189,7 +14190,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Awakened Draconium",
+          "name:8": "nomifactory.quest.db.258.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14230,7 +14231,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your first MV hull is as good of a place as any to consider yourself graduated from LV.\n\nYou might notice that these hulls can be made more cheaply in an §3Assembling Machine§r, but you don\u0027t have that weird fluid. Don\u0027t worry, you\u0027ll be able to make that soon.\n\n§2Overclocking mechanics have changed in CEu. All overclocks now multiply the speed by 2.0x (instead of the 2.0/2.8 split in CE). This means that to save energy, you should build more low-tier machines over overclocking a high-tier machine, especially for passive processes.\nAdditionally, ULV recipes will not overclock to LV. A ≤8 EU/t recipe won\u0027t overclock at all in an LV machine, will only overclock once in an MV machine, etc.",
+          "desc:8": "nomifactory.quest.db.259.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14241,7 +14242,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2MV Machine Hulls",
+          "name:8": "nomifactory.quest.db.259.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14282,7 +14283,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Electrolyzers§r use electricity to separate items into their more basic components.\n\nFor example, you can break down Water into §9Hydrogen Gas§r and §9Oxygen Gas§r, or break down §6Clay Dust§r into §6Sodium Dust§r, §6Silicon Dust§r, §6Lithium Dust§r, and §6Aluminium Dust§r.",
+          "desc:8": "nomifactory.quest.db.260.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14293,7 +14294,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Electrolyzer",
+          "name:8": "nomifactory.quest.db.260.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14336,7 +14337,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Having unlocked §6Signalum§r and §6Lumium§r, at long last you can now make §aSignalum Upgrade Kits§r!\n\nProvides more augment slots to machines and dynamos.\n\nDynamos operate at §a500% of base power and fuel burn rate§r.\n\nPortable Tanks hold §a800 buckets§r.\n\nMachines operate at §a400% of base speed§r.",
+          "desc:8": "nomifactory.quest.db.261.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14347,7 +14348,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Signalum Upgrade Kit",
+          "name:8": "nomifactory.quest.db.261.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14389,7 +14390,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An advanced ingredient used for the §aUltimate Extended Crafting Table§r and other late-game recipes. ",
+          "desc:8": "nomifactory.quest.db.262.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14400,7 +14401,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Conflux Catalyst",
+          "name:8": "nomifactory.quest.db.262.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14441,7 +14442,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Indium§r is a rare material requiring specialized bulk ore processing to acquire. It is useful for making §6Indium Gallium Phosphide§r (InGaP).\n\nYou will need to purify (with a §3Washer§r or §3Chemical Bath§r) §6Galena§r and §6Sphalerite§r to get §6Crushed Purified§r dusts. These need to be placed together in a §3Chemical Reactor§r along with §9Sulfuric Acid§r, which will result in §9Indium Concentrate§r.\n\nThis in turn needs to be reacted with §6Aluminium§r in another Chemical Reactor, to create §2Small Piles of Indium Dust, Aluminium Sulfite and §9Lead-Zinc Solution§r. The latter two can be centrifuged into various useful materials, and the Indium piles can be combined into full dusts.\n\n§2Indium can also be obtained from the Naquadah processing chain in LuV.\n",
+          "desc:8": "nomifactory.quest.db.263.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14452,7 +14453,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Indium",
+          "name:8": "nomifactory.quest.db.263.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14495,7 +14496,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your new §6§6§ §6Epoxy Circuit Boards§r, §6QBit CPUs§r, and some standard components, you can make the final type of Tier Four Circuit: the §6Quantum Circuit§r.\n\nAs the best form of Tier Four circuit, these should be automated and stockpiled. The variant recipe requiring §6Advanced System-on-Chip§r won\u0027t be available until ZPM.",
+          "desc:8": "nomifactory.quest.db.264.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14506,7 +14507,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third And Final Tier Four Circuits",
+          "name:8": "nomifactory.quest.db.264.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14548,7 +14549,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6QBit CPUs§r are an advanced Circuit Wafer crucial for §6Quantum Circuits§r.\n\nThere are two methods of creating them:\n\nThe simpler recipe uses two §6Quantum Eyes§r and two ingots worth of molten §9Gallium Arsenide§r to enhance a §6NanoCPU Wafer§r. This recipe is slow and requires substantially more §9Radon§r per craft.\n\nThe other route instead uses §6Indium Gallium Phosphide§r and a tiny amount of Radon. This skips the slow-crafting Quantum Eyes, using far less Radon in the process, but requires the infrastructure in place for obtaining §6Indium§r.\n\nThe second route is overall better, and you will need Indium processing to complete the pack so might as well do it.",
+          "desc:8": "nomifactory.quest.db.265.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14559,7 +14560,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "QBit Processing Unit",
+          "name:8": "nomifactory.quest.db.265.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -14600,7 +14601,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Item Pipes are back in GTCEu! They will transport items instantly through them.\n\nTheir advantage over EnderIO Item Conduits is their far higher throughput. An unupgraded EIO Item Conduit transports 8 items per second, and up to 128 when upgraded. In comparison, small low-tier Item Pipes can transfer 64 items per second, and those made from later materials can transfer multiple stacks per second.\n\nThey don\u0027t auto-extract by themselves, so you have to use Conveyor covers etc. with them.\n\nThe priority mechanics are more complicated, so skip ahead if you are not interested:\nA Destination will have a Routing Value calculated, which is the sum of all Routing Values of the individual Pipes to that Destination. Whichever Destination has the lowest Routing Value will be the one selected for Insertion.\nRestrictive Pipes typically have the lowest Priority for insertion due to their higher Routing Value.",
+          "desc:8": "nomifactory.quest.db.266.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14611,7 +14612,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2GT Item Pipes",
+          "name:8": "nomifactory.quest.db.266.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -14651,7 +14652,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Radon§r will be needed in large quantities.\n\nFor now, you\u0027ll need to obtain it from Tier Two Micro Miner missions, in the form of §6Radium Salt§r. Electrolyze it for Radon and §6Rock Salt§r. §2You can also get it from distilling liquid Ender Air.§r\n\nLater it will be possible to make Radon using a §bGregTech§r §3Fusion Reactor§r.",
+          "desc:8": "nomifactory.quest.db.267.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14666,7 +14667,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Radon",
+          "name:8": "nomifactory.quest.db.267.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14704,7 +14705,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Nothing new here, just use more standard circuit stuff and you can upgrade several §6Quantum Circuits§r into a §6Quantum Processor§r.",
+          "desc:8": "nomifactory.quest.db.268.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14715,7 +14716,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Third Tier Five Circuit",
+          "name:8": "nomifactory.quest.db.268.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14756,7 +14757,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Nothing special about this tier either.",
+          "desc:8": "nomifactory.quest.db.269.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14767,7 +14768,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Six Circuits",
+          "name:8": "nomifactory.quest.db.269.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14808,7 +14809,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Macerators§r are useful for grinding things down, replacing the §aMortars§r you\u0027ve needed until now. This is an important machine you will be using for many things in the future.\n\nOne useful application for a Macerator in the near future is grinding down §6Clay§r or §6Terracotta§r into §6Clay Dust§f.\n\nBesides not having limited durability, a key advantage of Macerators over Mortars is the chance to get additional materials when grinding things down. These are called §ebyproducts§r, and HV or better Macerators have three slots instead of one so byproducts can appear.\n\nWhen reading Macerator recipes in §bJEI§r, you can tell which outputs are byproducts by seeing if §ethe tooltip tells you it has a chance to appear§r: guaranteed outputs do not list a chance. §2The chance increases by a certain amount for each tier of machine you have above the tier of recipe. This chance is also listed in the tooltip.§r\n\n§2Macerators can now also recycle your old Machines for some extra materials.§r\n\nFinally, a Macerator will only start processing if there is room for all possible outputs. Make sure you empty them so they can keep working.",
+          "desc:8": "nomifactory.quest.db.270.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14819,7 +14820,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Macerator",
+          "name:8": "nomifactory.quest.db.270.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14861,7 +14862,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Reactor Stabilizer§r is a component needed for the Tier Nine and Tier Ten Micro Miners, as well as a component in a few Endgame recipes.\n\nThey are made in a Chaotic Tier fusion crafting setup, requiring a whopping §e56 Billion total RF each§r. You\u0027re gonna need some serious power generation and crafting infrastructure to make everything for these.",
+          "desc:8": "nomifactory.quest.db.271.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14872,7 +14873,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reactor Stabilizer",
+          "name:8": "nomifactory.quest.db.271.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14913,7 +14914,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The first tier of §6capacitors§r. These (or stronger versions) are required to make §bEnderIO§r machines run. They\u0027re also used as components in a variety of recipes.\n\nHigher tier capacitors will significantly increase the speed at which these machines operate, among other machine-specific properties.",
+          "desc:8": "nomifactory.quest.db.272.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14924,7 +14925,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basic Capacitors",
+          "name:8": "nomifactory.quest.db.272.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14965,7 +14966,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mixes two dusts to make a third.\n\nFor now, you\u0027ll be using it to make §6Glowstone Dust§r.\n\nGlowstone Dust is made from §6Tricalcium Phosphate Dust§r and §6Gold Dust§r, or you could eventually gather it from the Nether.",
+          "desc:8": "nomifactory.quest.db.273.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14976,7 +14977,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Mixer",
+          "name:8": "nomifactory.quest.db.273.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15017,7 +15018,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Dragon Hearts§r are needed for both §6Awakened Draconium§r and §6The Ultimate Material§r.",
+          "desc:8": "nomifactory.quest.db.274.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15028,7 +15029,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dragon Hearts",
+          "name:8": "nomifactory.quest.db.274.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15070,7 +15071,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Luminessence§r is used in a number of things, but right now, it will be a component in your §aExtended Crafting Tables§r.",
+          "desc:8": "nomifactory.quest.db.275.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15081,7 +15082,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Luminessence",
+          "name:8": "nomifactory.quest.db.275.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15123,7 +15124,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Phosphoric Acid§r is a key component of §6Luminessence§r, which will be used extensively for such things as §6Nether Stars§r, §6Lumium Blend§r, and §bExtended Crafting§r components.\n\nIt can be made using several equally viable recipes:\n\n§6Phosphorus§r, §9Oxygen§r, and §9Water§r can be chemically reacted to produce §9Phosphoric Acid§r.\n\nAlternatively, you can combine §6Phosphorus Pentoxide§r and Water for a much faster reaction.\n\nOtherwise, you can react §6Apatite Dust§r, §9Sulfuric Acid§r, and Water to get Phosphoric Acid, §9Hydrochloric Acid§r, and a whole bunch of §6Gypsum Dust§r.",
+          "desc:8": "nomifactory.quest.db.276.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15138,7 +15139,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phosphoric Acid",
+          "name:8": "nomifactory.quest.db.276.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -15211,7 +15212,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You can combine various items with a §6Blank Data Model§r for a completed §6Data Model§r that you can run inside the §3Simulation Chamber§r.",
+          "desc:8": "nomifactory.quest.db.278.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15222,7 +15223,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Simulated Mobs",
+          "name:8": "nomifactory.quest.db.278.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15263,7 +15264,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "\"§6Dragon Eggs§r?\" You might ask. Yep.\n\nThe final circuit theme, Wetware, will require a lot of them.\n\nTier Six Micro Miners can get some eggs (enough for this quest, as it happens), but Tier Seven miners are a better long-term solution for building up your supply, as they also give §6Dragon Hearts§r.\n\nLater, you\u0027ll also get substantial quantities from Tier Eight Micro Miners, while you are accumulating §6Chaos Shards§r.\n\n",
+          "desc:8": "nomifactory.quest.db.279.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15274,7 +15275,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Breaking Some Eggs",
+          "name:8": "nomifactory.quest.db.279.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15390,7 +15391,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Man, that\u0027s a LOT of quests linked to this one.\n\n§dOmnium§r, as the name suggests, is an incredible material composed of all elements and alloys you\u0027ve encountered so far.\n\nYou\u0027ve got all this automated, right?",
+          "desc:8": "nomifactory.quest.db.280.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15401,7 +15402,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mote of Omnium",
+          "name:8": "nomifactory.quest.db.280.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15479,7 +15480,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Fluix is initially made via in-world crafting, by dropping §6Redstone Dust§r, §6Nether Quartz§r, and a §6Charged Certus Quartz Crystal§r in the same block of §9Water§r. You\u0027ll see some sparks then the items will merge into a §6Fluix Crystal§r. Be sure to turn off any nearby item magnets/collectors or they might interrupt this crafting process.\n\nThe §3Energy Acceptor§r converts RF power into AE power that Applied Energistics uses, in a 2 RF to 1 AE ratio. This power will be transmitted through adjacent full-block ME Network devices, as well as along all connected §6ME Cables§r, §6ME Conduits§r, and §6Quartz Fiber§r. \n\nQuartz Fiber are §emicroparts§r you can put between an ME Cable and any ME Network block or another ME Cable. This will allow transmission of AE power but not data, which is useful for having data-isolated ME Networks all sharing the same power source.",
+          "desc:8": "nomifactory.quest.db.282.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15490,7 +15491,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Energy Acceptor",
+          "name:8": "nomifactory.quest.db.282.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -15540,7 +15541,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §6§2Rhodium Plated Lumium-Palladium§r-based machine hulls, Assembling Machine built, and §6Quantum Processor Mainframes§r squared away, you can finally get on the path to making a Ludicrous Voltage §3Circuit Assembling Machine§r.\n\nThis tier of Assembling Machine unlocks §6Crystal Circuits§r, as well as handling crafting recipes up to 32768 EU/t. It can also optionally overclock recipes that consume up to 8192 EU/t for improved speed at the cost of relatively more power.",
+          "desc:8": "nomifactory.quest.db.283.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15551,7 +15552,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LuV Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.283.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15629,7 +15630,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Vanadium-Gallium§r is an alloy made in the §3Electric Blast Furnace§r. It is a Ludicrous Voltage (LuV) cable material needed for certain recipes.\n\n§6",
+          "desc:8": "nomifactory.quest.db.285.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15640,7 +15641,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vanadium Gallium",
+          "name:8": "nomifactory.quest.db.285.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15682,7 +15683,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Assembly Line§r is a large multiblock structure that crafts complex materials, similar to an §3Assembling Machine§r. These will be crucial going forward for making a variety of components and machinery.\n\nMake sure your power generation and circuit production are up to the challenge. §2None of the Assembly Line recipes require programmed circuits anymore.§r\n\nNotice that all numbers of required items are §emultiples of 11.§r This is to make an Assembly Line that\u0027s 11 units long, allowing for 10 inputs and one output. This is a large enough Assembly Line to make a §aFusion Reactor Controller Mk1§r, but you\u0027ll need to expand to more inputs for later projects.\n\n§2You will also need a Maintenance Hatch.\n\n§aFluid Input Hatches§r can replace any of the §6Steel Casings§r along the bottom outside except for the Casings touching the §aOutput Bus§r. For the most part, ULV ones work fine, but a few recipes will need an LV one.\n\nThe §aEnergy Input Hatches§r along the top can be replaced by Steel Casings: you only need the one Energy Input Hatch (although you can add more if you want).\n\nThe §aInput Buses§r along the bottom §emust be ULV tier§r, nothing else. Make sure to spin them all so the hole is on the bottom.",
+          "desc:8": "nomifactory.quest.db.286.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15693,7 +15694,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Assembly Line",
+          "name:8": "nomifactory.quest.db.286.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15783,7 +15784,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Time to get fusing!\n\nThe §3Fusion Reactor§r is a multiblock that uses enormous amounts of energy to fuse fluids into new elements. This one is less flexible than the previous GregTech multiblocks, as you can only put hatches where the preview shows. §6Sneak-right click§r the controller to enable the in-world preview.\n\nThe §bJEI§r preview shows §e§eall valid hatch locations§r, but you don\u0027t actually need that many fluid hatches. You can replace any of the hatch positions in the structure with §2Fusion Glass or Fusion Machine Casings§r as long as you have at least §atwo Fluid Input Hatches§r and §aone Fluid Output Hatch§r. It\u0027s possible to use input/output hatches in every valid location, if you prefer.\n\nBecause of this, the quest only asks for §248 Fusion Machine Casings, 31 Fusion Glass§r. If you want to use the minimum number of fluid hatches, you\u0027ll need to craft an additional §231 Fusion Machine Casings§r.\n\nEach §aEnergy Input Hatch§r increases the reactor\u0027s power buffer. §aAll 16 Energy Input Hatches§r are required to be able to process all Mark 1 recipes and give a power buffer of §e160M EU§r.\n\nIn addition to the recipe power drain, Fusion Reactors have a §eheat§r mechanic related to the recipe\u0027s §e\"Eu to Start\"§r. This amount of power is drained from the reactor\u0027s buffer before starting the recipe to heat up the reactor to the necessary temperature, and is independent of the recipe\u0027s EU/t cost. As such, this determines the minimum tier of reactor you need for a recipe.\n\nIf the reactor stops processing, it will §erapidly lose heat§r, even if you pause it with a soft hammer. On the other hand, if the reactor is already at the required temperature for a recipe, §eno additional power§r is required to heat up the reactor! This is true even if you switch between different recipes. This mechanic incentivizes continuous use of the reactor.\n\nIf you switch to a recipe that requires more heat, §eonly the difference§r in heat values is consumed as EU to reach the target heat (up to a maximum heat equal to the reactor\u0027s current buffer).\n\nFusion Reactors §2now overclock§r, but they gate the next tier of materials, so you will eventually want to make more than one.",
+          "desc:8": "nomifactory.quest.db.287.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15794,7 +15795,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fusion Reactor MK1",
+          "name:8": "nomifactory.quest.db.287.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15873,7 +15874,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need at least §6Naquadah Coil Blocks§r in your blast furnace to smelt §6Draconium§r, as well as a healthy supply of §cHigh-Octane Gasoline§r to reach the immense heat it takes to liquefy.\n\nDraconium gets so hot that it requires the potent coolant §9Gelid Cryotheum§r to aid your §3Vacuum Freezer§r in turning it into usable ingots.\n\nThere are several ways to make Draconium: dust can be smelted into ingots, but you can also turn §6Ender Dragon Scales§r, which contain Draconium, directly into ingots. It uses a lot of§2 combustion fuel§r, but is the most efficient way to craft Draconium.\n\nYou\u0027ve been stockpiling fuel, right?",
+          "desc:8": "nomifactory.quest.db.288.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15884,7 +15885,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Draconium Ingots",
+          "name:8": "nomifactory.quest.db.288.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15925,7 +15926,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "By baking a §2Raw Crystal Chip §rand §6Emerald Plates§r with §9Helium§r in an §3Electric Blast Furnace§r, you can create an §6Engraved Crystal Chip§r.\n\nThis is a material needed for §6Crystal Circuits§r.",
+          "desc:8": "nomifactory.quest.db.289.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15936,7 +15937,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Engraved Crystal Chip",
+          "name:8": "nomifactory.quest.db.289.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16014,7 +16015,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Crystal CPUs§r are the cores of §6Crystal Circuits§r.\n\nYou\u0027ll need an §2LuV Precision Laser Engraver§r to craft this.",
+          "desc:8": "nomifactory.quest.db.291.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16025,7 +16026,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Crystal Processing Unit",
+          "name:8": "nomifactory.quest.db.291.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16066,7 +16067,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With some now-standard components you can upgrade a few §6Crystal Circuits§r into a §6Crystal Processor§r.",
+          "desc:8": "nomifactory.quest.db.292.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16077,7 +16078,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third Tier Six Circuits",
+          "name:8": "nomifactory.quest.db.292.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16119,7 +16120,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The culmination of so much effort.\n\n§6Chaotic Cores§r are the ultimate tier of §bDraconic Evolution§r core, used for the most powerful and advanced items.",
+          "desc:8": "nomifactory.quest.db.293.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16130,7 +16131,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chaotic Cores",
+          "name:8": "nomifactory.quest.db.293.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16171,7 +16172,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Restonia Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.294.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16182,7 +16183,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Restonia Gear",
+          "name:8": "nomifactory.quest.db.294.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16225,7 +16226,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bDraconic Evolution§r features §eFusion Crafting§r, which requires a §6Fusion Crafting Core§r and up to ten injectors of the appropriate tier.\n\nYou\u0027ll need eight §6Basic Fusion Crafting Injectors§r to upgrade any additional injectors you make to Wyvern Tier.\n\nYes, that means you should plan to make more than eight. If you really want to plan ahead, make thirty-four of these.",
+          "desc:8": "nomifactory.quest.db.295.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16236,7 +16237,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basic Fusion Injectors",
+          "name:8": "nomifactory.quest.db.295.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16283,7 +16284,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Obtaining §6Grains of Infinity§r will require you to mine all the way down to Bedrock level.\n\nUse Flint and Steel to light a fire (or many fires) and then wait for it to go out. There\u0027s a 50% chance of Grains Of Infinity to appear for every fire that burns out on its own.\n\nBut who wants to do that forever? There will be better ways before too long, don\u0027t worry.",
+          "desc:8": "nomifactory.quest.db.296.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16294,7 +16295,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Grains Of Infinity",
+          "name:8": "nomifactory.quest.db.296.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16342,7 +16343,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mixing §6Titanium§r with §6Mana Dust§r creates §6Mana Infused Metal Dust§r. This can be smelted into ingots in an §3Electric Blast Furnace§r equipped with §6Kanthal Coils§r or better.\n\nMana Infused Metal is the basis of §bThermal Expansion§r device casings, and is used for many advanced §aAugments§r.",
+          "desc:8": "nomifactory.quest.db.297.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16353,7 +16354,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mana Infused Ingot",
+          "name:8": "nomifactory.quest.db.297.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16403,7 +16404,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "ASSEMBLE!\n\n§6Mana Dust§r is an important material. It is needed for a variety of materials related to §bThermal Expansion§r.",
+          "desc:8": "nomifactory.quest.db.298.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16414,7 +16415,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mana Dust",
+          "name:8": "nomifactory.quest.db.298.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16455,7 +16456,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This casing is the structure for §bThermal Expansion§r\u0027s devices, which are simpler machines.\n\n",
+          "desc:8": "nomifactory.quest.db.299.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16466,7 +16467,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Thermal Device Casing",
+          "name:8": "nomifactory.quest.db.299.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16507,7 +16508,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Thermal Device Casings§r are upgradable to a §6Machine Frame§r with some §6Stainless Steel Plates§r.\n\nThese frames form the basis of §bThermal Expansion§r\u0027s more advanced machinery.",
+          "desc:8": "nomifactory.quest.db.300.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16518,7 +16519,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Thermal Machine Frame",
+          "name:8": "nomifactory.quest.db.300.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16559,7 +16560,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Redstone§r, a §6Snowball§r, and §6Blizz Powder§r creates §6Cryotheum Dust§r, a mixture imbued with potent elemental frost.",
+          "desc:8": "nomifactory.quest.db.301.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16570,7 +16571,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Cryotheum",
+          "name:8": "nomifactory.quest.db.301.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16611,7 +16612,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Redstone§r, §6Saltpeter§r, and §6Blitz Powder§r creates §6Aerotheum Dust§r, a mixture imbued with potent elemental air.",
+          "desc:8": "nomifactory.quest.db.302.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16622,7 +16623,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Aerotheum",
+          "name:8": "nomifactory.quest.db.302.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16663,7 +16664,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Redstone§r, §6Obsidian Dust§r, and §6Basalz Powder§r creates §6Petrotheum Dust§r, a mixture imbued with potent elemental earth.",
+          "desc:8": "nomifactory.quest.db.303.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16674,7 +16675,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Petrotheum",
+          "name:8": "nomifactory.quest.db.303.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16715,7 +16716,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Redstone§r, §6Sulfur§r, and §6Blaze Powder§r creates §6Pyrotheum Dust§r, a mixture imbued with potent elemental flame.",
+          "desc:8": "nomifactory.quest.db.304.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16726,7 +16727,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pyrotheum",
+          "name:8": "nomifactory.quest.db.304.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16767,7 +16768,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Bits of a §6Blaze Rod§r. Using a §3Macerator§r doubles your yield.",
+          "desc:8": "nomifactory.quest.db.305.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16778,7 +16779,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Blaze Powder",
+          "name:8": "nomifactory.quest.db.305.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -16819,7 +16820,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Bits of a §6Basalz Rod§r. Using a §3Macerator§r doubles your yield.",
+          "desc:8": "nomifactory.quest.db.306.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16830,7 +16831,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basalz Powder",
+          "name:8": "nomifactory.quest.db.306.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -16871,7 +16872,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Bits of a §6Blitz Rod§r. Using a §3Macerator§r doubles your yield.",
+          "desc:8": "nomifactory.quest.db.307.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16882,7 +16883,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Blitz Powder",
+          "name:8": "nomifactory.quest.db.307.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -16923,7 +16924,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Bits of a §6Blizz Rod§r. Using a §3Macerator§r doubles your yield.",
+          "desc:8": "nomifactory.quest.db.308.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16934,7 +16935,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Blizz Powder",
+          "name:8": "nomifactory.quest.db.308.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -16976,7 +16977,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Once you gain access to §9Fluoroantimonic Acid§r, you can make this more efficiently with respect to §9Fluorine§r.",
+          "desc:8": "nomifactory.quest.db.309.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16991,7 +16992,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Elemental Reduction Fluid",
+          "name:8": "nomifactory.quest.db.309.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17029,7 +17030,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Praise the sun. \\[T]/\n\nThis machine uses various tiers of §6Phyto-Gro§r and §9Water§r to grow plants.\n\nIt can be customized with various §aAugments§r.",
+          "desc:8": "nomifactory.quest.db.310.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17054,7 +17055,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phytogenic Insolator",
+          "name:8": "nomifactory.quest.db.310.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17109,7 +17110,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungstensteel§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
+          "desc:8": "nomifactory.quest.db.311.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17120,7 +17121,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tungstensteel Coil Blocks",
+          "name:8": "nomifactory.quest.db.311.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17161,7 +17162,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6HSS-G§r is an alloy of §6Tungstensteel§r, §6Chrome§r, §6Molybdenum§r, and §6Vanadium§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.\n",
+          "desc:8": "nomifactory.quest.db.312.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17172,7 +17173,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "High Speed Steel Type G",
+          "name:8": "nomifactory.quest.db.312.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17214,7 +17215,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6HSS-G§r is the fifth coil material available, increasing your EBF\u0027s operating temperature to 5400K so it can process more advanced materials, such as §6Naquadah§r.",
+          "desc:8": "nomifactory.quest.db.313.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17225,7 +17226,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "HSS-G Coil Block",
+          "name:8": "nomifactory.quest.db.313.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17266,7 +17267,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy plating made from §6Iridium§r for Tier Five and Tier Eight Micro Miners.",
+          "desc:8": "nomifactory.quest.db.314.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17277,7 +17278,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Iridium Heavy Plating",
+          "name:8": "nomifactory.quest.db.314.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -17319,7 +17320,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A heavy plating material required for the next two tiers of Micro Miners.",
+          "desc:8": "nomifactory.quest.db.315.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17330,7 +17331,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Signalum Heavy Plating",
+          "name:8": "nomifactory.quest.db.315.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17371,7 +17372,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy plating made from §6Enderium§r used for the Tier Six Micro Miner.",
+          "desc:8": "nomifactory.quest.db.316.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17382,7 +17383,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Enderium Heavy Plating",
+          "name:8": "nomifactory.quest.db.316.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17424,7 +17425,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A complex plating material used exclusively for the Tier Nine Micro Miner.",
+          "desc:8": "nomifactory.quest.db.317.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17435,7 +17436,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Quantum Fluxed Eternium Heavy Plating",
+          "name:8": "nomifactory.quest.db.317.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17476,7 +17477,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Naphtha route for Epoxy has been removed. You can only make Epoxy using the BPA route.\n\n§rBPA can be produced using petrochemistry distillation products, or via distilling §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r into useful components. Alternatively, you can get §9Phenol§r from §6Coal§r pyrolysis. §9Fermented Biomass§r is also useful to distill as it provides many useful products.\n\n§2Using the Large Chemical Reactor, you can skip two steps in the Epoxy production line.",
+          "desc:8": "nomifactory.quest.db.318.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17491,7 +17492,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Epoxy Production",
+          "name:8": "nomifactory.quest.db.318.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17519,7 +17520,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need large quantities of §6Canola§f (for §6Canola Oil§f in a §bCanola Press§f) and §6Sugarcane§f (for §6Ethanol§f).\n\nOf course, other crops can work as well, if you want to mix things up.",
+          "desc:8": "nomifactory.quest.db.319.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17530,7 +17531,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Farming",
+          "name:8": "nomifactory.quest.db.319.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17577,7 +17578,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Void Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.320.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17588,7 +17589,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Void Gear",
+          "name:8": "nomifactory.quest.db.320.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17629,7 +17630,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Palis Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.321.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17640,7 +17641,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Palis Gear",
+          "name:8": "nomifactory.quest.db.321.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17681,7 +17682,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Emeradic Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.322.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17692,7 +17693,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Emeradic Gear",
+          "name:8": "nomifactory.quest.db.322.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17734,7 +17735,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An otherworldly material exclusive to Microverses, §6Naquadah§r is an important material in the late game.\n\nFor its processing, you will need §9Aerotheum§r and §9Petrotheum§r to separate the §6Naquadah Oxide§r, and §9Neocryolite§r as the electrolyte to get the §6Naquadah§r out.\n\nIt can be alloyed and enriched to various forms, and is the eventual source of §6Neutronium§r in a §3Mark Three Fusion Reactor§r.",
+          "desc:8": "nomifactory.quest.db.323.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17745,7 +17746,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Ingots",
+          "name:8": "nomifactory.quest.db.323.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17786,7 +17787,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Naquadah§r is the sixth coil material available, increasing your EBF\u0027s operating temperature to 7200K so it can process more advanced materials.\n\n§2You cannot skip a coil material anymore.",
+          "desc:8": "nomifactory.quest.db.324.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17797,7 +17798,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Coil Blocks",
+          "name:8": "nomifactory.quest.db.324.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17838,7 +17839,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With a §3Fusion Reactor§r, you can make Europium!\n\nThis element is needed for making things in §bDraconic Evolution§r§r, as well as the §6Fusion Reactor Computer Mark 2§r, §2Crystal Chip growing§r, and §6Wetware Supercomputers§r§r.\n\nYou make it by fusing molten §9§9Neodymium§r§r and §9Hydrogen§r.",
+          "desc:8": "nomifactory.quest.db.325.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17849,7 +17850,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Europium Ingot",
+          "name:8": "nomifactory.quest.db.325.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17928,7 +17929,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Just ignore the protesters outside your base.\n\nEach craft in an §3LuV Chemical Reactor§r takes five minutes, so it\u0027s probably a good idea to have more than one machine running this recipe. At least you get §2128 from a single craft.\n",
+          "desc:8": "nomifactory.quest.db.327.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17939,7 +17940,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Stem Cells",
+          "name:8": "nomifactory.quest.db.327.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17980,7 +17981,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Boron§r is currently obtainable by doing ore processing on §6Lepidolite Ore§r and §6Salt Ore§r (via §6Borax§r).",
+          "desc:8": "nomifactory.quest.db.328.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17991,7 +17992,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Boron",
+          "name:8": "nomifactory.quest.db.328.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18032,7 +18033,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Basic Fusion Crafting Injectors§r can be upgraded to Wyvern Tier via fusion crafting.\n\nTechnically you only need six of these to start making the next tier of injectors, but some recipes will need more than that. Plan on making at least twenty-six of these.",
+          "desc:8": "nomifactory.quest.db.329.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18043,7 +18044,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Wyvern Fusion Injectors",
+          "name:8": "nomifactory.quest.db.329.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18084,7 +18085,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Draconic Fusion Crafting Injectors§r are the penultimate tier of injectors for fusion crafting.\n\nYou\u0027ll need a fusion crafting setup with ten of these for the next tier of injector, and the next tier you\u0027ll also need ten injectors, so consider making 20 of these.",
+          "desc:8": "nomifactory.quest.db.330.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18095,7 +18096,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconic Fusion Injectors",
+          "name:8": "nomifactory.quest.db.330.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18137,7 +18138,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The highest tier of fusion crafting injectors. You will need at least ten of these to reach the §dCreative Portable Tank§r.\n\nEach injector requires four ingots of §6Neutronium§r and four §6Chaos Shards§r, as well as two §6Crystal Matrix§r blocks.\n\nHope you\u0027ve got those Tier Eight Micro Miners automated.",
+          "desc:8": "nomifactory.quest.db.331.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18148,7 +18149,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chaotic Fusion Injectors",
+          "name:8": "nomifactory.quest.db.331.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18191,7 +18192,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The final form of Tier Six circuits, and the final circuit theme.\n\nUsing your §2Neuro Processing Units§r, you can craft (grow?) these circuits in a ZPM or better §3Assembling Machine§r.\n\nThese are fairly slow to craft and you\u0027re going to need considerable quantities, so make sure you have a good parallelized infrastructure for keeping these stocked.",
+          "desc:8": "nomifactory.quest.db.332.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18202,7 +18203,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Fourth And Final Tier Six Circuits",
+          "name:8": "nomifactory.quest.db.332.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18244,7 +18245,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Wetware Processors§r are made in §2the ZPM+ Circuit Assembler still.",
+          "desc:8": "nomifactory.quest.db.333.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18255,7 +18256,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third and Final Tier Seven Circuits",
+          "name:8": "nomifactory.quest.db.333.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18296,7 +18297,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Wetware Supercomputers§r are made in an §3Assembly Line§r at ZPM or better power.\n\nYou\u0027ll need §6Europium§r from the §3Fusion Reactor§r to craft these.",
+          "desc:8": "nomifactory.quest.db.334.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18307,7 +18308,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second And Final Tier Eight Circuits",
+          "name:8": "nomifactory.quest.db.334.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18349,7 +18350,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The final circuit!\n\nThe only novel ingredient is §6Tritanium Frames§r.\n\n§6Wetware Processor Mainframes§r are unique in that there are no subsquent circuit themes, and thus no other kinds of Tier Nine circuits. Unlike past mainframes, you will need to craft more than just a few of them. They\u0027re mostly used in the Endgame though, so you don\u0027t have to worry too much yet.\n\nDefinitely consider parallelizing your §3Assembly Lines§r if you haven\u0027t already. Even just having two or three lines will vastly improve your production speeds and help avoid bottlenecks as you push towards the Endgame.\n",
+          "desc:8": "nomifactory.quest.db.335.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18360,7 +18361,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First And Only Tier Nine Circuit",
+          "name:8": "nomifactory.quest.db.335.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18402,7 +18403,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Draconium is a complex material needed in vast quantities.\n\nYou\u0027ll likely have come by some dust while mining in the End, but you can also create it with §6Dragon\u0027s Breath§r and §6Manyullyn§r.",
+          "desc:8": "nomifactory.quest.db.336.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18413,7 +18414,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconium Dust",
+          "name:8": "nomifactory.quest.db.336.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -18455,7 +18456,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Draconic Cores§r are the first crafting step into §bDraconic Evolution§r.\n\nThese serve as the basis for crafting many items and can be upgraded into different tiers of cores via §eFusion Crafting§r.",
+          "desc:8": "nomifactory.quest.db.337.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18466,7 +18467,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconic Cores",
+          "name:8": "nomifactory.quest.db.337.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18507,7 +18508,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2You can make HV Batteries like LV and MV ones, but there is a better option.\n\nEnergium Crystals can store 6,400,000 EU, at the cost of some crafting complexity. They need an HV Autoclave.",
+          "desc:8": "nomifactory.quest.db.338.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18521,7 +18522,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2HV Power Storage",
+          "name:8": "nomifactory.quest.db.338.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18562,7 +18563,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6Titanium§r smelting automated, you can now build Machine Hulls for Extreme Voltage machines.\n\n§2Starting at EV, 4A Energy and Dynamo hatches are available at each tier.",
+          "desc:8": "nomifactory.quest.db.339.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18573,7 +18574,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2EV Machine Hulls",
+          "name:8": "nomifactory.quest.db.339.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18614,7 +18615,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An Extreme Voltage tier §bGregTech§r battery.\n\n§3§2Higher tier GT Batteries have been buffed to be quite strong - this one holds 25 MEU, or 100 MRF. You may want to consider using them over RF storage.",
+          "desc:8": "nomifactory.quest.db.340.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18628,7 +18629,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2EV Power Storage",
+          "name:8": "nomifactory.quest.db.340.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18669,7 +18670,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An Insane Voltage tier §bGregTech§r battery. §2Equivalent to 40 Vibrant Capacitor Banks!",
+          "desc:8": "nomifactory.quest.db.341.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18680,7 +18681,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2IV Power Storage",
+          "name:8": "nomifactory.quest.db.341.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18722,7 +18723,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A Ludicrous Voltage tier §bGregTech§r battery.",
+          "desc:8": "nomifactory.quest.db.342.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18733,7 +18734,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LuV Power Storage",
+          "name:8": "nomifactory.quest.db.342.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18811,7 +18812,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3The Empowerer§r is a machine from §bActually Additions§r used to convert its special crystalline materials into empowered variants.\n\nThe Empowerer is placed in the center of a flat 7x7 region. The four §aDisplay Stands§r are placed with a two-block gap from the Empowerer, one in each cardinal direction.\n\nRecipes require specific items to be placed on the Display Stands and the main item on the Empowerer itself. The items on the Display Stands are consumed and the central item is Empowered.\n\nRF power needs to be fed into the Display Stands to infuse the center item with power. The Display Stands have a low per-side power transfer rate so it takes a while. Consider putting energy conduits on multiple sides of each display stand to speed it up a bit.\n\nThis thing\u0027s a bit of a pain. It\u0027s slow, takes up a large space, and it\u0027s cumbersome to automate. Don\u0027t worry, you\u0027ll get access to the §3Crafting Core§r after you get §6Draconium§r, which is vastly faster, more compact, and easier to automate. Even better, that\u0027s pretty much immediately craftable into the §3Combination Package Crafter§r, which can do the Empowerer recipes directly through §bPackagedAuto§r and §bAE2§r.",
+          "desc:8": "nomifactory.quest.db.344.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18822,7 +18823,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowerer",
+          "name:8": "nomifactory.quest.db.344.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18869,7 +18870,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Wyvern Cores§r are the second tier of cores, used for intermediate crafting recipes.\n\nEach Wyvern Core is made via fusion crafting and the setup needs eight §6Basic Fusion Crafting Injectors§r.",
+          "desc:8": "nomifactory.quest.db.345.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18880,7 +18881,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Wyvern Core",
+          "name:8": "nomifactory.quest.db.345.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18960,7 +18961,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Steel Heavy Plating§r can be augmented with §6Tungsten Plates§r and §6Tough Alloy§r to make §6Basic Reactor Plating§r.\n\nThat\u0027s right-- it\u0027s time to get into §bNuclearCraft§r.\n\nEnhancing basic plating with §6YBCO§r and §6Hard Carbon alloy§r results in a better plating material for more advanced §bNuclearCraft§r blocks.",
+          "desc:8": "nomifactory.quest.db.347.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18971,7 +18972,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "NuclearCraft Platings",
+          "name:8": "nomifactory.quest.db.347.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19086,7 +19087,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The full complexity of §bNuclearCraft§r is far too much for the scope of this quest guide, so §eyou\u0027re encouraged to watch a tutorial or read a guide online§r. For the purposes of this particular quest, you\u0027ll be building a cheap breeder reactor to make §6Plutonium§r. This is a very basic reactor and can be changed to run faster and safer. Alternatively, reactors can be designed to produce a decent amount of power for the mid game of the pack.\n\nFirst, set up your 54 §6Reactor Casings§r to encase a 3x3 cube shape of empty air. The Casings should only cover the faces of the interior cube, not the edges or corners. You should have exactly the right number of Casings to encase a 3x3 space.\n\nNext, create a hole so you can get inside the cube. Place the §6Reactor Cells§r in all 8 corners. Then the §6Lapis Coolers§r will go between them: 4 on the top layer and 4 on the bottom layer. At this point, the top and bottom layers should have eight blocks each with an empty middle, and the middle layer is fully empty. In the middle layer, place the 4 §6Graphite Blocks§r on the corners, and the 4 §6Glowstone Coolers§r on the sides (so they touch both Lapis Coolers). Now the cube should be full, except for an empty column in the middle. The reactor will now be complete when you reseal it up with the Casings you removed to access the interior.\n\nFinally, place the §3Fission Reactor Controller§r along any edge or corner of the reactor. Opening the Reactor Controller GUI should let you know that the structure was properly formed; if not, go back and check what you did wrong.\n\nThe lever is placed on the reactor, as a redstone signal is required for it to start working. §cReactors can overheat and melt if the temperature exceeds its ability to cool.§r You can make a safety loop on the controller (instead of the lever) to automatically shut off the reactor when it starts getting hot using a §aRedstone Conduit§r, a §aRedstone Sensor Filter§r (on the input channel), and a §aRedstone NOT Filter§r (on the output channel). Make sure input and output are on the same channel color.",
+          "desc:8": "nomifactory.quest.db.350.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19097,7 +19098,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fission Reactor",
+          "name:8": "nomifactory.quest.db.350.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19174,7 +19175,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You don\u0027t need it just yet, but you can make it now.\n\nThis is a critical material for the Endgame.",
+          "desc:8": "nomifactory.quest.db.351.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19185,7 +19186,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Ultimate Material",
+          "name:8": "nomifactory.quest.db.351.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19227,7 +19228,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "If you don\u0027t want to mine Obsidian by hand, consider using a Fluid Solidifier to turn §cLava§r into §6Obsidian Blocks§r for you. The process is slow and energy intensive, though.\n\n§3Fluid Solidifiers§r are useful for lots of other things too, of course. Look through the various molds to see what you can make with one.",
+          "desc:8": "nomifactory.quest.db.352.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19238,7 +19239,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Fluid Solidifier",
+          "name:8": "nomifactory.quest.db.352.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19279,7 +19280,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aHang Glider§f is a great way to cross long distances, if you\u0027re so inclined.\n\nIf you don\u0027t want to go exploring for Cows, just buy a pair of \"§6Spawn Cow§f\" eggs and breed them. Seriously, spend your §dcoins§f!",
+          "desc:8": "nomifactory.quest.db.353.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19290,7 +19291,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Glider",
+          "name:8": "nomifactory.quest.db.353.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19331,7 +19332,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Enori Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.354.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19342,7 +19343,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Enori Gear",
+          "name:8": "nomifactory.quest.db.354.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19391,7 +19392,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A catalyst forged from §dOmnium§r, §6Empowered Gears§r, various enhanced §6Nether Stars§r, and a core made of §6The Ultimate Material§r.",
+          "desc:8": "nomifactory.quest.db.355.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19402,7 +19403,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Eternal Catalyst",
+          "name:8": "nomifactory.quest.db.355.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19445,7 +19446,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Are you ready to go infinite?\n\nReinforcing §6Heart of a Universe§r with §6Chaotic Cores§r, many §6Piles of Neutrons§r, and a bunch of §6Eternal Catalysts§r produces an §cInfinity Catalyst§r.\n\nThis material is the core of most creative-tier crafting recipes.",
+          "desc:8": "nomifactory.quest.db.356.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19456,7 +19457,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Catalyst",
+          "name:8": "nomifactory.quest.db.356.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19497,7 +19498,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This ingot is the most advanced basic material.\n\nWith all the automation you hopefully set up for your first §c§cInfinity Catalyst§r, these ingots should be easy.\n\nWell, not easy. But... Reasonable.\n\nFrom here, you are going to be crafting a multitude of Creative-Tier items from various mods. In addition to being useful for their regular functionality, they are needed for the final goal: the §dCreative Vending Upgrade§r.\n\n§bJEI§r is your friend: beyond noting a few more items, I will not be holding your hand anymore. I\u0027ve taught you everything you need to know to beat the pack.\n\nYou can do it!",
+          "desc:8": "nomifactory.quest.db.357.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19508,7 +19509,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Ingot",
+          "name:8": "nomifactory.quest.db.357.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19550,7 +19551,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A helmet to surpass the ultimate, forged with the hearts of stars and the raw fury of the universe.",
+          "desc:8": "nomifactory.quest.db.358.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19561,7 +19562,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Helmet",
+          "name:8": "nomifactory.quest.db.358.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19603,7 +19604,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A chestplate to surpass the ultimate, forged with the hearts of stars and the raw fury of the universe.",
+          "desc:8": "nomifactory.quest.db.359.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19614,7 +19615,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Chestplate",
+          "name:8": "nomifactory.quest.db.359.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19656,7 +19657,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Leggings to surpass the ultimate, forged with the hearts of stars and the raw fury of the universe.",
+          "desc:8": "nomifactory.quest.db.360.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19667,7 +19668,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Leggings",
+          "name:8": "nomifactory.quest.db.360.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19709,7 +19710,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Boots to surpass the ultimate, forged with the hearts of stars and the raw fury of the universe.",
+          "desc:8": "nomifactory.quest.db.361.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19720,7 +19721,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Boots",
+          "name:8": "nomifactory.quest.db.361.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19761,7 +19762,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An ultimate helmet, forged from all manner of materials across dimensions and microverses.",
+          "desc:8": "nomifactory.quest.db.362.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19772,7 +19773,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Helmet",
+          "name:8": "nomifactory.quest.db.362.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19813,7 +19814,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An ultimate chestplate, forged from all manner of materials across dimensions and microverses.",
+          "desc:8": "nomifactory.quest.db.363.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19824,7 +19825,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Chestplate",
+          "name:8": "nomifactory.quest.db.363.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19865,7 +19866,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An ultimate pair of boots, forged from all manner of materials across dimensions and microverses.",
+          "desc:8": "nomifactory.quest.db.364.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19876,7 +19877,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Boots",
+          "name:8": "nomifactory.quest.db.364.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19917,7 +19918,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An ultimate pair of leggings, forged from all manner of materials across dimensions and microverses.",
+          "desc:8": "nomifactory.quest.db.365.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19928,7 +19929,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Leggings",
+          "name:8": "nomifactory.quest.db.365.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19972,7 +19973,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You win.\n\nCongratulations.\n\nI hope you enjoyed playing §5Nomifactory§r.",
+          "desc:8": "nomifactory.quest.db.366.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19983,7 +19984,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Creative Vending Upgrade",
+          "name:8": "nomifactory.quest.db.366.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20024,7 +20025,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§dStabilized Micro Miners§r are the end game way of generating infinite resources.\n\n\"Stabilization\" is a process of injecting §6Micro Miners§r with a §6Heart of a Universe§r, which makes them reusable at a reasonable cost.\n\nMuch like regular Micro Miners, the stabilized versions must be inserted into appropriate §3Microverse Projectors§r. However, running stabilized missions doesn\u0027t require any catalysts.\n\nStabilized missions don\u0027t bring loot, but rather §dPristine Microverse Matter§r that can be exchanged for loot using an §3Actualization Chamber§r.\n\nIt\u0027s a good idea to invest into multiple chambers to be able to round-robin Pristine Matter between them, since you can\u0027t take integrated circuits out.\n\nThe §6Stabilized Tier Eight Micro Miner§r might be the best investment, but the final decision is down to you.",
+          "desc:8": "nomifactory.quest.db.367.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20035,7 +20036,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Stabilized Micro Miners",
+          "name:8": "nomifactory.quest.db.367.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20076,7 +20077,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §aGrappling Hook§f is very useful in an urban environment.\n\nThere are lots of ways to upgrade and improve your Grappling Hook, so play around with it.\n\nOpen your inventory and look for the Baubles button, click it to reveal the additional bauble slots and put the Hook there.\n\nThe default key is §6C§r, however since quite a lot of mods occupy this hotkey you\u0027ll need to visit the controls menu to resolve the button conflicts.",
+          "desc:8": "nomifactory.quest.db.368.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20087,7 +20088,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Grappling Hook",
+          "name:8": "nomifactory.quest.db.368.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20165,7 +20166,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2For making Charcoal for smelting, and Creosote, which can be used as furnace fuel, boiler fuel, and for Treated Planks.\n\nUse up to 5 Coke Oven Hatches for automation.",
+          "desc:8": "nomifactory.quest.db.370.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20176,7 +20177,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Coke Oven",
+          "name:8": "nomifactory.quest.db.370.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -20235,7 +20236,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §aSoft Hammer§f can be used to temporarily stop a machine from functioning. This is useful when you have two machines running and both are unable to keep going because of a lack of power... let one finish then turn the other one back on with a second hit from the hammer.",
+          "desc:8": "nomifactory.quest.db.371.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20255,7 +20256,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Soft Hammer",
+          "name:8": "nomifactory.quest.db.371.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20750,7 +20751,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A component used for more advanced items related to §bExtended Crafting§r.",
+          "desc:8": "nomifactory.quest.db.384.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20761,7 +20762,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Elite Component",
+          "name:8": "nomifactory.quest.db.384.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20802,7 +20803,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Again, combining a few Components will make a Catalyst.",
+          "desc:8": "nomifactory.quest.db.385.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20813,7 +20814,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Elite Catalyst",
+          "name:8": "nomifactory.quest.db.385.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20855,7 +20856,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This table allows you to craft 7x7 Extended Crafting Table recipes.",
+          "desc:8": "nomifactory.quest.db.386.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20866,7 +20867,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Elite Extended Crafting Table",
+          "name:8": "nomifactory.quest.db.386.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20907,7 +20908,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Combine several components into a catalyst.",
+          "desc:8": "nomifactory.quest.db.387.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20918,7 +20919,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Catalyst",
+          "name:8": "nomifactory.quest.db.387.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20960,7 +20961,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Used for Ultimate tier §bExtended Crafting§r.\n\nDon\u0027t worry if you can\u0027t make these for a while. You\u0027ll probably get to them around IV power.",
+          "desc:8": "nomifactory.quest.db.388.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20971,7 +20972,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Component",
+          "name:8": "nomifactory.quest.db.388.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21014,7 +21015,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the largest Extended Crafting Table, capable of handling 9x9 recipes.",
+          "desc:8": "nomifactory.quest.db.389.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21025,7 +21026,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Extended Crafting Table",
+          "name:8": "nomifactory.quest.db.389.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21066,7 +21067,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Infuses things with Redstone Flux.\n\nThis is useful for charging RF-powered devices, but it also can also charge §6Rich Phyto-Gro§r into §6Fluxed Phyto-Gro§r, and charge §6Activated Certus Quartz Crystals§r into §6Charged Certus Quartz Crystals§r.",
+          "desc:8": "nomifactory.quest.db.390.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21091,7 +21092,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Energetic Infuser",
+          "name:8": "nomifactory.quest.db.390.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21150,7 +21151,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "ASSEMBLE... TOO!\n\nYeah you get to craft §6Nether Stars§r. Cool huh?\n\nOver the course of the pack, Nether Stars are going to be needed in quantities that far exceed a reasonable player\u0027s ability to farm Withers. §eCraft them, don\u0027t bother trying to farm them.§r\n\nOnce you gain access to §6Tier 4.5 Micro Miners§r, they will become your best§6 Nether Star§r source.",
+          "desc:8": "nomifactory.quest.db.391.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21161,7 +21162,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Craftable Nether Stars",
+          "name:8": "nomifactory.quest.db.391.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21232,7 +21233,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Congratulations! You\u0027ve reached the end of the circuit progression.\n\nThe only UHV circuit is the §6Wetware Mainframe§r, which is used for crafting high-tier micro miners among some endgame stuff.",
+          "desc:8": "nomifactory.quest.db.392.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21243,7 +21244,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "UHV Circuit...s?",
+          "name:8": "nomifactory.quest.db.392.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21266,7 +21267,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You might be wondering what chunkloading options there are in the pack.\n\nOpen your inventory and look at the top-left corner of the screen. Click the map-looking icon called §eClaimed Chunks§r.\n\n§6Click a chunk§r to claim it as yours. This will prevent unwanted creeper explosions and other players from interacting with your base.\n\n§6Shift-left click a claimed chunk§r to load it. This will ensure that the chunk is loaded at all times, even when you\u0027re not there. Alternatively, there are §achunk-loading wards§f from §bExtra Utilities§f.\n\n§eIf you\u0027re playing on a server with custom settings, ask the server owner what methods are available§f.\n\nTo invite players to your §bFTB Utils§f party, look for a corresponding button in the same corner. Parties share claimed chunks with each other. You can configure permissions for your party\u0027s claimed chunks in the party settings menu.",
+          "desc:8": "nomifactory.quest.db.393.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21277,7 +21278,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Claim Your Chunks and Invite Teammates!",
+          "name:8": "nomifactory.quest.db.393.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21305,7 +21306,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Basic §aFlux Capacitors§r hold a whopping lot of energy - §a1 million RF§r - and are useful for keeping your §aRF-powered§r equipment and tools charged.\n\nPut one into your newly crafted §3Battery Buffer§r to charge it. You can then put it in your inventory to charge your items with §aRF§r. \n§cRF batteries such as Flux Capacitors cannot be drained by Battery Buffers!§r\n\nFlux Capacitor is a §bBauble§r, open your inventory and look for the Baubles button, click it to reveal the additional bauble slots menu and put it into any slot you wish.\n\nFinally you can charge up all those depleted §6Dark Boots§r and §6The Ender§r swords you\u0027ve looted.",
+          "desc:8": "nomifactory.quest.db.394.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21319,7 +21320,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Flux Capacitors",
+          "name:8": "nomifactory.quest.db.394.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21370,7 +21371,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Very fluxy.\n\nA reagent used in the majority of §6Micro Miner§r missions.\n\nThere are several ways to produce §6Quantum Flux§r. All are viable, so figure out which one works best for you.",
+          "desc:8": "nomifactory.quest.db.395.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21381,7 +21382,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Quantum Flux",
+          "name:8": "nomifactory.quest.db.395.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -21459,7 +21460,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A single-block solution to all your power needs.\n\nThis baby pushes out 2.14 GRF/t per side.",
+          "desc:8": "nomifactory.quest.db.397.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21470,7 +21471,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Creative RF Source",
+          "name:8": "nomifactory.quest.db.397.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21512,7 +21513,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Multi Smelter§r is an absolute smelting unit, and is most likely the best furnace added by a mod.\n\nIt\u0027s a 3x3x3 multiblock machine capable of §esmelting huge amounts of items per second§r. By upgrading its coils and power tier, it can become capable of smelting up to literal thousands of items per second.\n\nHover over different coil blocks: the higher the §elevel§r, the more items a Multi Smelter can smelt per operation: §e32 items per level§r. The most basic Multi Smelter essentially does 32 items in the same time as a furnace does one. With a set of level 4 coil blocks, that jumps to 128 items per operation.\n\nThis quest doesn\u0027t ask for coils, hatches or buses: feel free to choose whatever combination you want. You\u0027ll need §a8 coil blocks§r, §a1 input bus§r, §a1 output bus§r and at least §a1 energy hatch§r of any tier.\n\n",
+          "desc:8": "nomifactory.quest.db.398.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21523,7 +21524,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Multi Smelter",
+          "name:8": "nomifactory.quest.db.398.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21570,7 +21571,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Large Plasma Turbines§r are a powerful late game method of generating power. One Large Plasma Turbine produces §2a base of 16384 EU/t when using an IV Rotor Holder§r.",
+          "desc:8": "nomifactory.quest.db.399.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21581,7 +21582,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Plasma Turbine",
+          "name:8": "nomifactory.quest.db.399.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -21634,7 +21635,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Space exploration isn\u0027t mandatory in this pack, so if you don\u0027t feel like exploring space with §bAdvanced Rocketry§r, then you can centrifuge §9Hydrogen§r for §eDeuterium§r instead.\n\nJust keep in mind that it\u0027s much less rewarding to skip this and you\u0027ll need lots of Hydrogen to compensate, although you won\u0027t need too much for the first §3Microverse Projector§r.\n\n§2In HV Age and more effectively in IV Age, you can get this from processing Ender Air.",
+          "desc:8": "nomifactory.quest.db.400.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21649,7 +21650,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2I Don\u0027t Like Space",
+          "name:8": "nomifactory.quest.db.400.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21687,7 +21688,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Anvils§f can be used to repair almost all §bGregTech tools§f!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§f spawn abundantly in §bLost Cities§f buildings, so go and snatch one!\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§f to repair tools made of §6Wrought Iron§f. The only tools unable to be repaired are the mortar and the plunger.",
+          "desc:8": "nomifactory.quest.db.401.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21698,7 +21699,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Proper Tool Care",
+          "name:8": "nomifactory.quest.db.401.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21739,7 +21740,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bGregTech§r adds a very versatile way of augmenting machines with §aMachine Covers§r. Covers are \"upgrades\" that you can put on any GregTech machine, chest, or drum to expand its functionality. To work with covers, you\u0027ll need to make yourself a §aScrewdriver§r to configure covers, and a §aCrowbar§r to remove covers without having to break the machine.\n\nHere\u0027s a list of some covers there are in the game, and what they do:\n\n- §a§lConveyor§r: transfers items continuously to or from an adjacent inventory.\n\n- §a§lPump§r: is much like a §aConveyor§f, but for fluids.\n\n- §a§lRobotic Arm§r: is much like §aConveyor§r, but has two additional modes:\n    * §eKeep Exact§r: moves items to keep a stock of at most the specified number of items\n    * §eSupply Exact§r: transfers precisely the specified number of items per operation.\nThis cover is very useful for crafting automation.\n\n- §a§lFluid Regulator§r: is like a §aRobotic Arm§r, but works with fluids instead of items.\n\n- §a§lShutter§r: prevents automation from interacting with a specific side of a machine.\n\n- §2§lDetector§r: Available in Item, Fluid, Energy, Activity, and Advanced Activity flavours. Emits a Redstone signal depending on the status of whatever it\u0027s detecting.\n\n- §2§lDigital Interface§r: A graphical display for the machine\u0027s current status. Can display things like contained fluids, energy levels, etc.\n\nCovers that move items or fluids can have a §aFilter§r placed inside them. These modify the functionality of covers in ways explained in their own quests.\n",
+          "desc:8": "nomifactory.quest.db.402.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21750,7 +21751,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Machine Covers",
+          "name:8": "nomifactory.quest.db.402.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21807,7 +21808,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "All GregTech machines have one dedicated output side, which can be set by right-clicking a side with a §aGregTech Wrench§f. This is used for ejecting items into an adjacent inventory.\n\nTo enable auto-output, open the machine GUI and click one of the buttons in the bottom-left corner: §6orange§r is items and §9blue§r is fluids.\n\nIf you want to also be able to insert items into the output side, you\u0027ll have to right-click the output side with a §aGregTech Screwdriver§r.\n\nThis can be done by directly right clicking on the output side with a screwdriver, or §6shift right-clicking§r with a screwdriver from the machine grid.\n\nThese features can be used to chain machines together to make processing pipelines and facilitate crafting automation with §bApplied Energistics 2§f.",
+          "desc:8": "nomifactory.quest.db.403.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21823,7 +21824,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Screwdrive Output Sides!",
+          "name:8": "nomifactory.quest.db.403.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21852,7 +21853,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You can easily automate most §bGregTech§r machines with §aME Interfaces§r and processing §aPatterns§r early on by using the machines\u0027 auto-output feature.\n\nUse a §aGregTech Wrench§r to relocate the output side of a machine where you want it to be, right-click it with a §aGregTech Screwdriver§r to permit input on the output face, then put an ME Interface on that side of the machine.\n\nYou can also permit input from the output side by shift-right-clicking with a screwdriver on the output side via the machine grid.\n\nRight-click the machine and enable item auto-output (§6orange box§r in the bottom-left corner of the GUI).\n\nNow, stuff the ME Interface with processing patterns. The next time you order an item, the ME Interface will push ingredients into the machine, and the machine will push outputs back into the Interface once they\u0027re ready, completing the craft. No need to use conduits or import buses!",
+          "desc:8": "nomifactory.quest.db.404.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21863,7 +21864,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Simple GregTech Automation",
+          "name:8": "nomifactory.quest.db.404.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21891,7 +21892,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This modpack has §aCrafting Calculators§r. It has a steep learning curve, but once you manage to learn how to use it, it\u0027s going to be your trusty companion in calculating recipe costs.\n\nCraft yourself one and hit the book button in the top-left corner for a quick overview of how it works.\n\n§2The GTCEu Terminal also has an in-built equivalent to the Crafting Calculator, which you may use instead if you prefer.",
+          "desc:8": "nomifactory.quest.db.405.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21902,7 +21903,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crafting Calculator",
+          "name:8": "nomifactory.quest.db.405.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21946,7 +21947,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have §6Osmium§r and §6Iridium§r from the §6Tier Four Micro Miner§r, you can begin automating §bExtended Crafting§r recipes. While it is possible to use §6Automation Interfaces§r for this task, you have access to something §nvastly§r better§r: §bPackagedExCrafting§r.\n\nTo begin, you\u0027ll need to craft one of each extended §3Package Crafter§r listed on the right. Put an §3Unpackager§r on top of each one, and then a §3Packager§r on top of each Unpackager. These are all AE2 devices, so you\u0027ll need to connect them to an ME Network.\n\nNext, right-click the §3Package Recipe Encoder§r, and you should see a button saying \"Processing\": this button cycles through recipe types, including the various Extended Crafting tables. You\u0027ll have to choose the appropriate table for the recipe you want to encode.\n\n§6Holders§r must be encoded in pairs: one for the Packager, and one for the Unpackager. Select the appropriate table for the recipe, look up the recipe you want to encode, and press §6[+]§r in §bJEI§r to fill it in. Put two Holders in the top-left slot and press Save to encode the recipe to both of them. Finally, put each Holder into the respective machines.\n\nIf you\u0027ve done everything correctly, you should see the item appear as craftable in a Terminal.\n\nWhile it might seem that the crafting process is slow, §ePackagedAuto is excellent at parallelizing§r. You can surround an Unpackager with Crafters and it will use all of them. It\u0027s also possible to add more Unpackagers with Crafters to keep up with the Packager, as long as the Holders are all the same.\n\n",
+          "desc:8": "nomifactory.quest.db.406.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21957,7 +21958,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Automating Extended Crafting",
+          "name:8": "nomifactory.quest.db.406.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22029,7 +22030,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Medium Microverse Projector§r is a more powerful projector required for sending §6Tier Four§r through §6Tier Six Micro Miners§r into microverses.\n\nInitial missions can operate on §eIV power§r, while §eLuV power§r is required for later missions. As with the prior projector, this structure supports overclocking and the position of buses and hatches can be swapped with any §6Microverse Projector Casing§r.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.407.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22040,7 +22041,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Medium Microverse Projector",
+          "name:8": "nomifactory.quest.db.407.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22119,7 +22120,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bPackagedAuto§r is an addon for §bApplied Energistics 2§r. Its main purpose in §5Nomifactory§r is to allow you to automate extended crafting recipes.\n\nApplied Energistics 2 stores recipes in §aPatterns§r, but they are limited to at most 9 stacks of items (a standard 3x3 crafting grid). PackagedAuto stores recipes in §aPackage Recipe Holders§r, which don\u0027t have this limitation. Additionally, each Holder can store up to §e20 different recipes§r. Holders must be encoded in the §3Package Recipe Encoder§r.\n\nIn the vast majority of situations you\u0027ll need two identically-encoded Holders, as the following machines work together.\n\nThe §3Packager§r is a machine that compresses ingredients for a specific recipe into a set of §6Recipe Packages§r. Each package in a set can hold up to 9 stacks of ingredient items. A simple recipe might consist of one package, but a complex recipe can have up to 9 packages in its set (for 81 total item stacks).\n\nThe §3Unpackager§r is a machine that extracts ingredient items from complete sets of Recipe Packages made in a Packager, ejecting the items into an adjacent inventory. It will only extract the items if §eall packages in a set are present§r.\n\nWhen both a Packager and Unpackager are connected to an ME Network and have the same recipe, the resulting item will appear as craftable in your §aTerminal§r.\n\nUp to 8 §3Packager Extensions§r can optionally be added to the Packager to speed up package creation. Place the Packager Extensions in a plane surrounding the Packager, creating a 3 by 3 structure with the Packager in the center when all 8 Packager Extensions are placed.",
+          "desc:8": "nomifactory.quest.db.408.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22130,7 +22131,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "PackagedAuto",
+          "name:8": "nomifactory.quest.db.408.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22189,7 +22190,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Unlike §aRF power§r, which is safe to transport in any §6conduit§r, §aEU power §r§erequires caution§r. The key is to always §amatch or exceed§r the §eVoltage §rand §eAmperage§r of your power source with your §6cables§r and machines.\n\n§o§4§cNEVER §rhook up your Energy Converter§r to a cable that has fewer §eAmps§r than your Energy Converter or Battery Buffer§r generates. For example, you must use §64x cable§r for a 4A Converter§r, and §616x cable§r for a filled 16-slot Battery Buffer§r. Cables with insufficient amperage rating will §cburn and be destroyed§r. §2Both the multiple-amp-source and multiple-face-input bugs from CE have been fixed - the Energy network now works as intended.§r\n\nSimilarly, your cable must match or exceed the §eVoltage§r of your machines, or they will §cburn and be destroyed§r.\n\n§cNEVER§r connect a machine to excessive §eVoltage§r or it will §cvaporize§r. Touching a §6wire§r with connected §aEU power§r will §cinjure or kill you§r, so for your safety, §euse §6cables§e instead§r!\n\n§2Superconductor-type wires do not damage you in CEu. The 0-loss cables in CE (Conductive Iron, Energetic Alloy, etc.) are considered Superconductors.",
+          "desc:8": "nomifactory.quest.db.409.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22200,7 +22201,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2A Primer on Power",
+          "name:8": "nomifactory.quest.db.409.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22266,7 +22267,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Large Microverse Projector§r is a more powerful projector required for sending §6Tier Seven§r through §6Tier Ten Micro Miners§r into microverses.\n\nTier Seven missions will operate on §eLuV power§r, but higher energy tiers will be required for later missions. As with the prior projector, this structure supports overclocking and the position of buses and hatches can be swapped with any §6Microverse Projector Casing§r.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.411.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22277,7 +22278,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Large Microverse Projector",
+          "name:8": "nomifactory.quest.db.411.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22356,7 +22357,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Lunar Mining Station§r is a large multiblock structure used for mining gases from the moon. It is an excellent (though not the only) source of §9Deuterium§r or §9Helium-3§r, depending on what kind of §6Rover§r you use. \n\nRovers only have a 10% chance to break while mining, so a stack of them will last quite a while.\n\nWhile both available recipes require §eMV power§r, you can overclock it with higher tiers of power. The positions of hatches and buses can be swapped with any §6LuV Machine Casing§r.\n\n§6Sneak-right click§r the controller to enable the in-world preview.\n\nBecause this structure must be placed on the Moon, it is a good idea to use mechanisms like §aEnder Tanks§r or a §6Quantum Link Chamber§r for teleporting the fluids back to your base.\n\nMake sure to keep it chunk-loaded!\n",
+          "desc:8": "nomifactory.quest.db.412.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22367,7 +22368,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Lunar Mining Station",
+          "name:8": "nomifactory.quest.db.412.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22457,7 +22458,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The functions of the Extractor and Fluid Extractor have been combined into a single machine!\n\n§3Extractors§r are useful for melting things into liquids. For example, you can melt down ingots into molten metals, or §6Rubber Sheets§r into liquid §9Rubber§r.\n\nWhen you have access to §6Steel§r, you can make molds and use §3Fluid Solidifiers§r to form various components more efficiently from fluids, like §6Gears§r.",
+          "desc:8": "nomifactory.quest.db.413.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22468,7 +22469,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Extractor",
+          "name:8": "nomifactory.quest.db.413.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22546,7 +22547,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have a §aFlux Capacitor§r to keep things charged, you might consider making yourself a §aFluxomagnet§r.\n\nThis relatively inexpensive bauble will suck nearby items into your inventory.",
+          "desc:8": "nomifactory.quest.db.415.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22560,7 +22561,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluxomagnet",
+          "name:8": "nomifactory.quest.db.415.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22605,7 +22606,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Fish Oil, surprisingly, comes from fish.",
+          "desc:8": "nomifactory.quest.db.416.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22616,7 +22617,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fish Oil",
+          "name:8": "nomifactory.quest.db.416.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22668,7 +22669,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A much more efficient version of the §3Empowerer§r.\n\nThis is a digital upgrade to the §3Crafting Core§r, allowing you to craft Empowerer recipes directly through §bPackagedAuto§r.\n\nThe §aMarked Pedestals§r can be placed freely within three blocks distance of the Crafting block, as long as they are on the same Y-level.\n\nAs usual with PackagedAuto crafters, you need to encode the recipe in the correct mode and place a copy in two places: a §3Packager§r somewhere on your network, and an §3Unpackager§r adjacent to the §3Combination Package Crafter§r.\n\nThese recipes require large amounts of RF and it §ewill not use power from your §aME Network§r, so you must also connect the package crafter directly to energy conduits.",
+          "desc:8": "nomifactory.quest.db.417.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22679,7 +22680,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Combination Package Crafter",
+          "name:8": "nomifactory.quest.db.417.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25316,7 +25317,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Useful to carry more stuff.\n\nWhat more explanation are you expecting?",
+          "desc:8": "nomifactory.quest.db.488.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25330,7 +25331,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basic Satchel",
+          "name:8": "nomifactory.quest.db.488.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25374,7 +25375,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Most plates are made in the Bending Machine instead of here. (Technically this was the case in CE, but this modpack transferred its recipes to the Compressor.)\n\nHowever, this machine will still see use for compressing Nuggets into Ingots, Ingots into Blocks, and gem Dusts into Plates (such as Certus).",
+          "desc:8": "nomifactory.quest.db.489.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25385,7 +25386,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Compressor",
+          "name:8": "nomifactory.quest.db.489.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25426,7 +25427,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §3Autoclave§r is a machine that uses liquids (usually water) to polish stones, carve gems into lenses, infuse gems with special liquids, and crystallize various dusts.\n\nYou\u0027ll need an Autoclave for many recipes, but right now you want it to make §6Activated Certus Quartz Crystals§r for §bApplied Energistics§r out of the §bGregTech§r §6Certus Quartz§r and its dust you get from mining and ore processing.",
+          "desc:8": "nomifactory.quest.db.490.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25437,7 +25438,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Autoclave",
+          "name:8": "nomifactory.quest.db.490.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25478,7 +25479,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "No need for Lumberaxes anymore, §dGregTech Axes§r will cut down entire trees for you. They won\u0027t destroy your Storage Drawer networks, too.",
+          "desc:8": "nomifactory.quest.db.491.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25494,7 +25495,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Veinmining Trees?",
+          "name:8": "nomifactory.quest.db.491.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25540,7 +25541,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Is it expensive? Yes. Is it worth it? Hell yes.\n\nIt doesn\u0027t start to shine until you get the good upgrades for it though, so maybe hold off for a while.",
+          "desc:8": "nomifactory.quest.db.492.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25554,7 +25555,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Drill Baby Drill",
+          "name:8": "nomifactory.quest.db.492.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25635,7 +25636,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This terminal allows you to interact with fluid storage on your ME Network, like §aFluid Storage Disks§r.\n\nPut fluids in or remove fluids via this terminal with any GUI-compatible container, by clicking on a fluid to fill it, or an empty space to drain into the network.\n\nIt\u0027s a micropart, so you need to place it on §6ME Cable§r (not a conduit).",
+          "desc:8": "nomifactory.quest.db.494.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25646,7 +25647,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluid Terminal",
+          "name:8": "nomifactory.quest.db.494.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25687,7 +25688,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aStorage Drawer Controllers§r are the central hub of any good storage system. They can pull from any drawers they are connected to (via other drawers, or drawer trims) within a 12 block cubic radius. This leads to a potential 25x25x25 area to connect drawers, centered on the controller.\n\nThe appearance can be customized by crafting the controller into §aFramed Controller§r and putting it into a §aFraming Table§r.\n\n§aController Slaves§r do not extend the range, but rather act as another access point to that controller - allowing you to push/pull from any of the drawers within range of the local Drawer Controller.\n\nConnecting an §6ME Storage Bus§f to a controller exposes all of the drawers to §bApplied Energistics§f. Particularly large networks can be laggy though, so keep your drawer networks a manageable size.\n",
+          "desc:8": "nomifactory.quest.db.495.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25698,7 +25699,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Storage Drawer Controller",
+          "name:8": "nomifactory.quest.db.495.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25739,7 +25740,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bStorage Drawers§f provide a huge amount of storage for a single item type. Use them for things you have a lot of, such as stone, dirt and ores.\n\nIf the default appearances aren\u0027t your style, the §3Framing Table§f is useful for making custom drawers out of §6Framed Drawers§f and up to three additional items which define how the resulting drawer will look.\n\nIn addition, the §aHand Framing Tool§r has been implemented, allowing you to reframe your drawers in world, and convert default drawers into Framed Drawers§r in-world. See the §eJEI Information Page§r of the Hand Framing Tool§r for more information.",
+          "desc:8": "nomifactory.quest.db.496.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25750,7 +25751,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Drawers",
+          "name:8": "nomifactory.quest.db.496.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25797,7 +25798,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Great for automatically converting between Nuggets, Ingots, and Blocks of metals, or simply storing massive amounts of things.\n\nThe appearance can be customized by crafting the drawer into §aFramed Compacting Drawer§r and putting it into a §aFraming Table§r.",
+          "desc:8": "nomifactory.quest.db.497.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25808,7 +25809,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Compacting Drawers",
+          "name:8": "nomifactory.quest.db.497.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25849,7 +25850,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "When making circuits, you\u0027ll need either molten §9Tin§r, or molten §9Soldering Alloy§r§r§r. §2Soldering Alloy is made in the Mixer with 6 parts Tin Dust, 3 parts Lead Dust and 1 part Antimony Dust.§r You then process it in an §3Extractor §rfor the usual 144mB of fluid per unit.\n\nThe §2Circuit Assembler§r will only consume half as much Soldering Alloy as it would have consumed molten Tin per craft (72mB vs 144mB), so it\u0027s very efficient to use this stuff.\n\n§2Antimony can be directly smelted from Stibnite Ore, allowing you to skip ore processing for this.",
+          "desc:8": "nomifactory.quest.db.498.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25864,7 +25865,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Soldering Alloy",
+          "name:8": "nomifactory.quest.db.498.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25959,7 +25960,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your new§2 Epoxy Circuit Boards§r, §6Nano CPUs§r, and some standard components, you can make the final type of Tier Three Circuit: the §6Nanocircuit§r.\n\nAs the best form of Tier Three circuit, these should be automated and stockpiled. As with the Final Tier Two circuits, the §6Advanced System-on-Chip§r variant recipes won\u0027t be available for a while.",
+          "desc:8": "nomifactory.quest.db.500.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25970,7 +25971,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third And Final Tier Three Circuits",
+          "name:8": "nomifactory.quest.db.500.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26035,7 +26036,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A small appetizer, before the §dOmnium§r main course.\n\nAs the name suggests, this catalyst is formed from exotic non-elemental materials and alloys.",
+          "desc:8": "nomifactory.quest.db.501.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26046,7 +26047,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Exotic Materials Catalyst",
+          "name:8": "nomifactory.quest.db.501.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26088,7 +26089,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Capacitors§r are devices that store electrical energy, which is useful for circuits.\n\nNot to be confused with §bEnderIO§r\u0027s capacitors§r, which store redstone flux.",
+          "desc:8": "nomifactory.quest.db.502.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26099,7 +26100,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Capacitors",
+          "name:8": "nomifactory.quest.db.502.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26140,7 +26141,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.503.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26151,7 +26152,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dark Soularium Ingots",
+          "name:8": "nomifactory.quest.db.503.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26192,7 +26193,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts both LV and MV Brewery.\n\nYou can turn §6Plant Balls§r and other various §6sugary crops§r into §9Biomass§r with a §3Brewery§r. Biomass is the first step towards making Plastic in the form of §9Polyethylene§r.\n\nThe Brewery is a very very slow machine, but it requires almost no power. Building §2many Breweries§r is necessary to brew enough Biomass for plastics.",
+          "desc:8": "nomifactory.quest.db.504.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26203,7 +26204,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Brewery",
+          "name:8": "nomifactory.quest.db.504.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26245,7 +26246,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Ethanol§r is alcohol, which you can first produce from distilling §9Biomass§r.\n\nBoiling §6Sugar Cane§r in a §3Brewery§r is a great way to get Biomass, but you can also get it from other crops and saplings if you want.\n\nOnce you have a hefty starting stock of Ethanol, consider making and distilling §9Fermented Biomass§r in a §3Distillation Tower§r for extra chemicals.",
+          "desc:8": "nomifactory.quest.db.505.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26260,7 +26261,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ethanol",
+          "name:8": "nomifactory.quest.db.505.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26335,7 +26336,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need §9Chlorine§r at this point. It is an important ingredient in many chemical processes, and you can currently get it from electrolyzing either §6Salt§r or §6Rock Salt§r.\n\n§2Later, you can use Fluid Rigs or break down Ghast Tears to obtain Salt Water, and electrolyze it to Chlorine.",
+          "desc:8": "nomifactory.quest.db.507.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26350,7 +26351,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Chlorine",
+          "name:8": "nomifactory.quest.db.507.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26388,7 +26389,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.508.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26399,7 +26400,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Ruridit Ingots",
+          "name:8": "nomifactory.quest.db.508.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26440,7 +26441,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bEnderIO§r and §bThermal§r alloys are a bit more expensive than the normal wires, but they come with the huge advantage of being §e§2superconductors§r. Lossy cables like §6Tin§r and §6Copper§r will bleed out energy for every block they travel, but §2superconductors§r do not.\n\nThe §2cheap superconductors§r for each tier are:\n\nLV - Conductive Iron\nMV - Energetic Alloy\nHV - Vibrant Alloy\nEV - End Steel\nIV - Lumium \nLuV   - Signalum \nZPM - Enderium \nUV     - Draconium \nMAX - §2Draconic Superconductor§r, Omnium\n\n§2There are an additional set of superconductors, one for each tier, which are the CEu default superconductors. Their advantage is their higher amperage rating, reaching the hundreds of amps for higher tier 16x wires. They are also used in crafting Field Generators.§,§r\n\nMV and higher cables are made in an §3Assembling Machine§r. They\u0027re made with liquid §9Rubber§r and §6Wires§r, plus a reusable §6Programmed Circuit§r that tells it what thickness of wire to make.\n\nYou can use Wires, and for these materials they\u0027ll conduct just as well as if they were covered. §2Superconductor wires also won\u0027t kill you when touched now. In fact, you have to use Wires for Superconductors, because they don\u0027t even have cables!",
+          "desc:8": "nomifactory.quest.db.509.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26451,7 +26452,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Lossless Cables",
+          "name:8": "nomifactory.quest.db.509.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26492,7 +26493,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mix together these two crushed gems along with §9Resonant Ender§r to make §9Dew of the Void§r, the fluid that will power §bEnderIO§r interdimensional teleportation.\n\nPlease note that Dew of the Void goes great with Doritos.",
+          "desc:8": "nomifactory.quest.db.510.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26507,7 +26508,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dew Of The Void",
+          "name:8": "nomifactory.quest.db.510.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26565,7 +26566,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bEnderIO§r\u0027s equivalent of a §3Chemical Reactor§r, roughly speaking.\n\nThe only way to make several important liquids from EnderIO.",
+          "desc:8": "nomifactory.quest.db.511.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26576,7 +26577,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Vat",
+          "name:8": "nomifactory.quest.db.511.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26619,7 +26620,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Slice\u0027N\u0027Splice§r is a machine from §bEnderIO§r.\n\nIt is used for making monster-head-related items that are components for various things.\n\nIt needs to be supplied with an Axe and Shears, which are slowly damaged over time as items are crafted.",
+          "desc:8": "nomifactory.quest.db.512.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26630,7 +26631,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Slice\u0027N\u0027Splice",
+          "name:8": "nomifactory.quest.db.512.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26671,7 +26672,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.513.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26682,7 +26683,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Red Steel Ingots",
+          "name:8": "nomifactory.quest.db.513.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26797,7 +26798,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Not as common a component, but used in a number of critical machines.\n\nAlso useful as a machine cover for continuously moving items.",
+          "desc:8": "nomifactory.quest.db.516.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26808,7 +26809,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Conveyor",
+          "name:8": "nomifactory.quest.db.516.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26850,7 +26851,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Robot Arms§r are components of several powerful machines, and are also useful as a machine cover for precise item movement.\n\nOne of the most expensive components, as it requires motors, pistons, and a circuit.",
+          "desc:8": "nomifactory.quest.db.517.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26861,7 +26862,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Robot Arm",
+          "name:8": "nomifactory.quest.db.517.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26939,7 +26940,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Naquadah Reactor Mk1§r is a structure used to generate considerable amounts of EU power from decaying §6Enriched Naquadah§r or §6Naquadria§r into §6Lead§r.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.519.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26950,7 +26951,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Reactor Mk1",
+          "name:8": "nomifactory.quest.db.519.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27022,7 +27023,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Four §6Microprocessors§r combined with §6Titanium Plates§r and a few other standard components will make a §6MicroSupercomputer§r.",
+          "desc:8": "nomifactory.quest.db.520.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27037,7 +27038,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Second Tier Four Circuits",
+          "name:8": "nomifactory.quest.db.520.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27084,7 +27085,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Provides more augment slots to machines and dynamos.\n\nDynamos operate at §a1000% of base power and fuel burn rate§r.\n\nPortable Tanks hold §a1250 buckets§r.\n\nMachines operate at §a600% of base speed§r.",
+          "desc:8": "nomifactory.quest.db.521.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27095,7 +27096,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Resonant Upgrade Kit",
+          "name:8": "nomifactory.quest.db.521.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27137,7 +27138,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This compressor is needed for making §6Iridium Heavy Plating§r and §6Enderium Heavy Plating§r.",
+          "desc:8": "nomifactory.quest.db.522.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27148,7 +27149,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LuV Compressor",
+          "name:8": "nomifactory.quest.db.522.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27189,7 +27190,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Upgrading to the §6Nano Supercomputer§r requires some standard circuit components, but also some §6Lumium Wire§r and §2Fine Tungstensteel Wire.",
+          "desc:8": "nomifactory.quest.db.523.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27200,7 +27201,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Five Circuits",
+          "name:8": "nomifactory.quest.db.523.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27241,7 +27242,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The first and most expensive Tier Six Circuit, needed for crafting the §3IV Assembling Machine§r.\n\nRequires a bunch of standard circuit components.",
+          "desc:8": "nomifactory.quest.db.524.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27252,7 +27253,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Six Circuits",
+          "name:8": "nomifactory.quest.db.524.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27293,7 +27294,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Nothing you haven\u0027t seen here: just combine some standard circuit components and §6Nanocircuits§r to make a §6Nanoprocessor§r.",
+          "desc:8": "nomifactory.quest.db.525.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27304,7 +27305,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Four Circuits",
+          "name:8": "nomifactory.quest.db.525.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27347,7 +27348,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §6Titanium§r-based machine hulls and §6Mainframes§r squared away, you can finally get on the path to making an Extreme Voltage §3Circuit Assembling Machine§r.\n\nThis tier of Assembling Machine unlocks §6Nanocircuits§r, as well as handling crafting recipes up to 2048 EU/t. It can also optionally overclock recipes that consume up to 512 EU/t for improved speed at the cost of relatively more power.",
+          "desc:8": "nomifactory.quest.db.526.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27358,7 +27359,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2EV Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.526.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27399,7 +27400,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Glowing! §2But all the GTCEu machines glow already, so...§r\n\nThis one takes a significant amount of time to cook, so make sure to have it going constantly.\n\nWires made from §6Lumium§r transmit IV power losslessly, and it forms part of the basis for §6LuV Machine Hulls§r.",
+          "desc:8": "nomifactory.quest.db.527.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27410,7 +27411,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Lumium",
+          "name:8": "nomifactory.quest.db.527.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27451,7 +27452,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "What?!\n§6STEAM DYNAMO§r is evolving!\n\nUpgrade kits can be applied to Thermal Expansion Dynamos, machines, and even Portable Tanks. Machines and dynamos get additional augment slots.\n\nWhen applied to a dynamo, it increases the §apower generation and fuel burn rate to 150%§r.\n\nIncreases the base capacity of Portable Tanks to §a200 buckets§r.\n\nAllows machines operate at §a150% of base power per tick§r. The more power a machine can use, the faster it works.\n",
+          "desc:8": "nomifactory.quest.db.528.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27462,7 +27463,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Hardened Upgrade Kit",
+          "name:8": "nomifactory.quest.db.528.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27504,7 +27505,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §6Tungstensteel§r-based machine hulls and §6Nanoprocessor Mainframes§r squared away, you can finally get on the path to making an Insane Voltage §3Circuit Assembling Machine§r.\n\nThis tier of Assembling Machine unlocks §6Quantum Circuits§r, as well as handling crafting recipes up to 8192 EU/t. It can also optionally overclock recipes that consume up to 2048 EU/t for improved speed at the cost of relatively more power.",
+          "desc:8": "nomifactory.quest.db.529.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27515,7 +27516,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2IV Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.529.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27557,7 +27558,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With all of the components made, it\u0027s time to craft an §2Electronic Circuit§r.\n\nThis is where your §3Crafting Station§f setups will really shine! With the patterns encoded into a Crafting Stations (well, really over §omany§r Crafting Stations), you\u0027ll be able to §ebatch craft circuits quickly§f.\n\nYou\u0027ll be making a LOT§r of circuits, so take advantage of the improved crafting efficiency.",
+          "desc:8": "nomifactory.quest.db.530.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27568,7 +27569,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Your First Circuit",
+          "name:8": "nomifactory.quest.db.530.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27615,7 +27616,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now you can craft the §6Quantum Processor Mainframe§r, the first Tier Seven circuit.\n\nThese are required for crafting the Ludicrous Voltage (LuV) §3Assembling Machine§r.",
+          "desc:8": "nomifactory.quest.db.531.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27626,7 +27627,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Seven Circuits",
+          "name:8": "nomifactory.quest.db.531.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27667,7 +27668,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3HV Circuit Assembling Machine§r unlocks §2the Mainframe§r, as well as handling crafting recipes that consume up to 512 EU/t.\n\nIt can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
+          "desc:8": "nomifactory.quest.db.532.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27678,7 +27679,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2HV Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.532.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27720,7 +27721,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §2Naquadah Alloy§r-based machine hulls and §6Crystal Processor Mainframes§r squared away, you can finally get on the path to making a ZPM §3Circuit Assembling Machine§r.\n\nThis tier of Assembling Machine unlocks §6Wetware Circuits§r, as well as handling crafting recipes up to 131072 EU/t. It can also optionally overclock recipes that consume up to 32768 EU/t for improved speed at the cost of relatively more power.",
+          "desc:8": "nomifactory.quest.db.533.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27731,7 +27732,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2ZPM Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.533.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27773,7 +27774,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6Enderium§r, you can assemble a §6Crystal Supercomputer§r.",
+          "desc:8": "nomifactory.quest.db.534.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27784,7 +27785,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Seven Circuits",
+          "name:8": "nomifactory.quest.db.534.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27825,7 +27826,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Crystal Processor Mainframe§r is the first Tier Eight circuit.\n\nAlong with things you already know how to make, this needs §6HSS-E Frames§r.\n\nThese are required for crafting the §3ZPM Assembling Machine§r. As usual, these are extremely expensive: invest in the next theme of circuits instead of trying to mass-produce these.\n",
+          "desc:8": "nomifactory.quest.db.535.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27836,7 +27837,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Eight Circuits",
+          "name:8": "nomifactory.quest.db.535.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27877,7 +27878,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6ZPM Machine Hulls§r are made with §2Naquadah Alloy Plates,§r but you\u0027ll notice they also need §2Polybenzimidazole§r.\n\nZPM stands for Zero Point Module.\n\nThis is the last tier of machine that\u0027s sensible to produce before you reach the §dCreative Tank§r. Multiblock hatches are a different matter: feel free to upgrade your §3EBF§rs to Ultimate Voltage, if you can handle the power drain.\n",
+          "desc:8": "nomifactory.quest.db.536.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27888,7 +27889,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2ZPM Machine Hulls",
+          "name:8": "nomifactory.quest.db.536.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27929,7 +27930,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Sterilized Growth Medium§r is needed for §6Wetware Circuits§r.\n\nYou\u0027ll need to mix §6Mincemeat§r, §2Calcium, Salt, Agar, and Mutagen§r with water in a mixer to make §9Raw Growth Medium§r, then use a §3Fluid Heater§r to sterilize it. §2This is a significantly more involved process than before.§r\n\nMincemeat comes from pulverizing any kind of animal meat. A §aPowered Spawner§r might be useful for this endeavor. §2Agar is produced from Mincemeat through multiple steps.",
+          "desc:8": "nomifactory.quest.db.537.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27944,7 +27945,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Sterilized Growth Medium",
+          "name:8": "nomifactory.quest.db.537.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28019,7 +28020,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Phosphorus§r can be obtained by processing §6Tricalcium Phosphate§r or §6Apatite§r with §6Sand§r and §6Coke§r in the §3Blast Furnace§r.",
+          "desc:8": "nomifactory.quest.db.539.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28030,7 +28031,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phosphorus",
+          "name:8": "nomifactory.quest.db.539.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28073,7 +28074,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Extruder§r is an alternative way to form shapes from metal. §aExtruder Shapes§r are used for telling an Extruder which shape to make.\n\nExtruders are §2no longer strictly needed for Large Pipes.§r Extruders use ingots, but are as efficient for making §6Gears§r as melting and solidifying. They are also the most efficient way to make §6Bolts§r, §6Small Gears§r, and §6Rings§r.\n\nYou can also use Extruders to make things from other machines like plates and wires, but they are less efficient than using the dedicated machines for these purposes.",
+          "desc:8": "nomifactory.quest.db.540.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28084,7 +28085,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2MV Extruder",
+          "name:8": "nomifactory.quest.db.540.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28125,7 +28126,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Overclocking aside, as you continue to progress in §5Nomifactory§f, materials made in the §3Electric Blast Furnace§f will take longer to complete. §eMore advanced coils do not give speed bonuses§f §2directly§r; they mainly allow for the furnace to §eget hot enough to process more advanced materials§f, §2and they also granting energy efficiency bonuses and speed bonuses to overclocking.§r\n\nConsequently, you\u0027ll need to continually expand your smelting and power generation infrastructure.\n\nYou don\u0027t have to get all four of these Electric Blast Furnaces completed and running just yet, but be prepared to make many of them over the course of the pack.\n\n§2As a reminder, all blocks and hatches can be shared across EBFs, except Maintenance!",
+          "desc:8": "nomifactory.quest.db.541.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28136,7 +28137,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2More Blast Furnaces",
+          "name:8": "nomifactory.quest.db.541.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28178,7 +28179,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and Experience to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.",
+          "desc:8": "nomifactory.quest.db.542.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28189,7 +28190,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Soul Binder",
+          "name:8": "nomifactory.quest.db.542.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28230,7 +28231,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.543.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28241,7 +28242,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Blue Steel Ingots",
+          "name:8": "nomifactory.quest.db.543.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28283,7 +28284,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Carry even more stuff.",
+          "desc:8": "nomifactory.quest.db.544.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28297,7 +28298,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Hardened Satchel",
+          "name:8": "nomifactory.quest.db.544.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28354,7 +28355,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Carry §oeven more§r stuff.",
+          "desc:8": "nomifactory.quest.db.545.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28368,7 +28369,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reinforced Satchel",
+          "name:8": "nomifactory.quest.db.545.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28424,7 +28425,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts both LV and MV Distillery. §2If you are distilling Ethanol, you now need an MV Distillery.\n\n§rThe §3Distillery§r is a single-block machine which only outputs one distillate out of several and §cdiscards§r the rest. You can use this now to get §9Ethanol§r from §9Biomass§r, or to selectively distill §9Oil§r in multiple steps to §9Ethylene§r. Its advantage over the full Tower, apart from cost, is its §denergy efficiency§r.§r \n\nHowever, the Distillation Tower is mandatory for advanced chemistry, as most things have more than one important output: §9Fermented Biomass§r, §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r, and the entire line of petrochemicals from §9Oil§r, to name a few.\n\nCan\u0027t avoid it forever!\n\n",
+          "desc:8": "nomifactory.quest.db.546.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28435,7 +28436,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Distillery",
+          "name:8": "nomifactory.quest.db.546.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28476,7 +28477,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "",
+          "desc:8": "nomifactory.quest.db.547.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28491,7 +28492,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Scanner Module: Block",
+          "name:8": "nomifactory.quest.db.547.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28536,7 +28537,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aMolds§r are used in a §3Fluid Solidifier§r or §3Alloy Smelter§r to form materials into specific shapes. These are not consumed or damaged during crafting, so you can leave them in a machine to dedicate it to that shape.\n\nThe Fluid Solidifier tends to be the more efficient option: for example, you can use §e8 ingots§r to make one §6Gear§r in an Alloy Smelter, but with an Extractor and Solidifier you can accomplish the same result with §e4 ingots§r.\n\nBe careful not to accidentally make §aExtruder Shapes§r. Those are for a machine you will get access to later. The three molds in this quest are ones you will find useful right away.",
+          "desc:8": "nomifactory.quest.db.548.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28547,7 +28548,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Molds",
+          "name:8": "nomifactory.quest.db.548.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28607,7 +28608,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Fluid Rigs will harvest fluids from underground fluid veins. Note that the fluid veins are simply simulated and don\u0027t exist in the world. §r\n\nUse your §3Prospector\u0027s Scanner§r to see the type and amount of fluid underground and to check the depletion state of the vein. The first number represents the base amount of fluid extracted per second. \n\nIn the §eOverworld§r, it can harvest: §9Oil, Light Oil, Heavy Oil, Raw Oil, Natural Gas, Salt Water§r\n\nIn the §eNether§r: §eLava, Natural Gas§r\n\nOn the §eMoon§r: §9Deuterium, Helium-3§r\n\nThe first tier of Fluid Rig is good for §d100,000 operations§r. Higher tier Fluid Rigs harvest fluids far faster and deplete veins slower.",
+          "desc:8": "nomifactory.quest.db.549.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28622,7 +28623,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fluid Rig",
+          "name:8": "nomifactory.quest.db.549.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28677,7 +28678,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Place the §3Vertical Digger§r over an ore vein, feed it RF, and it will mine up the entire vein for you.\n\nFor drills, you will need a §6GregTech Drill§r (any LV drill will work), a §6Fluxbore§r (Reinforced tier is required) and an §6Actually Additions Drill§r (any color is fine, but take out any augments you wish to keep).\n\nThe GregTech Drill will not be consumed, but everything else will be.",
+          "desc:8": "nomifactory.quest.db.550.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28688,7 +28689,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vertical Digger",
+          "name:8": "nomifactory.quest.db.550.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28729,7 +28730,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "These are useful for extending the range of other \"Phantom\" machines and devices from §bActually Additions§r.",
+          "desc:8": "nomifactory.quest.db.551.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28740,7 +28741,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phantom Booster",
+          "name:8": "nomifactory.quest.db.551.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28781,7 +28782,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Being able to fly is pretty sick. It\u0027s also pretty expensive.\n\nIt\u0027s probably a bit premature to consider a §6jetpack§r at this point, but if you really want to craft this bad boy, I won\u0027t stop you.\n\nThere\u0027s also a quest chain for §bEnderIO§r Jetpacks (starting with the §6Conductive Iron Jetpack§r). Eventually you\u0027ll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really really like flying.\n\nIf the §6Jetpack§r overview and information from §bThe One Probe§r conflict, they can be adjusted through the §bSimply Jetpacks 2§r §eConfiguration file§r or the command §6/topcfg§r respectively.",
+          "desc:8": "nomifactory.quest.db.552.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28796,7 +28797,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Leadstone Jetpack",
+          "name:8": "nomifactory.quest.db.552.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28843,7 +28844,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Better flying.",
+          "desc:8": "nomifactory.quest.db.553.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28858,7 +28859,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Hardened Jetpack",
+          "name:8": "nomifactory.quest.db.553.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28903,7 +28904,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Even better flying.\n\nYou\u0027re not getting up to Resonant for a long time, just FYI.",
+          "desc:8": "nomifactory.quest.db.554.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28918,7 +28919,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reinforced Jetpack",
+          "name:8": "nomifactory.quest.db.554.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28963,7 +28964,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Rich Phyto-Gro§r can be further enhanced by infusing it with Redstone Flux in the §3Energetic Infuser§r.",
+          "desc:8": "nomifactory.quest.db.555.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28974,7 +28975,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluxed Phyto-Gro",
+          "name:8": "nomifactory.quest.db.555.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -29015,7 +29016,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The 4.5th Micro Miner.\n\nAll of the Tier Four missions require §68 Quantum Flux§r and a stack of §6Aerotheum Dust§r.\n\nThis miner will be your primary source of mob drops all the way until the end\n\nWhen equipped with a §6Sapling§r:\n§6* Creeper, Skeleton and Zombie skulls\n* Bone\n* Rotten Flesh\n* Gunpowder\n* Slime Block\n* Guardian Scale§r\n\nWhen equipped with a §6Block of Netherrack:\n* Wither Skeleton Skull and Bones\n* Blaze Rod\n* Ghast Tear\n* Magma Cream§r\n\nWhen equipped with a §6Block of Endstone:\n* Enderman Skull\n* Enderpearl Block\n* Shulker Shell§r\n\nWhen equipped with §6Ender Eyes:\n* Dragon Lair Data\n* Ender Dragon Head§r\n\nWhen equipped with §6Wither Bones§r:\n§6* Wither Realm Data\n* Nether Star Block\n",
+          "desc:8": "nomifactory.quest.db.556.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29026,7 +29027,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Tier 4.5 Micro Miner",
+          "name:8": "nomifactory.quest.db.556.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -29103,7 +29104,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is an augment that will work in all §3dynamos§f. It increases the efficiency of the fuel being used inside the dynamo, increasing the power it generates. However, the rate of power generation remains the same, the fuel simply lasts longer. So, while §6Fuel Catalyzers§f decrease the amount you\u0027ll need to go mining for §6Coal§f, they won\u0027t boost your production of RF per second.\n\nEach Fuel Catalyzer increases fuel efficiency by §a15%§f, additively (so two will make fuel last §a30% longer§f, three is §a45% longer§f, etc.).",
+          "desc:8": "nomifactory.quest.db.558.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29114,7 +29115,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fuel Catalyzers",
+          "name:8": "nomifactory.quest.db.558.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -29156,7 +29157,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aAuxiliary Transmission Coil §ris an augment that will work in all types of dynamos. It will consume fuel faster to produce a correspondingly higher RF per tick.\n\nEach augment increases both base power production and fuel consumption by 100%, additively (so the second is 200%, third is 300%, etc.).\n\nConsider the tradeoffs however, as you could just make another dynamo, and you miss out on §aFuel Catalyzer§r augments that make fuels burn longer for more total RF generated. The Auxiliary Transmission Coil will put additional stress your fuel production infrastructure.\n\nIf that\u0027s an acceptable tradeoff, then Auxiliary Transmission Coils are a cheap and effective way to boost your power production.",
+          "desc:8": "nomifactory.quest.db.559.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 2,
@@ -29167,7 +29168,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Auxiliary Transmission Coils",
+          "name:8": "nomifactory.quest.db.559.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -29356,7 +29357,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "How much do you think these solar panels weigh? \n\nThese are quite expensive and two of them are required for each Tier Ten Micro Miner.\n\n§6Neutronium Solar Panels§r generate an enormous amount of RF power in sunlight, so once you get your tank it\u0027s also a good choice for compact power generation.\n\nProtip: it\u0027s always daytime in space.",
+          "desc:8": "nomifactory.quest.db.564.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29367,7 +29368,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Neutronium Solar Panel",
+          "name:8": "nomifactory.quest.db.564.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -29963,7 +29964,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "As you continue to progress, crafting times for more advanced §3Electric Blast Furnace§r recipes will continue to increase. More advanced coils do not give speed bonuses, they just increase the operating temperature so you can smelt more advanced materials, §2and they also grant energy efficiency bonuses and speed bonuses to overclocking.§r\n\nTo compensate, you\u0027ll need to get your infrastructure for smelting, as well as for power generation, up to snuff.\n\nYou don\u0027t need to get all eight of these completed and running just yet, but plan to at some point in the future. Instead of upgrading existing EBFs, have them passively automating a stock of materials and build new EBFs with higher specifications for new materials.\n\n",
+          "desc:8": "nomifactory.quest.db.580.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29974,7 +29975,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Blast Furnaces Galore",
+          "name:8": "nomifactory.quest.db.580.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30052,7 +30053,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.582.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30063,7 +30064,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluxed Electrum Ingots",
+          "name:8": "nomifactory.quest.db.582.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30104,7 +30105,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.583.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30115,7 +30116,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Signalum Ingots",
+          "name:8": "nomifactory.quest.db.583.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30156,7 +30157,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.584.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30167,7 +30168,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Enderium Ingots",
+          "name:8": "nomifactory.quest.db.584.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30208,7 +30209,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.585.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30219,7 +30220,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pulsating Iron Ingots",
+          "name:8": "nomifactory.quest.db.585.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30261,7 +30262,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.586.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30272,7 +30273,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "High Speed Steel Type E Ingot",
+          "name:8": "nomifactory.quest.db.586.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -30313,7 +30314,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.587.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30324,7 +30325,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "High Speed Steel Type G Ingots",
+          "name:8": "nomifactory.quest.db.587.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30366,7 +30367,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.588.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30377,7 +30378,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "High Speed Steel Type S Ingots",
+          "name:8": "nomifactory.quest.db.588.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -30418,7 +30419,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.589.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30429,7 +30430,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crystal Matrix Ingots",
+          "name:8": "nomifactory.quest.db.589.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30507,7 +30508,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.591.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30518,7 +30519,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vanadium Steel Ingots",
+          "name:8": "nomifactory.quest.db.591.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30559,7 +30560,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.592.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30570,7 +30571,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Electrical Steel Ingots",
+          "name:8": "nomifactory.quest.db.592.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30611,7 +30612,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.593.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30622,7 +30623,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "End Steel Ingots",
+          "name:8": "nomifactory.quest.db.593.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30664,7 +30665,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.594.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30675,7 +30676,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Microversium Ingots",
+          "name:8": "nomifactory.quest.db.594.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -30716,7 +30717,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.595.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30727,7 +30728,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mana Infused Ingots",
+          "name:8": "nomifactory.quest.db.595.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30768,7 +30769,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.596.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30779,7 +30780,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dark Steel Ingots",
+          "name:8": "nomifactory.quest.db.596.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30820,7 +30821,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.597.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30831,7 +30832,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vibrant Alloy Ingots",
+          "name:8": "nomifactory.quest.db.597.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30872,7 +30873,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.598.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30883,7 +30884,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Energetic Alloy Ingots",
+          "name:8": "nomifactory.quest.db.598.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30924,7 +30925,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.599.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30935,7 +30936,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Soularium Ingots",
+          "name:8": "nomifactory.quest.db.599.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30977,7 +30978,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.600.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30988,7 +30989,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Manyullyn Ingots",
+          "name:8": "nomifactory.quest.db.600.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31029,7 +31030,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.601.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31040,7 +31041,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Magnalium Ingots",
+          "name:8": "nomifactory.quest.db.601.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31081,7 +31082,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.602.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 64,
@@ -31092,7 +31093,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Kanthal Ingots",
+          "name:8": "nomifactory.quest.db.602.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31133,7 +31134,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": " nomifactory.quest.db.603.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31144,7 +31145,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nichrome Ingots",
+          "name:8": "nomifactory.quest.db.603.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31185,7 +31186,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "No hypothetical aliens were harmed in the harvesting of this item.\n\nProbably.",
+          "desc:8": "nomifactory.quest.db.604.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31196,7 +31197,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Heart Of A Universe",
+          "name:8": "nomifactory.quest.db.604.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31239,7 +31240,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You are become Death, destroyer of Universes.\n\nMight probably be obvious, but this miner gathers §6Heart of a Universe§r.",
+          "desc:8": "nomifactory.quest.db.605.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31250,7 +31251,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tier Ten Micro Miner",
+          "name:8": "nomifactory.quest.db.605.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31291,7 +31292,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Kind of redundant, really.\n\nThis plating is used exclusively for the Tier Ten Micro Miner. You need some serious protection from forces when harvesting a whole microverse.",
+          "desc:8": "nomifactory.quest.db.606.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31302,7 +31303,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Neutronium Heavy Plating",
+          "name:8": "nomifactory.quest.db.606.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31344,7 +31345,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Neutronium§r is a hyper-dense material normally found in the hearts of neutron stars: the collapsed cores of stars between ten and thirty times the size of the sun.\n\nFun fact: a single neutronium block is approximately 2884 million metric tons and somewhere around 600000K, yet you\u0027re somehow capable of holding one with your bare hands. Don\u0027t think about it too much.\n\nNeutronium is made from fusing molten §9Naquadria§r, a super-enriched form of §6Naquadah§r, with molten §9Americium§r. \n\nAfter getting §6Chaotic Fusion Injectors§r, you might consider using Tier Nine Micro Miners to supplement the fusion, as it is net-positive for Neutronium. These miners are expensive though, so it\u0027s up to you.\n",
+          "desc:8": "nomifactory.quest.db.607.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31355,7 +31356,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Neutronium Ingot",
+          "name:8": "nomifactory.quest.db.607.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -31396,7 +31397,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Coating §6Draconium Wire§r with §9Molten Nether Star§r and freezing it solid results in a superconductive material capable of transmitting enormous amounts of energy.\n\nThese wires losslessly transmit \"MAX\" tier, which is effectively infinite transfer rate. This means they will work for any tier of power. 1x wires handle 4 amps, meaning 4x wires can handle 16 amps.\n\nThese can also be made into RF conduits that can transmit a whopping 134 Million RF/t.",
+          "desc:8": "nomifactory.quest.db.608.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31407,7 +31408,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Superconductor Wire",
+          "name:8": "nomifactory.quest.db.608.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31449,7 +31450,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Provides more augment slots to machines and dynamos.\n\nDynamos operate at §a250% of base power and fuel burn rate§r.\n\nTanks hold §a450 buckets§r.\n\nMachines operate at §a250% of base speed.",
+          "desc:8": "nomifactory.quest.db.609.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31460,7 +31461,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reinforced Upgrade Kit",
+          "name:8": "nomifactory.quest.db.609.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31501,7 +31502,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An alloy of §6Steel§r and §6Boron§r. Pretty simple.",
+          "desc:8": "nomifactory.quest.db.610.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31512,7 +31513,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ferroboron",
+          "name:8": "nomifactory.quest.db.610.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31553,7 +31554,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Alloying some §6Lithium§r into your §6Ferroboron§r results in §6Tough Alloy§r, a common component in §bNuclearCraft§r blocks.",
+          "desc:8": "nomifactory.quest.db.611.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31564,7 +31565,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tough Alloy",
+          "name:8": "nomifactory.quest.db.611.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31605,7 +31606,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The ZPM tier §3Compressor§r is needed for the most advanced heavy plating types: §6Draconium§r and §6Crystal Matrix§r.",
+          "desc:8": "nomifactory.quest.db.612.title",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31616,7 +31617,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ZPM Compressor",
+          "name:8": "nomifactory.quest.db.612.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31658,7 +31659,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.613.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31669,7 +31670,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 001: Hydrogen",
+          "name:8": "nomifactory.quest.db.613.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31710,7 +31711,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": " nomifactory.quest.db.614.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31721,7 +31722,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 002: Helium",
+          "name:8": "nomifactory.quest.db.614.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31762,7 +31763,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.615.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31773,7 +31774,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 003: Lithium",
+          "name:8": "nomifactory.quest.db.615.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31814,7 +31815,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.616.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31825,7 +31826,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 004: Beryllium",
+          "name:8": "nomifactory.quest.db.616.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31866,7 +31867,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.617.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31877,7 +31878,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 005: Boron",
+          "name:8": "nomifactory.quest.db.617.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31918,7 +31919,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.618.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31929,7 +31930,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 006: Carbon",
+          "name:8": "nomifactory.quest.db.618.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31971,7 +31972,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.619.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31982,7 +31983,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 007: Nitrogen",
+          "name:8": "nomifactory.quest.db.619.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32024,7 +32025,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.620.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32035,7 +32036,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 008: Oxygen",
+          "name:8": "nomifactory.quest.db.620.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32076,7 +32077,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.621.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32087,7 +32088,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 009: Fluorine",
+          "name:8": "nomifactory.quest.db.621.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32128,7 +32129,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.622.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32139,7 +32140,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 010: Neon",
+          "name:8": "nomifactory.quest.db.622.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32180,7 +32181,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.623.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32191,7 +32192,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 011: Sodium",
+          "name:8": "nomifactory.quest.db.623.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32232,7 +32233,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.624.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32243,7 +32244,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 012: Magnesium",
+          "name:8": "nomifactory.quest.db.624.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32284,7 +32285,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.625.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32295,7 +32296,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 013: Aluminium",
+          "name:8": "nomifactory.quest.db.625.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32336,7 +32337,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.626.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32347,7 +32348,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 014: Silicon",
+          "name:8": "nomifactory.quest.db.626.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32388,7 +32389,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.627.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32399,7 +32400,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 015: Phosphorus",
+          "name:8": "nomifactory.quest.db.627.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32440,7 +32441,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.628.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32451,7 +32452,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 016: Sulfur",
+          "name:8": "nomifactory.quest.db.628.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32492,7 +32493,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.629.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32503,7 +32504,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 017: Chlorine",
+          "name:8": "nomifactory.quest.db.629.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32544,7 +32545,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.630.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32555,7 +32556,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 018: Argon",
+          "name:8": "nomifactory.quest.db.630.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32596,7 +32597,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.631.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32607,7 +32608,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 019: Potassium",
+          "name:8": "nomifactory.quest.db.631.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32648,7 +32649,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.632.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32659,7 +32660,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 020: Calcium",
+          "name:8": "nomifactory.quest.db.632.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32700,7 +32701,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.633.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32711,7 +32712,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 057: Lanthanum",
+          "name:8": "nomifactory.quest.db.633.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32752,7 +32753,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.634.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32763,7 +32764,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 022: Titanium",
+          "name:8": "nomifactory.quest.db.634.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32804,7 +32805,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.635.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32815,7 +32816,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 023: Vanadium",
+          "name:8": "nomifactory.quest.db.635.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32856,7 +32857,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.636.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32867,7 +32868,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 024: Chromium",
+          "name:8": "nomifactory.quest.db.636.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32908,7 +32909,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.637.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32919,7 +32920,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 025: Manganese",
+          "name:8": "nomifactory.quest.db.637.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32960,7 +32961,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.638.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32971,7 +32972,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 026: Iron",
+          "name:8": "nomifactory.quest.db.638.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33012,7 +33013,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.639.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33023,7 +33024,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 027: Cobalt",
+          "name:8": "nomifactory.quest.db.639.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33064,7 +33065,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.640.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33075,7 +33076,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 028: Nickel",
+          "name:8": "nomifactory.quest.db.640.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33116,7 +33117,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.641.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33127,7 +33128,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 029: Copper",
+          "name:8": "nomifactory.quest.db.641.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33168,7 +33169,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.642.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33179,7 +33180,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 030: Zinc",
+          "name:8": "nomifactory.quest.db.642.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33220,7 +33221,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.643.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33231,7 +33232,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 031: Gallium",
+          "name:8": "nomifactory.quest.db.643.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33272,7 +33273,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.644.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33283,7 +33284,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 033: Arsenic",
+          "name:8": "nomifactory.quest.db.644.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33324,7 +33325,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.645.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33335,7 +33336,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 036: Krypton",
+          "name:8": "nomifactory.quest.db.645.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33376,7 +33377,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.646.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33387,7 +33388,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 039: Yttrium",
+          "name:8": "nomifactory.quest.db.646.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33428,7 +33429,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.647.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33439,7 +33440,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 046: Palladium",
+          "name:8": "nomifactory.quest.db.647.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33480,7 +33481,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.648.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33491,7 +33492,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 047: Silver",
+          "name:8": "nomifactory.quest.db.648.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33532,7 +33533,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": " nomifactory.quest.db.649.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 64,
@@ -33543,7 +33544,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 049: Indium",
+          "name:8": "nomifactory.quest.db.649.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33584,7 +33585,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.650.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33595,7 +33596,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 050: Tin",
+          "name:8": "nomifactory.quest.db.650.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33637,7 +33638,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.651.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33648,7 +33649,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 051: Antimony",
+          "name:8": "nomifactory.quest.db.651.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -33689,7 +33690,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.652.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33700,7 +33701,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 054: Xenon",
+          "name:8": "nomifactory.quest.db.652.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33741,7 +33742,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.653.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33752,7 +33753,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 074: Tungsten",
+          "name:8": "nomifactory.quest.db.653.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33793,7 +33794,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.654.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33804,7 +33805,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 076: Osmium",
+          "name:8": "nomifactory.quest.db.654.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33845,7 +33846,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.655.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33856,7 +33857,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 077: Iridium",
+          "name:8": "nomifactory.quest.db.655.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33897,7 +33898,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.656.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33908,7 +33909,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 078: Platinum",
+          "name:8": "nomifactory.quest.db.656.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33949,7 +33950,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.657.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33960,7 +33961,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 079: Gold",
+          "name:8": "nomifactory.quest.db.657.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34001,7 +34002,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.658.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34012,7 +34013,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 080: Mercury",
+          "name:8": "nomifactory.quest.db.658.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34053,7 +34054,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.659.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34064,7 +34065,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 086: Radon",
+          "name:8": "nomifactory.quest.db.659.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34105,7 +34106,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.660.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34116,7 +34117,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 090: Thorium",
+          "name:8": "nomifactory.quest.db.660.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34157,7 +34158,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.661.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34168,7 +34169,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 092: Uranium",
+          "name:8": "nomifactory.quest.db.661.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34209,7 +34210,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.662.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34220,7 +34221,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 093: Neptunium",
+          "name:8": "nomifactory.quest.db.662.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34261,7 +34262,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.663.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34272,7 +34273,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 094: Plutonium",
+          "name:8": "nomifactory.quest.db.663.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34313,7 +34314,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.664.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34324,7 +34325,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 095: Americium",
+          "name:8": "nomifactory.quest.db.664.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34365,7 +34366,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.665.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34376,7 +34377,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 096: Curium",
+          "name:8": "nomifactory.quest.db.665.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34417,7 +34418,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.666.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34428,7 +34429,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 097: Berkelium",
+          "name:8": "nomifactory.quest.db.666.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34469,7 +34470,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.667.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34480,7 +34481,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 098: Californium",
+          "name:8": "nomifactory.quest.db.667.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34522,7 +34523,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.668.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34533,7 +34534,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 099: Einsteinium",
+          "name:8": "nomifactory.quest.db.668.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -34574,7 +34575,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "When you have enough materials, you can craft Uranium isotope clumps into Low-Enriched Uranium 235 Fuel (or §6LEU-235§r, for short). This fuel uses an 8:1 ratio of U238 to U235.\n\nThis fuel is processed in your §3Fission Reactor§r by placing it in the controller. When a redstone signal is applied it will burn the fuel, generating some power from the reactor and after a while you\u0027ll get a §6Depleted LEU-235 Fuel§r§r.\n\nThe depleted fuel is separated in a regular §3Centrifuge§r, resulting in many tiny clumps of fissile materials: Uranium 238, §6Neptunium 237§r, §6§6Plutonium 239§r, and §6Plutonium 241§r.",
+          "desc:8": "nomifactory.quest.db.669.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34585,7 +34586,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Uranium Fission",
+          "name:8": "nomifactory.quest.db.669.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34632,7 +34633,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Steam Machines can run recipes listed as up to §d32 EU/t§r. They need to have their vent side unobstructed. Use a Wrench to change the venting side.\n\n- §3Forge Hammer§r: Allows you to make §62 plates§r from §63 ingots§r.\n\n- §3Macerator§r: Allows you to grind §6Clay§r into §6Clay Dust§r.\n\n- §3Compressor§r: Allows you to make §6Compressed Fireclay§r and §6Rubber Sheets§r.\n\n- §3Alloy Smelter§r: Allows you to make §6Bronze§r more efficiently, as well as other useful alloys like §6Invar§r. Also allows you to cast §6Glass§r, and make components like §eGears§r more easily with Molds.\n\nYou can upgrade them to HP version with Steel, which doubles their speed.",
+          "desc:8": "nomifactory.quest.db.670.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34643,7 +34644,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Steam Machines",
+          "name:8": "nomifactory.quest.db.670.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -34701,7 +34702,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Thorium is another basic fissile material that can be used to get into the fissile chain. Thorium comes from §6Pitchblende Ore§r, §6Thorium Ore§r, and even §2Black Granite§r (with a few processing steps).\n\nThorium-Bred Uranium, or §6TBU§r for short, is made from nine clumps of §6Thorium 232§r enriched in a §3Thermal Centrifuge§r.\n\nThe depleted fuel provides tiny clumps of §6Uranium 233§r, §6Uranium 235§r, §6§6Neptunium 236§r, and §6Neptunium 237§r.",
+          "desc:8": "nomifactory.quest.db.671.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34712,7 +34713,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Thorium Fission",
+          "name:8": "nomifactory.quest.db.671.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34765,7 +34766,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Climbing the ladder of fissile materials will require some specific raw materials and machinery.\n\n§2Uraninite is the base resource you will need, which comes from Uraninite and Pitchblende Ore. You will need to react it with Fluorine and Hydrofluoric Acid in a Chemical Reactor to form Uranium Hexafluoride.\n\nThe Uranium Hexafluoride must then be separated into Depleted and Enriched Uranium Hexafluoride in a Centrifuge. The Depleted UF₆ will grant Uranium-238, while the Enriched UF₆ will grant Uranium-235.\n\n",
+          "desc:8": "nomifactory.quest.db.672.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34776,7 +34777,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Nuclear Fuel Infrastructure",
+          "name:8": "nomifactory.quest.db.672.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34823,7 +34824,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Low-Enriched Neptunium 236, or §6LEN-236§r, is the next step in the fissile material fuel chain.\n\nThis fuel requires an 8:1 ratio of §6Neptunium 237§r to §6Neptunium 236§r. Using only the results from Thorium fission, it will take two batches of §6Depleted TBU Fuel§r to make your first LEN fuel.\n\nOf course, higher order reactions also will result in small amounts of Neptunium that you can work with as well.\n\n§6Depleted LEN 236§r gives a small bit of Neptunium 237 back, but principally provides §6Plutonium§r and §6Americium§r isotopes.\n",
+          "desc:8": "nomifactory.quest.db.673.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34834,7 +34835,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Neptunium Fission",
+          "name:8": "nomifactory.quest.db.673.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34893,7 +34894,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Uranium 233§r is obtained exclusively from the fission of §6TBU Fuels§r.\n\n§6LEU-233§r is made from one §6U233§r and eight §6U238§r.\n\n§6Depleted LEU-233§r will give you various §6Plutonium§r isotopes and some §6Americium§r.",
+          "desc:8": "nomifactory.quest.db.674.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34904,7 +34905,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LEU-233",
+          "name:8": "nomifactory.quest.db.674.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34952,7 +34953,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Low-Enriched Plutonium 239, or §6LEP-239§r, is made from the usual 8:1 ratio of two isotopes of §6Plutonium§r acquired from earlier depleted fuels.\n\n§6Depleted LEP-239§r will give you some §6Curium§r for further enrichment.\n\nHigh-Enriched Plutonium fuels will give better results, but §cgenerate a lot more heat§r. Make sure your reactor cooling is up to the task.",
+          "desc:8": "nomifactory.quest.db.675.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34963,7 +34964,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Plutonium Fission",
+          "name:8": "nomifactory.quest.db.675.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -35023,7 +35024,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Low-Enriched Curium 243, or §6LECm-243§r, is made from §6Curium-243§r and §6Curium-246§r.\n\n§6Depleted LECm-243 Fuel§r gives mostly Curium-246 back, but also small quantities of §6Berkelium§r and §6Californium§r isotopes.\n\n§6HECm-247§r is a better alternative for strictly Californium, if your reactor can withstand the heat.",
+          "desc:8": "nomifactory.quest.db.676.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35034,7 +35035,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Curium Fission",
+          "name:8": "nomifactory.quest.db.676.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -35093,7 +35094,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Americium 242§r and §6Americium 243§r are used to make §6LEA-242 Fuel§r.\n\nThere\u0027s also §6Americium 241§r, but this is only useful for making RTGs (which produce small amounts of RF continuously) or decaying down into §6Neptunium§r.\n\n§6Depleted LEA 242 Fuels§r§r will return large amounts of §6Curium 246§r and small amounts of other isotopes.",
+          "desc:8": "nomifactory.quest.db.677.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35104,7 +35105,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Americium Fission",
+          "name:8": "nomifactory.quest.db.677.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35163,7 +35164,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Depleted LEB-248 Fuel§r results in several different isotopes of §6§6Californium§r.",
+          "desc:8": "nomifactory.quest.db.678.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35174,7 +35175,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Berkelium Fission",
+          "name:8": "nomifactory.quest.db.678.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35233,7 +35234,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Californium§r is the final fissile material in the NuclearCraft processing chain.\n\n§6Depleted LECf-249 Fuel§r results in... different isotopes of Californium.\n\nUnless you want §6Californium RTGs§r or are experimenting with further fission routes, this step is probably unnecessary for general materials processing.",
+          "desc:8": "nomifactory.quest.db.679.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35244,7 +35245,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Californium Fission",
+          "name:8": "nomifactory.quest.db.679.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35304,7 +35305,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have all the basic building blocks of nuclear fission, you\u0027ll need to start creating breeding chains to mass produced stabilized versions of each element, for the synthesis of §dOmnium§r.\n\nExperiment around with larger breeder reactors that can handle highly enriched fuels.\n\nYou\u0027ll probably want to build multiple reactors to make all the fissile elements in any reasonable amount of time.",
+          "desc:8": "nomifactory.quest.db.680.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35315,7 +35316,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Further Adventures In Fission",
+          "name:8": "nomifactory.quest.db.680.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35344,7 +35345,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aImplosion Compressor§f is like an autoclave that uses explosions instead of water. It is the only way to turn most gem dusts into gemstones.\n\nIt will also be vital for processing §5Motes of Omnium§f.\n\nIn addition to the controller and casings, you will need one §eLV or better§r §6Item Input Bus§r, §6Item Output Bus§r, and §6Energy Input Hatch§r.\n\n§2If desired, you may upgrade this directly to an Electric Implosion Compressor, which can accept Parallel Control hatches.",
+          "desc:8": "nomifactory.quest.db.681.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35355,7 +35356,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Implosion Compressor",
+          "name:8": "nomifactory.quest.db.681.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35396,7 +35397,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §2CEu§r§r version of Nomi is already slightly harder than the original, due to various progression changes CEu makes.\n\nBut if you want a §charder§r, or perhaps a more \"§5true§r\" §dGregTech§r experience, check out the §cExpert§r mode. This pack mode is based on the §bSelf-Torture Edition fork§r of the original pack.\n\nHighlights include:\n\n- No §bDML§r for easy infinite resources\n- §6Omnicoins§r can\u0027t be spent\n- The §7Steam Age§r\n- No §3Creative Tank§r; instead...\n- §6Stabilized Micro Miners§r for late-game infinite resources\n- Harder recipes for assorted things like §6Iridium§r, §3Numismatic Dynamos§r, and more\n\nTo enable §cExpert§r mode, change the pack mode (Options -\u003e Pack Mode) to Expert, then run §e/bq_admin default load ExpertQuests§r. The same command should be used for updating the quest book on Expert mode.\nTo go back, change the pack mode to §aNormal§r and run §e/bq_admin default load§r.\n\nTo tune your challenge even further, check out the various recipe configs in the GregTech config file.",
+          "desc:8": "nomifactory.quest.db.682.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35407,7 +35408,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Hard Mode",
+          "name:8": "nomifactory.quest.db.682.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -35434,7 +35435,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Provide your §3Simulation Chamber§r with RF power and §6Pulsating Polymer Clay§r. Then insert a §6Data Model§r of your choice. The Simulation Chamber will consume Polymer Clay and a decent amount of power to begin simulating mob kills. This will generate §6Overworldian Matter§r and may occasionally provide you with §6Pristine Matter§r.\n\n§6Overworldian Matter§r can be eaten to gain experience, or can be combined with other materials to obtain drops from Overworld mobs. With these drops, you can then create Data Models for other mob types as well.",
+          "desc:8": "nomifactory.quest.db.683.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35445,7 +35446,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Overworldian Matter",
+          "name:8": "nomifactory.quest.db.683.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35486,7 +35487,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6String§r and §6Coal Dust§r can be baked together into a §6Carbon Mesh§r in an §3Alloy Furnace§r.\n\nCombine that with §6Pulsating Dust§r to get a §6Pulsating Mesh§r.\n\n",
+          "desc:8": "nomifactory.quest.db.684.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35497,7 +35498,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pulsating Mesh",
+          "name:8": "nomifactory.quest.db.684.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35556,7 +35557,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Loot Fabricator",
+          "name:8": "nomifactory.quest.db.191.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35692,7 +35693,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Feeding §3Steam producers§r with water by hand is a pretty silly idea.\n\nA §2Primitive Water Pump§r will take care of that for you.",
+          "desc:8": "nomifactory.quest.db.687.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35703,7 +35704,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Infinite Water",
+          "name:8": "nomifactory.quest.db.687.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35878,7 +35879,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Graphene§r is the cable material required for §6IV Motors§r, and it\u0027s not trivial to make anymore.\n\nPresently, you can make it by reducing §6Graphene Oxide§r with §9Argon§r and §9Hydrazine§r. §9Hydrazine§r is produced in multiple steps using §9Ammonia§r and §9Hydrogen Peroxide§r with §9Acetone§r as a recycled reagent.\n\nLater, you can use a §6Magnetron§r to make it from §6Graphite§r directly. Note that the other recipe requires no §6Graphite§r.",
+          "desc:8": "nomifactory.quest.db.690.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35889,7 +35890,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Graphene",
+          "name:8": "nomifactory.quest.db.690.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -35998,7 +35999,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Confused about all the Wrenches yet?\n\nThe §aCrescent Hammer§r is for use on machines from §bThermal Expansion§f, but can be used for basic wrench interactions with blocks from almost every mod.\n\nThe §aYeta Wrench§r is used with machines and conduits from §bEnderIO§f, and has several special display modes (§6sneak-mouse wheel§f to switch between them).\n\nThe §aGregTech Wrench§r is used to rotate GregTech machines and redefine their output sides. §2It also has some of the capabilities of the other Wrenches now.§r\n\nYou can see which mod a machine is from with the §9blue text§f at the bottom of its tooltip.",
+          "desc:8": "nomifactory.quest.db.692.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36009,7 +36010,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Wrenches Galore",
+          "name:8": "nomifactory.quest.db.692.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -36068,7 +36069,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Give me a little juice, FRIDAY!",
+          "desc:8": "nomifactory.quest.db.693.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36083,7 +36084,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity War",
+          "name:8": "nomifactory.quest.db.693.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -36129,7 +36130,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "I\u0027m running out of MCU puns.\n\nThe §aAngel Ring§r is actually slower than a jetpack, but it grants creative flight and requires no fuel (except a bit of GP).\n\nUp to you if you want to use it over a jetpack for day to day stuff, but it\u0027s an ingredient in the next jetpack, so if you want that you\u0027ll need to make one eventually.",
+          "desc:8": "nomifactory.quest.db.694.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36140,7 +36141,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Captain... Marvel? IDK",
+          "name:8": "nomifactory.quest.db.694.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -36182,7 +36183,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the flight of our lives.",
+          "desc:8": "nomifactory.quest.db.695.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36197,7 +36198,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Endgame",
+          "name:8": "nomifactory.quest.db.695.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -36242,7 +36243,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Naquadah Reactor Mk2§r is an upgraded reactor that can generate immense amounts of EU energy from the same types of fuels as the Mk1. The materials it requires are similar to the Mk1, and you can almost reuse the same structure. Make sure you are prepared for the UV power output by adding a §6UV Energy Output Hatch§r.\n\nThis is a pretty expensive structure though, as it needs blocks of §dOmnium§r. Maybe wait until after you get the §dCreative Tank§r?\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.696.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36253,7 +36254,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Reactor Mk2",
+          "name:8": "nomifactory.quest.db.696.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37416,7 +37417,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "When you first started the pack, we told you that ore doubling can wait, and that\u0027s true... But you will need to start doing some rudimentary ore processing for §ebyproducts§r.\n\nByproducts are additional materials that can only be obtained from processing ores in certain machines. For example, there is no \"Gallium Ore\" or \"Arsenic Ore\". You get §6Gallium§r and §6Arsenic §ras a byproduct from processing other ores.\n\nOres have various means of processing, and eventually you\u0027ll use machine pipelines to process ores in specific ways to optimize what byproducts you gain. You can look at the §b§b§6Ore Byproduct Page§6§r of an ore in §bJEI§r, accessed by pressing \u0027U\u0027 on an ore and navigating to the byproduct tab, to see the required route to obtain desired byproducts. \n\nThe relevant machines are as follows:\n \n- §3Macerator§r: turns ores into §6Crushed Ores§r, Crushed Ores into §6Impure Dusts§r, and §6Purified Crushed Ores§r into §6Pure Dusts§r. Higher tiers of macerators have byproduct slots and gain a chance to get a full pile of byproduct from ores and both types of crushed ores.\n\n- §3Ore Washer§r: cleans Crushed Ores with §9Water§r, making Purified Crushed Ores§r, and a guaranteed 3 tiny piles of byproduct. Using §9Distilled Water§r makes them go faster. §2You can also perform a simple wash with this similar to Cauldron washing, which is extremely fast, but grants no byproducts.§r\n\n- §3Chemical Bath§r: §2uses Sodium Persulfate or Mercury to purify certain ores, granting a chance to yield a full pile of a byproduct.\n\n§r- §3§3Centrifuge§r: separates Pure or Impure dusts into the final material, producing a guaranteed §21 (nerfed from 3) tiny pile of byproduct§r.\n\n- §3Electrolyzer§r: uses power to split compounds into individual elements, sometimes gaining useful byproducts in the process. §2Be warned that certain dusts may be better to directly smelt instead of electrolyze!§r\n\n- §3Thermal Centrifuge§r: not to be confused with the regular Centrifuge. §2Less slow and power-hungry now, but still so. However, it yields 3 additional tiny piles of byproduct, and macerating the Centrifuged Ore can grant a special third byproduct.\n\n§2- Sifter: filters high-quality Gems from Purified Crushed gem Ores for an overall higher yield.\n\n- Electromagnetic Separator: filters magnetic metals from certain ores, increasing their yields.§r\n\nYour first forays into ore processing for byproducts will be the Electrolyzer and the Centrifuge.\n",
+          "desc:8": "nomifactory.quest.db.727.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37427,7 +37428,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Ore Processing for Byproducts",
+          "name:8": "nomifactory.quest.db.727.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37455,7 +37456,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Uraninite Ore§r is the first source of §6Pulsating Dust§r but is not a very good one in the long term. Instead you should make §6Resonant Clathrates§r, which are an infinitely-renewable and effective source of Pulsating Dust.\n\nResonant Clathrates are made by melting §6Ender Pearls§r with a §3Fluid Extractor§r into §9Resonant Ender§r, then mixing that with §6Nether Quartz§r in an MV or better §3Chemical Reactor§r. Smelting this clathrate gives Pulsating Dust.\n\nWith Resonant Clathrates now accessible, everything you need for crafting §6Pulsating Polymer Clay§r can be automated in a net-positive loop.§r Doing so is a boon to automation of §bDeep Mob Learning§r, which is §ea primary source of important materials for the rest of the pack§r.\n\nThe exact implementation is up to you. Make use of the various LV and MV machines you have, and look through §bJEI§r for the automatable infinite sources of each ingredient (like §aEnderman Models§r for pearls).\n\n",
+          "desc:8": "nomifactory.quest.db.728.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37466,7 +37467,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Resonant Clathrate",
+          "name:8": "nomifactory.quest.db.728.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37507,7 +37508,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the fluid counterpart to the standard §aME Interface§r.\n\nFluids inserted into it are automatically digitized into the network, though it does have internal storage that can back up if you run out of space.\n\nYou can configure the interface to stock up to six different fluids (or for faster throughput later on, several tanks of the same fluid). You can use §aPump covers§r on §bGregTech§r machines to pull fluids from or extract fluids into an interface. This is useful for routing fluids if you\u0027re already using the output side for items or a different fluid.\n\nIt is also far more performant and scales better without lag than §aFluid Import/Export Buses§r.",
+          "desc:8": "nomifactory.quest.db.729.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37518,7 +37519,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluid Interface",
+          "name:8": "nomifactory.quest.db.729.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37559,7 +37560,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Working with fluids is a bit tricky. AE2 §aPatterns§r have no notion of fluids, meaning that you have to §ededicate separate machines to specific fluid combinations§r, ensuring they remain stocked.\n\nAE2 has a §aFluid Import Bus§r and §aFluid Export Bus§r, and this is the usual go-to for players experienced with AE2. A §aCapacity Card§r will let you export or import five specific chemicals through a single bus, which is enough for, say, §3Chemical Reactors§r. However, §cexcessive use of AE2 buses will cause lag§r.\n\nA better approach for §bGregTech§r machines is using a stocked §aFluid Interface§r and a §aPump§r or a §aFluid Regulator§r. This works almost identically to passive autocrafting with Robot Arms, and §aFluid Filters§r can allow routing specific fluids to adjacent machines. This method is much more performant, scaling without causing lag like buses. For machines from other mods, you can route fluids from a Fluid Interface with conduits.\n\n",
+          "desc:8": "nomifactory.quest.db.730.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37570,7 +37571,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Fluids and Autocrafting",
+          "name:8": "nomifactory.quest.db.730.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37598,7 +37599,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your §3Chemical Reactors§r will be making a lot of different fluids. You\u0027ll need to manage the logistics of routing and storing all the different fluids you\u0027re automating.\n\nWherever possible, having one Chemical Reactor output directly into another machine that needs its output chemical saves you from having to figure out additional storage and routing. §aFluid Filters§r and §aPump covers§r are very useful for moving fluids around a compact processing pipeline.\n\nBut what about the final output fluids that you need elsewhere?\n\nOne option is to use the output tanks of the Chemical Reactors as a small storage buffer, letting it back up and stop crafting automatically. A §aFluid Storage Bus§r on the machine will expose the fluid to your ME Network. Whenever you need some of this fluid, your AE2 system will pull the needed fluid out and the machine will resume processing.\n\nThere\u0027s some catches with this approach though. First is that the inaccessible input tanks will also show up in AE but you won\u0027t be able to access them. You will want to set the Storage Bus to §eExport Only§r so AE doesn\u0027t try to store random fluids in the Chemical Reactor, and you may want to §ereduce the priority§r of the Storage Bus as well: this will signal to AE that you want it to remove fluids from that location first. Also, if multiple fluids are produced, §ethe machine will not resume processing if it doesn\u0027t have room for all fluid outputs§r.\n\nWhen you get access to them, it\u0027s probably just better to use single-fluid-formatted §aFluid Storage Cells§r and dump outputs into AE via Fluid Interfaces. You can fill up the cells, then pull the fluids out wherever else you need them.\n\n",
+          "desc:8": "nomifactory.quest.db.731.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37609,7 +37610,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Fluid Logistics",
+          "name:8": "nomifactory.quest.db.731.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37637,7 +37638,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Hard Carbon Alloy§r is an alloy made from §2Steel§r and §6Diamonds§r.",
+          "desc:8": "nomifactory.quest.db.732.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37648,7 +37649,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Hard Carbon Alloy",
+          "name:8": "nomifactory.quest.db.732.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37689,7 +37690,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aDraconic Evolution Information Tablet§r contains useful information about the mod as well as diagrams for valid Fusion Crafting block placement.\n\nYou might also be interested in the §oDraconic Evolution Fusion Core Automation§r guide linked to in §9#omnicompendium§r in the official §5Nomifactory§r Discord server.",
+          "desc:8": "nomifactory.quest.db.733.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37700,7 +37701,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconic Evolution Information Tablet",
+          "name:8": "nomifactory.quest.db.733.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38074,7 +38075,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§eUSE JEI!!!§r\n\n§bJEI§r stands for §bJust Enough Items§r. It\u0027s the list of all items that you see every time you open your inventory. It\u0027s the better(tm) recipe book that shows you all available items and recipes in the modpack.\n\nTo see it in action, pull up a quest that requires an item of some sort and just click the item!\n\nIf you want to know how to craft an item, just hover your mouse over it and press §6R§r. JEI will list all available recipes.\n\nIf you instead want to know what recipes use an item, hover over it and press §6U§r.\n\nHover over an item and press §6A§r to bookmark it. To remove a bookmarked item from the list, press A on the bookmark.\n\nOne of the remarkable features of JEI is that it\u0027s also capable of helping you with recipes. Right-click a crafting table, look up the recipe you need and press the §a[+]§r button: if you have all required items for the recipe, this will put them all into the crafting table for you.",
+          "desc:8": "nomifactory.quest.db.743.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38085,7 +38086,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Use JEI! Use JEI! USE. JEI.",
+          "name:8": "nomifactory.quest.db.743.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38113,7 +38114,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "That\u0027s a lot of foil. §2These use Platinum Foil instead of Electrum now.§r\n\nThese boards are required for §6Crystal Circuits§r, as well as the future basis of §6Wetware Lifesupport Circuit Boards§r. These will get you from tier five to tier eight.",
+          "desc:8": "nomifactory.quest.db.744.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38124,7 +38125,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Multi-Layer Fiber-Reinforced Epoxy Substrate",
+          "name:8": "nomifactory.quest.db.744.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38177,7 +38178,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Not glowing.\n\nThis one takes a significant amount of time to cook, so make sure to have it going constantly.\n\n§6Signalum§r is noteworthy as the long-awaited next tier upgrade for your §bThermal Expansion§r machines and dynamos following \"Reinforced\" back in MV.",
+          "desc:8": "nomifactory.quest.db.745.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38188,7 +38189,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Signalum",
+          "name:8": "nomifactory.quest.db.745.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38229,7 +38230,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A very power-efficient, if slow before upgrades, means of creating plates. Also the only way to directly make plates from single gems.\n\nUpgrading the machine tier with §aUpgrade Kits§r and applying §aAugments§r to boost its crafting speed is a good idea.",
+          "desc:8": "nomifactory.quest.db.746.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38254,7 +38255,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Compactor",
+          "name:8": "nomifactory.quest.db.746.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38310,7 +38311,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r.\n\n",
+          "desc:8": "nomifactory.quest.db.747.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38321,7 +38322,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dark Steel Enchanter",
+          "name:8": "nomifactory.quest.db.747.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38362,7 +38363,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §3Compactor§r§r§r specialized to a §aGear Press§r is a very power efficient way to make gears. It is slower than its overclocking GTCE counterparts, but is required for some gears, most notably the crystal and gemstone ones.\n\nLike all §aAugments§r, the Gear Press specialization takes up an upgrade slot, but you can still use the rest of the slots for other ones like speed upgrades.",
+          "desc:8": "nomifactory.quest.db.748.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38373,7 +38374,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Gearworking Die",
+          "name:8": "nomifactory.quest.db.748.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38416,7 +38417,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Upgrade time! \n...or building a new one, which is probably better.\n\nYet again this quest asks for the minimal number of casings. Make an extra 28 if you don\u0027t want more than §a2 Fluid Inputs§r§r and §a1 Fluid Output§r.\n\nIf you insist on upgrading instead of making a new one, don\u0027t dismantle the current one before you\u0027re sure you\u0027ve got everything you need to upgrade it, or you might end up having to rebuild the §3Mark 1 Fusion Reactor§r again.\n\nThe §3Mark 2 Fusion Reactor§r has an energy buffer of §e320M EU§r.",
+          "desc:8": "nomifactory.quest.db.749.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38427,7 +38428,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fusion Reactor MK2",
+          "name:8": "nomifactory.quest.db.749.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38492,7 +38493,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A complex material from §bThermal Expansion§r cooked in an §3Electric Blast Furnace§r.\n\n§6Enderium§r doesn\u0027t require much power (running on as little as MV) but it does need a lot of heat and is incredibly slow without overclocking. §2You can use small amounts of Krypton from Liquid Ender Air distillation to significantly decrease the smelting time.§r\n\nAs with all later blast furnace materials, dedicate a furnace to keeping these in stock and have it running constantly to ensure a stable supply (turning it off when you have an acceptably vast stockpile).\n\nIn addition to its other uses, Enderium gets you access to §aResonant Upgrade Kits§r for machines and the §6Resonant Satchel§r. These quests can be found on the §eProgression§r tab.\n\n",
+          "desc:8": "nomifactory.quest.db.750.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38503,7 +38504,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Enderium Ingot",
+          "name:8": "nomifactory.quest.db.750.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38544,7 +38545,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Aqueous Accumulators§r in §5Nomifactory§r are infinite water sources; they §l§ndo not§r require any water blocks nearby.\n\nThis machine can produce §9Water§r as fast as you can extract it (the only downside being that it makes some annoying noises).\n\nFriendship with §aEndervoirs§r ended.",
+          "desc:8": "nomifactory.quest.db.751.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38568,7 +38569,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinitest Water",
+          "name:8": "nomifactory.quest.db.751.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38622,7 +38623,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Universal Crystallizer§r can make §6Crystal Matrix Ingots§r at about a ninth of the §6Diamond§r cost, makes §6Wyvern§r and §6Awakened Cores§r and §6Awakened Draconium§r far faster than §3Fusion Crafting§r, and crafts §6Empowered Blocks§r without hassle.\n\nThis is the final machine you will make, and the most costly. You will need §d12 Hearts of a Universe§r and §d80 Chaos Shards§r, among others.\n\nIt requires a small amount of Enriched Naquadah to run, and an immense amount of power - but with §6Creative RF Source§r, it shouldn\u0027t be a problem.",
+          "desc:8": "nomifactory.quest.db.752.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38633,7 +38634,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Universal Crystallizer",
+          "name:8": "nomifactory.quest.db.752.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -38716,7 +38717,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Carry the most stuff.\n\nIf you need more space than this, enchant it with §aHolding IV§r.",
+          "desc:8": "nomifactory.quest.db.753.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38730,7 +38731,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Resonant Satchel",
+          "name:8": "nomifactory.quest.db.753.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38787,7 +38788,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Before you travel to the Moon, you\u0027ll want to set up a way to easily return.\n\nLay out nine of the §6Telepad Blocks§r in a 3x3 pattern. They should turn into a multiblock. While having some §6Paper§r in your inventory, use the §aCoordinate Selector§r to create a §6Location Printout§r of an area near the Telepad. Keep track of this Printout and make sure to bring it with you to the Moon!\n\nMake sure the Telepad on the Overworld is ready to go. It needs power, a tank of §9Dew of the Void§r, and the chunk it\u0027s in needs to be §eChunkloaded§r. Bring the other nine Telepad Blocks with you when you go to the Moon, and once there, set up a similar layout. The one on the Moon will also need power, Dew of the Void and its chunk loaded. Consider making a solar panel and a capacitor bank to keep it powered.\n\nOnce your Moon Telepad is up and running, put your Overworld coordinates into it. Then record your current location on the Moon with the Coordinate Selector. Teleport home, and put those coordinates into the Overworld Telepad. Now you can travel back and forth easily!\n\nYou might consider building a room dedicated to Telepad transit, both on the Overworld and to other Planets, and label them. You\u0027ll be visiting many other worlds soon enough.",
+          "desc:8": "nomifactory.quest.db.754.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38798,7 +38799,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Telepad",
+          "name:8": "nomifactory.quest.db.754.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38851,7 +38852,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bBuilding Gadgets§r.\n\nThese devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn\u0027t make them from nothing.\n\nAlso important to note that it won\u0027t work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines).\n\nBy default, the config GUI is bound to §6G§r.",
+          "desc:8": "nomifactory.quest.db.755.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38868,7 +38869,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Inspector Gadget",
+          "name:8": "nomifactory.quest.db.755.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38947,7 +38948,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Taranium§r is an exotic material found in tiny quantities from... §6Stone Dust§r.\n\nProcess Stone Dust through a long chain (and enjoy the byproducts), and eventually, you\u0027ll reach the §6Taranium Dust§r. It\u0027s used in several powerful endgame tools, such as §6UV Field Generator§r and §3Advanced Ore Drilling Plant II§r. ",
+          "desc:8": "nomifactory.quest.db.756.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38958,7 +38959,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Taranium",
+          "name:8": "nomifactory.quest.db.756.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -38998,7 +38999,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You may have noticed that The End portals in Strongholds are disabled.\n\nThe only way to access The End is to... §ebake a cake§r. You can refill it with §6Eyes of Ender§r.\n\nPrepare some gear, eat a slice, and get ready for a fight!",
+          "desc:8": "nomifactory.quest.db.757.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39009,7 +39010,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The End...?",
+          "name:8": "nomifactory.quest.db.757.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39050,7 +39051,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Find a clever way to make the Ender Dragon\u0027s Egg to fall onto a torch. This neat trick will turn it into a collectible item so you can bring it home with you.\n\nYou might be interested in getting yourself a §3Dragon Egg Mill§r to place it on for free 500 GP.",
+          "desc:8": "nomifactory.quest.db.758.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39061,7 +39062,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Egg Thief",
+          "name:8": "nomifactory.quest.db.758.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39108,7 +39109,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Fire Water§r is a great way of producing §6Grains of Infinity§r. Spill a bucket over a patch of bare bedrock and watch it drop grains every so often. There\u0027s a 2% chance per random tick for one to be generated on each block of bedrock the Fire Water is flowing on.\n\nMake sure to chunkload the area.",
+          "desc:8": "nomifactory.quest.db.759.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39123,7 +39124,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fire Water",
+          "name:8": "nomifactory.quest.db.759.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39180,7 +39181,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you\u0027ve dealt with the dragon, seek the bedrock structure floating mid-air around the edge of the main island.\n\nCarefully throw an §6Ender Pearl§r inside one (where there\u0027s a portal-looking texture) to teleport to a distant island.\n\nOnce there, gather some §6Chorus Flowers§r. You\u0027ll have to smash the flower itself to get it: simply breaking the stem of a plant will not drop the flower.\n\nAnd finally, obtain some §6Draconium Dust§r. Its ore spawns in small quantities, but should be everywhere.\n\nTo get back to the main island, throw an Ender Pearl into another bedrock portal structure.\n\n",
+          "desc:8": "nomifactory.quest.db.760.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39191,7 +39192,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Outer Islands",
+          "name:8": "nomifactory.quest.db.760.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39238,7 +39239,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Dislocator Pedestals§f are a very simple way of inter-dimensional transport.\n\nHold a §6Dislocator§f in your hand and §6sneak-right click§f to bind it to your position. Now, place it inside a Pedestal so you can travel to the bound spot anytime you want.\n\nBefore going to the Moon, you\u0027ll need §etwo Dislocators§f and §etwo Pedestals§f.\n\nBind one Dislocator to a location in the Overworld, then take it with you to the Moon and put it down on a Pedestal.\n\nBind the other Dislocator to a location on the Moon, then use the first Pedestal to return home. Place the second Dislocator on the second Pedestal, then you can warp between the two locations at will. Neat!\n\n§aTip: Dislocators don\u0027t lose durability on use when placed in a Pedestal!",
+          "desc:8": "nomifactory.quest.db.761.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39249,7 +39250,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Thinking with Dislocators",
+          "name:8": "nomifactory.quest.db.761.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39297,7 +39298,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have §einterdimensional teleportation§r, you can travel to and from the Moon without launching a rocket each way.",
+          "desc:8": "nomifactory.quest.db.762.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39308,7 +39309,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Interdimensional Transport",
+          "name:8": "nomifactory.quest.db.762.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39337,7 +39338,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A good, but slightly gated way of teleporting back to your telepads.\n\nIt won\u0027t be possible to make this until you reach EV tier power.",
+          "desc:8": "nomifactory.quest.db.763.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39348,7 +39349,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Rod of Return",
+          "name:8": "nomifactory.quest.db.763.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39391,7 +39392,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are LV, and can all be substituted in recipes.\n\n§7§2Electronic Circuits§r are the worst in terms of cost and effort required to produce, but you have to start with something.\n\n§2§2Integrated Circuits§r are the middle layer between §2Electronic Circuits and Microprocessors.§r\n\nAnd finally, §2Microprocessors§r, which take the lowest effort.",
+          "desc:8": "nomifactory.quest.db.764.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39402,7 +39403,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Circuits",
+          "name:8": "nomifactory.quest.db.764.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39425,7 +39426,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Progression tab was added so you can keep track of the important bits of the pack.\n\nCircuits are the baseline of the entire Nomifactory progression, so keep climbing!",
+          "desc:8": "nomifactory.quest.db.765.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39436,7 +39437,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "What is This?",
+          "name:8": "nomifactory.quest.db.765.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39467,7 +39468,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are MV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.",
+          "desc:8": "nomifactory.quest.db.766.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39478,7 +39479,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Circuits",
+          "name:8": "nomifactory.quest.db.766.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39504,7 +39505,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are HV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.",
+          "desc:8": "nomifactory.quest.db.767.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39515,7 +39516,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "HV Circuits",
+          "name:8": "nomifactory.quest.db.767.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39541,7 +39542,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are EV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.",
+          "desc:8": "nomifactory.quest.db.768.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39552,7 +39553,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "EV Circuits",
+          "name:8": "nomifactory.quest.db.768.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39578,7 +39579,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are IV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.",
+          "desc:8": "nomifactory.quest.db.769.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39589,7 +39590,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "IV Circuits",
+          "name:8": "nomifactory.quest.db.769.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39615,7 +39616,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are LuV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.\n\nMake sure to set up the wetware board production as soon as possible! These take a very long time to make.\n\nIt\u0027s LuV, not LUV.\n",
+          "desc:8": "nomifactory.quest.db.770.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39626,7 +39627,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LuV Circuits",
+          "name:8": "nomifactory.quest.db.770.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39651,7 +39652,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are ZPM, and can all be substituted in recipes.",
+          "desc:8": "nomifactory.quest.db.771.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39662,7 +39663,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ZPM Circuits",
+          "name:8": "nomifactory.quest.db.771.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39685,7 +39686,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are UV, and can both be substituted in recipes.",
+          "desc:8": "nomifactory.quest.db.772.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39696,7 +39697,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "UV Circuits",
+          "name:8": "nomifactory.quest.db.772.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39753,7 +39754,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Lathe§r is an important machine that makes rods less expensive to craft.",
+          "desc:8": "nomifactory.quest.db.774.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39764,7 +39765,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Lathe",
+          "name:8": "nomifactory.quest.db.774.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39805,7 +39806,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2GregTechCEu§r adds an §einteractive in-world preview§r for all §bGregTech§r multiblocks! §6Shift-right-click§r a placed controller §2with an empty hand§r to activate a hologram depicting the default layout of the structure to help you with building. As you place blocks, the structure will be validated and the §efirst incorrect block§r it detects will be highlighted in red.\n\n§6Sneak-right-click§r to cycle from the full view through each layer. When on the final layer of the preview, this will remove the preview.\n\n§6Sneak-left-click§r to go back to the previous layer, or close the preview from the full view.\n\nIn the §eJEI previews§r for multiblocks, §6left-click§r and drag the mouse to rotate the preview.\n\nAdditionally, you can §6right-click§r and drag the mouse to pan the preview or §6shift-right-click§r and drag to zoom in or out.\n\nSome blocks in the multiblock preview have additional tooltips to provide more information on how the multiblock can form.",
+          "desc:8": "nomifactory.quest.db.775.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39816,7 +39817,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Multiblock Machine Previews",
+          "name:8": "nomifactory.quest.db.775.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39844,7 +39845,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Awakened Cores§6§r are the third tier of §bDraconic Evolution§r core, and are common components of endgame recipes.\n\nThese cores are made with §6Awakened Draconium§r and also cost §e3 Billion RF§r to craft.",
+          "desc:8": "nomifactory.quest.db.776.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39855,7 +39856,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Awakened Core",
+          "name:8": "nomifactory.quest.db.776.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39896,7 +39897,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Diamantine Crystal§6§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.777.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39907,7 +39908,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Diamantine Gear",
+          "name:8": "nomifactory.quest.db.777.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39948,7 +39949,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have §6Awakened Cores§r, you can make the §eEnergy Storage Core§r from §bDraconic Evolution§r. It\u0027s a great way to store all the energy required to craft power-hungry late game items.\n\nThe §eEnergy Storage Core§r is a multiblock structure that can be upgraded to store increasingly immense amounts of RF energy. See the §bDraconic Evolution§r manual for more information on the material requirements for each tier.\n\n§2You cannot use regular Draconium Blocks to build this structure. You must treat it with Enriched Naquadah to make Activated Draconium before it can be used in the Energy Storage Core.\n\n§6Energy Pylons§r are required to input and output energy from the core. Each pylon allows movement in a single direction, so you need at least two.\n\nOnce you have the materials together for your desired tier, § the structure can build itself: simply access the GUI of the §6Energy Core§r, set the tier, and click Assemble. Items will be automatically used from your inventory. Once the structure is built, you can access the core\u0027s GUI again through §6Energy Core Stabilizers§r to activate it.\n\nIt is recommended to postpone Tier 8 until after you reach the §dCreative Portable Tank§r, as it requires large amounts of §2Activated §6Awakened Draconium§r.\n\n",
+          "desc:8": "nomifactory.quest.db.778.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39959,7 +39960,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Power Storage on a Massive Level",
+          "name:8": "nomifactory.quest.db.778.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -40006,7 +40007,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Cobblestone can be processed into many useful materials:\n\n§6Stone Dust§r is useful for small amounts of a whole host of useful materials.\n\n§6Gravel§r is useful for making conduits and §9Concrete§r.\n\n§6Sand§r is useful for §6Glass§r, which can be turned into §6Nether Quartz§r or §6Silicon Dioxide§r for §6Oxygen§r.\n\nFinally, §6Dust§r can be turned into §6Netherrack§r.\n\nSet up a §ecobbleworks§r soon, so you can stockpile all these useful materials.\n",
+          "desc:8": "nomifactory.quest.db.779.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40017,7 +40018,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Infinite Cobblestone",
+          "name:8": "nomifactory.quest.db.779.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40074,7 +40075,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §eNether§r contains quite a few useful resources:\n- Some initial pieces of §6Sulfur§r\n- §6Glowstone§r and §6Soul Sand§r\n- §6Fluorine§r, §6Certus Quartz§r, §6Molybdenum§r, §6Antimony§r, and §6Gold§r-bearing ores\n- §9§2Nether Air§r, which can be distilled for useful gases\n- §eLava§r and §eNatural Gas§r from §2Fluid Rigs\n\n§rNether ores also contain §ddouble§r the resources per ore block compared to Overworld ores.",
+          "desc:8": "nomifactory.quest.db.780.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40085,7 +40086,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2To the Nether",
+          "name:8": "nomifactory.quest.db.780.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -40166,7 +40167,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Large Turbines have been improved in CEu. They are quite complex to run, but can generate lots of power when done well and scale very well.§r\n\nRight now, you can make the §6Large Steam Turbine§r and §6Large Gas Turbine§r. Once you get a §3Fusion Reactor§r going, you can make the §6Large Plasma Turbine§r.\n\nEach Large Turbine will need a §3Rotor Holder§r of the same or higher tier than the Large Turbine itself, and a §3Dynamo Hatch§r capable of handling the energy output. Each §3Rotor Holder§r tier above the Large Turbine §ddoubles§r the energy production and adds 10% to fuel efficiency.\n\nYou will need a §aRotor§r to go into each §3Rotor Holder§r§r. The Rotor will grant multiplicative Power and Efficiency bonuses depending on its material. Each Rotor also has a Durability, which is the number of seconds it will last.\n\n§aExample: §r§6Large Gas Turbine§r, with §3HSS-E Rotor§r and §3IV Rotor Holder§r:\n§aProduction:§r 4096 * 2.80 * 2 \u003d 22938 EU/t (91752 RF/t)\n§aEfficiency:§r 1.40 * 1.10 \u003d 154.0%\n§aDurability:§r 205,600 s (57.1 h)\n\nYou can run the §6Large Gas Turbine§r off §9LPG§r and §9Methane§r from §3Fluid Rigs§r, or §9Nitrobenzene§r from §6Wood§r.\nThe best §6Large Steam Turbine§r fuel is a closely-guarded government secret.",
+          "desc:8": "nomifactory.quest.db.783.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40177,7 +40178,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Large Turbines",
+          "name:8": "nomifactory.quest.db.783.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40204,7 +40205,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "These are the basic cables used by §3Applied Energistics§r to transport network connectivity. Due to the fact that channels are disabled, these cables will be your main method of transporting network connectivity, rather than the dense cables.\n\nThese cables do not share blockspace with conduits or cables for other mods, so they can be somewhat unweildy to build with, but they do accept §3Applied Energistics§r§6§r §6Facades§r, so they can be hidden very easily.\n\nLater you can make a variant of the cable that can share blockspace with §3Ender IO§r conduits.",
+          "desc:8": "nomifactory.quest.db.784.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40215,7 +40216,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "ME Cables",
+          "name:8": "nomifactory.quest.db.784.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40255,7 +40256,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Rubber§r has been sufficient for making cables so far, but you will soon discover that this basic type of rubber won\u0027t withstand more than §2Extreme Voltage§r. Higher quality rubber is necessary to properly insulate your wires.\n\nThere are two better types of rubber, and you will eventually need to make both of them. §eThese can also be used for insulating lower voltage wires more efficiently, requiring less fluid§r!\n\n§9§2Both Styrene-Butadiene Rubber (SBR) and Silicone Rubber (SiR) can wrap any Cable tier.§r However, SBR requires petrochemistry infrastructure you may not have yet, and is not mandatory until you are making late-game components. On the other hand, SiR can conveniently be made from chemicals you are already familiar with. By setting this up now, you won\u0027t have to change your wire coating material later!\n\nTo make Silicone Rubber, you will need to create §6Polydimethylsiloxane Dust§r in one of several ways, then mix it with §6Sulfur§r in a §3Chemical Reactor§r. You can then coat wires with it in an §3Assembling Machine§r.\n\n",
+          "desc:8": "nomifactory.quest.db.785.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40270,7 +40271,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2New Cable Coverings",
+          "name:8": "nomifactory.quest.db.785.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40307,7 +40308,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bEffortless Building§r is a mod that makes it much easier to build. You can create large platforms or various other shapes in just a few clicks, and even build multiple identical structures at the same time!\n\nTo use §bEffortless Building§r, start by pressing and holding the §6Alt§r key. This opens a wheel-shaped menu displaying §especial building modes§r. With this menu open, simply move your cursor over the desired building mode and release §6Alt§r. This will select that mode and you can begin building.\n\nChoose the starting location for your shape by §6right-clicking§r on a blockspace while holding your desired building block. Next, move your cursor to another blockspace to see a preview of the final structure. §6Right-click§r again on the desired ending block to actually build the shape from blocks in your inventory.\n\nMost shapes are flat and are defined using a starting and ending location, but 3D shapes have a third location to complete the shape. Some special modes also have §eoptions§r, like making a §ehollow cube§r instead of a §efilled cube§r.\n\nIf you made a mistake, you can use the §aUndo§r button in the menu to break the blocks you just placed so you can collect them and try again.\n\nTo change building modes, just open the menu with §6Alt§r as before and pick a different one. To exit the special building modes, select the §eNormal§r mode.\n\n§cMake sure you return to Normal mode when you\u0027re done building shapes, since the special building modes will interfere with normal gameplay.§r\n\nThe size of shapes you can make in special building modes is limited by your §ereach§r, which is how far away you can click from yourself to start building, or from the previous location to complete a shape. You can craft and eat several tiers of §areach upgrades§r in succession to increase your reach to very high numbers.\n\nOverall, §bEffortless Building§r is a powerful mod that is very useful for construction. Experiment with it and you\u0027ll see how much time it can save you!",
+          "desc:8": "nomifactory.quest.db.786.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40318,7 +40319,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Effortless Building",
+          "name:8": "nomifactory.quest.db.786.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40347,7 +40348,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Farming Station§r is a machine that automates growing and harvesting trees and crops around it, based on what items you put in it.\n\nThe Farming Station will principally collect crops, saplings, and wood, but it will also collect things like §6Apples§r from Oak Trees and §6Sticky Resin§r from Rubber Trees. It can also collect leaves if you want it to.\n\nLike other §bEnderIO§r machines, it requires an §6RF capacitor§r. The quality of capacitor affects the overall size of the farm as well as the speed and energy at which it operates.\n\nYou can configure which crops or tree types will be planted relative to the Farming Station by placing the crop or sapling in the various quadrants in the GUI. Clicking the lock button will ensure that the stack placed there won\u0027t be completely consumed, as that could lead to plants migrating to other quadrants.\n\nIn addition to power, the Farming Station§r requires specific §etools§r (and usually a supply of §9Water§r) to operate. If you\u0027re missing anything, the machine will refuse to operate and displays a message over itself to let you know.\n\nFor planting §6crops§r or §6saplings§r, you need a §aHoe§r.\nFor chopping §6trees§r, you need an §aAxe§r. To collect §6leaves§r, you also need §aShears§r.\n\nTool durability is consumed as the farm performs work, so the tools will eventually break. You can make §aStone Tools§r from a cobblestone generator and some sticks, or even §aDiamond Tools§r using diamonds from your §3Deep Mob Learning§r setup.\n\nAlternately, you can invest in fancier tools such as th§re §aDark Backhoe§r (which is designed for use in the Farming Station), or even unbreakable tools much later like the §aFlux Infused Axe§r and §aOmniwrench§r (shears).\n\nThe Farming Station also has a lesser-known feature: it respects enchantments and upgrades on your tools. Tools with §eEmpowered§r upgrades will be ejected into the output slots when they run out of charge (if they don\u0027t break first). Tools with the §eMending§r enchantment are similarly ejected when they are about to break.\n\nYou can use these properties to your advantage.\n\n",
+          "desc:8": "nomifactory.quest.db.787.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40358,7 +40359,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Farming Station",
+          "name:8": "nomifactory.quest.db.787.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40398,7 +40399,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Smart Item Filter§r from §3GregTech§r is an important tool when automating otherwise troublesome machines. It is a cover which filters item transfer based on whether a valid recipe exists for those items in a specified machine.\n\nThis is powerful in combination with movement covers like the §6Robot Arm§r. If you place this filter on the §eElectrolyzer§r mode in a Robot Arm set to §eSupply Exact§r mode, the Robot Arm will transfer precisely the right amounts of all valid items into an §3Electrolyzer§r so it will operate without clogging. There\u0027s no other way to accomplish this feat!\n\nThis filter also has §eSifter§r and §eCentrifuge§r§r modes for use with those machines. It does not have modes for any other machines.\n\nThe §eDefault§r button lets you click it to §eIgnore Fluids§r, which is useful when you have recipes that also require fluids (like §9Hydrogen§r in an Electrolyzer). Since Robot Arms can\u0027t move fluids, it would otherwise prevent the cover from working.\n",
+          "desc:8": "nomifactory.quest.db.788.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40409,7 +40410,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Smart Item Filter",
+          "name:8": "nomifactory.quest.db.788.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40449,7 +40450,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aFilters§r are a type of machine cover that controls what items or fluids are allowed to pass through it. They can be used directly on the side of a machine to affect external automation or the Machine\u0027s §aAuto-Output Functionality§r.\n\nYou can also §eplace filters inside of other covers§r to control what items or fluids that cover will interact with. When used in a §6Robot Arm§r, §aItem Filters§r make for a powerful automation tool for §ekeeping specific items in stock§r in specific quantities in Machines. With §6Fluid Regulators§r, similar behavior is possible with fluids using a §aFluid Filter§r. For §6Conveyors§r and §6Pumps§r, it simply limits what that cover will move.\n\n§aFilters§r all have 9 configurable slots and whitelist/blacklist modes, and can be applied to multiple sides of machines. When placed inside a §6Robot Arm§r in §eKeep Exact§r or §eSupply Exact§r mode§r, the item count in a filter can be incremented by §eRight Clicking§r and decremented by §eLeft Clicking§r. Holding §eShift§r causes the count to increase/decrease by a factor of 2. This controls the number of each type of item that will be kept in stock or moved at a time.\n\nSimilar controls are available for the §aFluid Filter§r when placed inside a §6Fluid Regulator§r.\n\nAdditionally, the §aOre Dictionary Filter§r§r is a powerful tool that has a specialized filter which uses ore dictionary entries and §2uses regular expressions (regex)§r, e. g. \"§6ingotHot*§r\" will match all hot ingots, \"§6dustRegular*§r\" will match all regular dusts, and \"§6dustTiny*§r\" will match all tiny piles.\n\nAll §bGregTech§r Filters can be configured using ghost items from §bJEI§r.",
+          "desc:8": "nomifactory.quest.db.789.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40460,7 +40461,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Filters",
+          "name:8": "nomifactory.quest.db.789.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40512,7 +40513,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Machine Controller§r is a cover that manages the operation of §bGregTech§r machines, similar to a §aSoft Hammer§r. These are crucial for §epassive automation§r, where a machine is dedicated to keeping something in stock for you.\n\n\"Machines\" here is broader than you might think. It of course works on single-block machines, but can also be used on §eMultiblock Controllers§r like your §3Electronic Blast Furnace§r. But it\u0027s even more flexible than that: you can use it on any §bGregTech§r block that accepts transfer covers, as long as the controllable cover is placed on it first! This means it also works for things like §6Chests§r, §6Drums§r, and Multiblock inputs.\n\nThe cover works by detecting a §eredstone signal§r. By default, the entire machine will be disabled if a sufficiently strong signal is detected by the cover.\n\nWhen you open the Machine Controller\u0027s GUI with a §aScrewdriver§r, you will see several options for configuring its behavior:\n\nThe strength of the signal required to trigger the Machine Controller is configurable using the top slider.\n\nAnother button allows you to select whether to control the whole machine (where applicable) or a specific cover. This lets you do things like stop moving items into a machine, but also allow the machine to continue working.\n\nSwitching from §eNormal§r to §eInverted§r mode will make the Machine Controller instead disable the machine until it receives the requisite redstone signal. This is often preferable when working with §6Level Emitters§r to prevent machines from starting up if your §eME Network§r is offline.\n\nSome use cases:\n• Control machines through vanilla redstone contraptions or a simple lever.\n\n• The §6Redstone Upgrades§r from §bStorage Drawers§r can be used when outputting into a drawer to make the drawer emit redstone that can control the machine.\n\n• When you progress to digital storage, an §6ME Level Emitter§r or §6ME Fluid Level Emitter§r can be used to emit signal based on specific items or fluids in your network.\n",
+          "desc:8": "nomifactory.quest.db.790.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40523,7 +40524,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Machine Controllers",
+          "name:8": "nomifactory.quest.db.790.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40564,7 +40565,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Processing Array§r is a §bGregTech§r multiblock that allows for processing multiple recipes in parallel in a single stucture and is extremely useful for saving space.\n\nUp to 16 of the same recipe can be processed in parallel by placing the machines for the recipe in exactly one §aMachine Access Interface§r in the multiblock structure, as well as the ingredients and non-consumable items (like §6Integrated Circuits§r) for the recipe you want to process in one or more input buses. While a recipe is running, the Machine Access Interface is §elocked§r and machines cannot be added or removed.\n\nNote that each machine will still draw the full voltage required for the recipe, which may be more than a single §aEnergy Input Hatch§r can provide. This is why the §6Processing Array§r has an astounding Hatch limit, and can support up to §e4 Energy Inputs§r on the structure. This allows you to get the needed 16 Amps of power to the machine from a single tier-appropriate §3CEF§r.\n\nProcessing Arrays distribute their buffered power at the appropriate voltage, so there\u0027s no danger of your machines exploding if you, for example, operate 16 HV machines off one amp of IV power.\n\nBecause the required number of Inputs, Outputs, and Casings is highly variable, this quest only asks you to craft the §6Processing Array Controller§r and the §aMachine Access Interface§r. Make sure your buses and hatches are large enough to hold the ingredients and outputs for the number of parallel crafts you\u0027re attempting, and that you\u0027re providing enough power for all those machines!\n\nAn advanced feature of the Processing Array is §eDistinct Bus Mode§r. This makes the Processing Array only consider a single item input bus at a time when determining whether it can run a recipe. This is useful when recipes for a particular machine require different catalyst items, like §6Integrated Circuits§r on different configurations or §6Extruder Shapes§r.\n\nDistinct Bus Mode may be enabled or disabled via the Processing Array controller by clicking in the designated area.\n\n",
+          "desc:8": "nomifactory.quest.db.791.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40575,7 +40576,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Processing Array",
+          "name:8": "nomifactory.quest.db.791.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40622,7 +40623,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Dynamite§r is an explosive made from §9Glyceryl Trinitrate§r, which is itself made of §9Glycerol§r and §9Nitration Mixture§r. You can throw dynamite to blow things up, but it is primarily a crafting ingredient you can use in the §3Implosion Compressor§r.\n\n§6TNT§r is another explosive that could be made instead of Dynamite. It\u0027s a stronger explosive so you need fewer TNT per recipe it\u0027s used in relative to dynamite, but it has its own unique processing chain.",
+          "desc:8": "nomifactory.quest.db.792.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40633,7 +40634,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dynamite",
+          "name:8": "nomifactory.quest.db.792.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40673,7 +40674,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6TNT§r is an explosive made from §9Toluene§r, a distillation byproduct of §9Wood Tar§r or various §eSteam-Cracked Fuels§r. Besides its typical uses in Minecraft, it is a crafting ingredient you can use in the §3Implosion Compressor§r.\n\n§6Dynamite§r is an alternative explosive for the Implosion Compressor, though you need relatively more of them per craft.",
+          "desc:8": "nomifactory.quest.db.793.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40684,7 +40685,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "TNT",
+          "name:8": "nomifactory.quest.db.793.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40764,7 +40765,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Advanced System-on-Chip§r (or §6ASoC§r) is the §2penultimate§r component miniaturization. These unlock the most efficient recipe for producing §2Nanocircuits and §6Quantum Circuits§r.\n\nThe latter circuits must be made in a §aZPM Assembling Machine§r.",
+          "desc:8": "nomifactory.quest.db.795.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40775,7 +40776,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced System-on-Chip",
+          "name:8": "nomifactory.quest.db.795.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40815,7 +40816,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Naquadah-Doped Boule§r produces even more wafers per boule. It also is relatively cheap, due to the abundance of Naquadah that is gained from the §eTier 5 Micro Miner Mission§r.\n\nThis boule also allows the production of §6Advanced System on Chip§r wafers, which are used to make the final forms of the circuits very cheaply. However, you might not be able to take advantage of the §6Advanced System on Chip§r yet, due to the power requirements.",
+          "desc:8": "nomifactory.quest.db.796.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40826,7 +40827,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Boules",
+          "name:8": "nomifactory.quest.db.796.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40918,7 +40919,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Sunnarium§r is an alloy formed from §6Stabilized Plutonium§r and §6Stabilized Curium§r in an IV or better §3Alloy Smelter§r.\n\nIt is a common ingredient in higher tier §6Solar Panels§r, as well as a crucial ingredient of the §3Processing Array§r.\n\nThis stuff takes a long time to produce so consider stocking it passively.",
+          "desc:8": "nomifactory.quest.db.798.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40929,7 +40930,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Sunnarium",
+          "name:8": "nomifactory.quest.db.798.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40970,7 +40971,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Carry a whole lotta stuff!",
+          "desc:8": "nomifactory.quest.db.799.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40984,7 +40985,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Signalum Satchel",
+          "name:8": "nomifactory.quest.db.799.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41074,7 +41075,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6§3Pyrolyse Oven§r can make more interesting products than just §9Phenol§r.\n\n§a§9Charcoal Byproducts§r breaks down into various wood products, such as§9 Wood Tar§r,§9 Wood Gas§r, and §a§9Wood Vinegar§r, each of which can be further broken down into various useful chemical compounds, such as §a§9Toluene§r, §a§9Methanol§r, etc.\n\nHowever, to take full advantage of decomposing these wood products, a §6§3Distillation Tower§r is required, so that all possible outputs can be obtained. You will need more§e Distillation Tower Slices§r than requested in the§r Distillation Tower quest, so be prepared to spend some more §6Stainless Steel§r.",
+          "desc:8": "nomifactory.quest.db.801.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41089,7 +41090,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pyrolyse Products",
+          "name:8": "nomifactory.quest.db.801.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41138,7 +41139,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Fusion Coils§r are §2no longer EBF coil materials, but they are used in the next Fusion Reactors.",
+          "desc:8": "nomifactory.quest.db.802.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41149,7 +41150,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fusion Coils",
+          "name:8": "nomifactory.quest.db.802.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41189,7 +41190,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Whether or not you (or your server admin) picked the default §bLost Cities§r overworld type, you have the option of teleporting yourself to the §eLost Cities Dimension§r. This is useful if you like other world types but want to still be able to explore cities for things like §eloot and spawners§r§r.\n\nTo create a portal, you must place a §aBed§r§r down on two §6Blocks of Diamond§r. Then, you surround the bed with any kind of §eMonster Skulls§r. Sleep in this bed and you will be teleported there.\n\n§cDon\u0027t forget to have a way to get back!§r§r You can use the §e/sethome§r§r command to register where your house is, and §e/home§r§r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some §erestrictions§r on this though: §eit takes a few seconds of standing still to activate§r and there is a §ecooldown§r between uses.\n\nLater on you\u0027ll have other means of teleportation.\n\nMonster Skulls might take a little while to get if you\u0027re playing in §ePeaceful§r§r. §6Skeleton Skulls§r would be the way to go in that case.",
+          "desc:8": "nomifactory.quest.db.803.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41200,7 +41201,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Lost Cities and Registering Homes",
+          "name:8": "nomifactory.quest.db.803.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41253,7 +41254,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §a§r§3Assembly Line§r is a particularly unusual multiblock from an automation standpoint. Up until now, it has been possible to dump ingredients into a single input bus. Clearly, this won\u0027t work for the Assembly line, since it has a whole bunch of ULV inputs buses that hold one item stack each.\n\nYou might be tempted to dump everything into a chest and route items around to specific buses with §aItem Conduits§r. You\u0027ll probably find this to be slow, prone to jamming, and inflexible when you want to run different recipes.\n\nIf you\u0027ve unlocked §3§3The Empowerer§r§r, you might have considered §aPhantomfaces§r. These would certainly be an improvement over item conduits, but there\u0027s an even better solution.\n\nEnter §aItem Laser Relays§r§r: these handy tools from §bActually Additions§r allow you to create a virtual inventory out of multiple real ones; that is, you can use them to make other automation think that all of the input buses are the same inventory.\n\n§eOne important thing to note is that lasers appear to be \"placed\" on a particular block but they will interact with all adjacent (non-laser) blocks.§r Take this into account when placing them.\n\nTo start, place a laser on each of the input buses. Then, place the §a§aItem Interface§r adjacent to the laser on the first input bus. This will serve as the access point to the virtual inventory where you can connect things like an §3Unpackager§r or §aME Interface§r.\n\nTake your §aLaser Wrench§r and right click the first laser relay, then the second laser relay, to link them together. Repeat this with the second and third relays, third and fourth relays, etc. until they have all been linked together. Now you have a laser network virtualizing all of the input buses!\n\n§cWarning: be careful not to place a second laser on a laser network adjacent to the network\u0027s Item Interface. This will immediately crash your game because it creates a cycle in the network. You will have to either restore from backup or edit the level.dat directly to remove the block to play again.§r\n\nIf you need to do recipes with an §6§6Integrated Circuit§r, you can leave it in an input bus and skip placing a laser there. Remember to always use §eBlocking Mode§r when connecting the laser network to on-demand crafting. As long as you do, you can have §edifferent circuits in the Assembly Line without recipe conflicts§r. If you don\u0027t use Blocking Mode, you are likely to accidentally craft something else and jam your Assembly Line.",
+          "desc:8": "nomifactory.quest.db.804.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41264,7 +41265,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Assembly Line Automation",
+          "name:8": "nomifactory.quest.db.804.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41350,7 +41351,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2You only need this step if you are using normal Chemical Reactors. If you are using LCRs, the Allyl Chloride step is skipped.\n\n§9Allyl Chloride§r provides an alternative means of producing §9Epichlorohydrin§r for §9Epoxy§r.\n\nReacting §9Chlorine§r and §9Propene§r will produce Allyl Chloride. Propene is distilled in a §3Distillation Tower§r from any of various cracked petroleum products like §9Steam-Cracked Naphtha§r.",
+          "desc:8": "nomifactory.quest.db.806.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41365,7 +41366,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Allyl Chloride",
+          "name:8": "nomifactory.quest.db.806.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41393,7 +41394,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Plant some crops, fluid extract some seeds, bam! §9Seed Oil§r.",
+          "desc:8": "nomifactory.quest.db.807.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41404,7 +41405,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Seed Oil",
+          "name:8": "nomifactory.quest.db.807.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41448,7 +41449,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§5Nomifactory§r has an official Discord server which serves as a useful community resource.\n\nOn the server, the dev team posts links to in-depth guides on a variety of topics related to the pack, makes development announcements, assists with tech support questions, and investigates possible bug reports.\n\nYou can also chat with many fellow players there if you like, who are largely willing to help with general questions one might have.\n\nTo join the server, you can use the button on the Main Menu to go to the join URL, or if you\u0027re not into Discord you can find our projects on GitHub at our organization page: §9https://github.com/Nomifactory§r.\n\nIssue tracking and development, including many community-submitted guides, is handled on our respective GitHub project repositories.\n\n§2This fork\u0027s GitHub page can be found at §9https://github.com/m2r1k5/nomi-ceu§2",
+          "desc:8": "nomifactory.quest.db.808.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41459,7 +41460,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Discord and GitHub",
+          "name:8": "nomifactory.quest.db.808.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41486,7 +41487,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Vanadium Pentoxide§r is a catalyst used in the production of §9Sulfuric Acid§r and §9Phthalic Anhydride§r. It\u0027s also the way you get §6Vanadium§r metal.\n\nYou will need §6Salt§r, §9Ammonia§r, and §9Hydrochloric Acid§r for the multi-step processing of §6Vanadium Magnetite Ore§r into §6V₂O₅§r.",
+          "desc:8": "nomifactory.quest.db.810.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41497,7 +41498,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vanadium Pentoxide",
+          "name:8": "nomifactory.quest.db.810.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -41572,7 +41573,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Check out the new Material Tree tab! It will show you nearly all the different forms of a GregTech material (Plates, Rods, Screws, Dusts...) on a single page. You can then click on those to see their recipes.",
+          "desc:8": "nomifactory.quest.db.813.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41583,7 +41584,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Material Tree",
+          "name:8": "nomifactory.quest.db.813.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41610,7 +41611,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Technically not new to CEu, but it was disabled in the original version, and it had much less functionality in CE.§r\n\nThe Arc Furnace allows you to make §6Annealed Copper§r, which will be used in the MV Age. It can also make 2 pieces of Glass from 1 Sand. Later, it can make §2Tempered Glass§r§r for use in higher-tier recipes.\n\nThe Arc Furnace also functions as a §auniversal recycling machine§r. Pretty much anything can be recycled into ingots and dusts of its base components.\n\nAll of its recipes require Oxygen.\n\nAll Arc Furnace recipes use exactly 30 EU/t, so you can get away with using LV Arc Furnaces for the whole pack!",
+          "desc:8": "nomifactory.quest.db.814.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41621,7 +41622,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2LV Arc Furnace",
+          "name:8": "nomifactory.quest.db.814.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41661,7 +41662,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Bending Machine makes, depending on what Programmable Circuit it\u0027s given:\n- Plates from a single ingot (instead of the Compressor)\n- 4 Foils from a Plate (instead of the Cluster Mill, which is no more)\n- Double Plates from two Plates\n- Dense Plates from nine Plates\n- Small Springs from one Rod\n- Springs from one Long Rod. \n\nWhy was this removed?!",
+          "desc:8": "nomifactory.quest.db.815.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41672,7 +41673,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2LV Bending Machine",
+          "name:8": "nomifactory.quest.db.815.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41729,7 +41730,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Circuit Assemblers§r are the linchpin of your factory, gating progression through the §6Circuits§r. \n\nEach time you upgrade to a new voltage of Circuit Assembler, you will be able to craft more advanced §ethemes§r of circuits. These use more complex ingredients and require new infrastructure to be in place, but are more efficient to craft overall than the same tier of circuit from the prior theme.\n\n§2The LV Circuit Assembler allows you to make Electronic Circuits far more easily.\n\nThe circuit progression has been largely replaced with the progression native to CEu, with a few minor changes to reflect the progression of this pack better.§r Check out the §dProgression quest book tab§r to see the flow of circuit progression.\n",
+          "desc:8": "nomifactory.quest.db.816.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41740,7 +41741,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2LV Circuit Assembler",
+          "name:8": "nomifactory.quest.db.816.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41780,7 +41781,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Steam Grinder functions as 5.3 LV Macerators in parallel. It requires an input of Steam through a Steam Hatch, but it uses very little Steam.\n\nYou may want to consider setting up a rudimentary ore-doubling setup with it. Point the output in the direction of several upgraded Furnaces.\n\nYou may wish to wait until you have a Metal Bender at LV to reduce the cost.",
+          "desc:8": "nomifactory.quest.db.817.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41791,7 +41792,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Steam Grinder",
+          "name:8": "nomifactory.quest.db.817.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41831,7 +41832,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An advanced component used for the Circuit Assembling Machine.",
+          "desc:8": "nomifactory.quest.db.818.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41842,7 +41843,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "LV Emitter",
+          "name:8": "nomifactory.quest.db.818.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41882,7 +41883,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2With MV Batteries unlocked, you can make Power Units for electric GT tools. Most notable among them is the Drill, which at MV tier can mine a 3x3x3 area of blocks.\n\nHigher tier drills can mine 5x5x5, 7x7x7 and 9x9x9 areas! Shift-right-click to change the breaking area.\n\nCharge these with a Battery of appropriate tier, or in an appropriately tiered machine.\n\nYou may want to look into Chainsaws for mass tree felling as well. The other electric tools are probably not worth making.",
+          "desc:8": "nomifactory.quest.db.819.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41899,7 +41900,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2GregTech Drill",
+          "name:8": "nomifactory.quest.db.819.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41941,7 +41942,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Diodes are a component in the next Circuit tiers. They are made from liquid Glass, Fine Copper Wire and Gallium Arsenide, which is made in a Mixer with Gallium and Arsenic.\n\nLater, you will unlock better recipes for this.",
+          "desc:8": "nomifactory.quest.db.820.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41952,7 +41953,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Diodes",
+          "name:8": "nomifactory.quest.db.820.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41992,7 +41993,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Sodium Persulfate§r §2and Iron III Chloride§r are used to make cheaper §9Good Circuit Boards§r, as it cuts the Silver amount by a factor of four. They are also §drequired§r to make §9Plastic Circuit Boards§r.\n\nMaking §aSodium Persulfate§r will yield §aHydrochloric Acid§r as a coproduct, which you may re-use to make §aIron III Chloride§r. This should the best approach right now, but the decision is entirely yours. With more automation later in the game, Iron III Chloride will be the cheaper and more straight forward path.\n\nSodium Persulfate§r can also be used in §9Ore Processing§r in the §3Chemical Bath§r, to get various bonus outputs you would not normally obtain. It is completely optional, but pretty rewarding.",
+          "desc:8": "nomifactory.quest.db.821.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42007,7 +42008,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Sodium Persulfate and Iron III Chloride",
+          "name:8": "nomifactory.quest.db.821.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42048,7 +42049,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Phenolic Substrates need to be turned into Circuit Boards with Silver before being usable in Circuit production.\n\nSodium Persulfate and Iron III Chloride are troublesome to get right now, but using them in making Circuit Boards will reduce the amount of Silver required by 4 times.",
+          "desc:8": "nomifactory.quest.db.822.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42059,7 +42060,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Good Circuit Boards",
+          "name:8": "nomifactory.quest.db.822.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42099,7 +42100,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This quest accepts an LV or MV Sifter.\n\nThe Sifter gets you Flawless and Exquisite Gems from Crushed Purified Gem Ores. Overall it results in a higher yield. Higher tiers of Sifter increase the yield further.\n\nYou will need small quantities of Flawless Emeralds for MV Emitter and Sensor components.",
+          "desc:8": "nomifactory.quest.db.823.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42110,7 +42111,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Sifter",
+          "name:8": "nomifactory.quest.db.823.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42150,7 +42151,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The successor of Small Coils, Inductors are another circuit component you will need.\n\nFor the best results, use Nickel Zinc Ferrite and Annealed Copper to make these.\n\nBut depending on which setups you build first, you may not need to make many of the basic version over the SMD version.",
+          "desc:8": "nomifactory.quest.db.824.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42161,7 +42162,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Inductors",
+          "name:8": "nomifactory.quest.db.824.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42202,7 +42203,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Polytetrafluoroethylene (PTFE, or Teflon) is a polymer made from Carbon and Fluorine.\n\nThis polymer is most importantly used to make Large Chemical Reactors. It\u0027s also required for IV and LuV Machine Hulls, and can be substituted in some cases for higher yields.",
+          "desc:8": "nomifactory.quest.db.825.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42217,7 +42218,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Polytetrafluoroethylene",
+          "name:8": "nomifactory.quest.db.825.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42254,7 +42255,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The §3§2Large Chemical Reactor (LCR)§r §2is a multiblock §3§2Chemical Reactor§r §2with more input/output slots.§r\n\nThe §3LCR§r can perform some exclusive reactions which allow you to combine multiple normal §3Chemical Reactor§r steps into a §6single step§r, such as:\n- §aNitrogen Dioxide§r\n- §r§aSulfuric Acid§r\n-§r §aEpichlorohydrin§r, needed for...\n-§r §aEpoxy§r\n\nThe §3LCR§r also is required to perform some recipes, such as §aRaw Gasoline§r production.\n\nAny other recipe which could be done in a normal §9Chemical Reactor§r, as well as certain §9Mixer§r recipes, can also be done in an §3LCR§r.\n\nAll §dOverclocks§r in the §3LCR§r are §6100% efficient§r; each overclock will §5quadruple the speed§r, as opposed to doubling it.",
+          "desc:8": "nomifactory.quest.db.826.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42265,7 +42266,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Large Chemical Reactor",
+          "name:8": "nomifactory.quest.db.826.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42323,7 +42324,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A rudimentary version of Platinum Group Sludge (PGS) processing existed in the base pack. Here, it is a strong source of the Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum - as well as Gold. All of these elements will be used in IV-tier and above materials.\n\n§rYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.",
+          "desc:8": "nomifactory.quest.db.827.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42334,7 +42335,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Platinum Group Processing",
+          "name:8": "nomifactory.quest.db.827.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42380,7 +42381,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This is the highest tier of polymer. It is used in crafting Advanced SMD components, ZPM+ Machine Hulls, among other things.\n\nThis polymer requires at least 14 processing steps to craft. Good luck!",
+          "desc:8": "nomifactory.quest.db.828.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42395,7 +42396,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Polybenzimidazole (PBI)",
+          "name:8": "nomifactory.quest.db.828.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42432,7 +42433,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The next tier of Assembling Machine. This one can make quite a few nice things - check the surrounding quests.",
+          "desc:8": "nomifactory.quest.db.830.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42443,7 +42444,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "HV Assembler",
+          "name:8": "nomifactory.quest.db.830.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42483,7 +42484,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A more compact infinite Water source. Place this as a cover on any GT machine and it will insert 16B of water every second.",
+          "desc:8": "nomifactory.quest.db.831.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42494,7 +42495,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Greggy Infinite Water",
+          "name:8": "nomifactory.quest.db.831.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42534,7 +42535,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Ender Fluid Link Covers are GTCEu\u0027s Ender Tanks§r. Each Cover sends their fluids through a frequency defined by an §68-digit hexadecimal number§r (0-9, then A-F for each digit). That gives you §64.29 billion§r channels to work with! \n\nEnder Fluid Link Covers work as long as their chunk is loaded - regardless of distance or dimension.\n\nSetting the mode to Import will §o§c§opull§r fluids from the world location it is attached to, while Export will §o§9§opush§r fluids to the world. You must turn the I/O to Enabled for it to start working. Each channel has a buffer of §d64 buckets§r.\n\nThe \"Virtual Tank Viewer\" app in your §4Terminal§r allows you to see the contents of all Ender Fluid Link channels. Regardless, I recommend you set up a system to organise all those channels. I would also advise against using the default channel (FFFFFFFF) in all cases.\n",
+          "desc:8": "nomifactory.quest.db.832.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42545,7 +42546,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Super Ender Tanks",
+          "name:8": "nomifactory.quest.db.832.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42604,7 +42605,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Central Monitor allows you to... monitor... parts of your factory. Coupled with Wireless Digital Interface Covers, you can see the status, capacity, and more of machines, and even access their GUI remotely!\n\nCheck out the GTCEu wiki on GitHub for more of its details.",
+          "desc:8": "nomifactory.quest.db.833.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42615,7 +42616,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Central Monitor",
+          "name:8": "nomifactory.quest.db.833.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42667,7 +42668,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Super Tanks are the high-tier GT Fluid storage solution.§r\n\nThe first tier holds §64,000 buckets§r, and higher tiers hold more. They can also be used like Drums to put fluids in and out of machines.\n\nYou can conveniently configure §cvoiding§r for them to always void, start voiding at 95% capacity, or never void.\n\nThe item equivalent are §3Super Chests§r, which are used in certain §6Microminer§r recipes. Higher-tier versions of these are called §3Quantum Tanks§r and §3Quantum Chests§r. They all require their respective tier §3Hermetic Casings§r to craft.",
+          "desc:8": "nomifactory.quest.db.834.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42678,7 +42679,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Super Tanks",
+          "name:8": "nomifactory.quest.db.834.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42718,7 +42719,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Oil Cracking Unit gives you higher yields from cracking organic substances.\n\nNew in GTCEu, many organic substances offer the option of being Severely or Lightly cracked, each one granting different ratios of distillates.",
+          "desc:8": "nomifactory.quest.db.835.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42729,7 +42730,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Oil Cracking Unit",
+          "name:8": "nomifactory.quest.db.835.title",
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42770,7 +42771,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2In GTCEu, higher-tier blends of dusts require higher-tier Mixers to mix. The MV Mixer is required for making Vanadiumsteel and Stainless Steel.\n\nThere will not be more mixer quests above this one. Remember this when making higher-tier dust blends.",
+          "desc:8": "nomifactory.quest.db.836.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42781,7 +42782,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2MV Mixer",
+          "name:8": "nomifactory.quest.db.836.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42823,7 +42824,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A bit of Vanadiumsteel is used for progression. It\u0027s also a very strong tool material.\n\n§6Vanadium§r is an element acquired by processing §6Vanadium Magnetite Ore§r.",
+          "desc:8": "nomifactory.quest.db.837.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42834,7 +42835,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Vanadiumsteel",
+          "name:8": "nomifactory.quest.db.837.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42875,7 +42876,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Systems on Chip can be engraved with HV power and Glowstone Boules. This unlocks the ultimate tier one circuit recipe in the EV Circuit Assembler.\n\nThe ultimate tier two circuit recipe requires an IV Circuit Assembler.",
+          "desc:8": "nomifactory.quest.db.838.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42886,7 +42887,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Systems on Chip",
+          "name:8": "nomifactory.quest.db.838.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42927,7 +42928,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Your first few Raw Crystal Chips must be grown in an Autoclave from liquid Europium, and Exquisite Emeralds or Exquisite Olivine.\n\nAfter the first few, you can smash them into pieces using a Forge Hammer, and duplicate them with Bacterial Sludge, Mutagen, or more Europium.\n\nBacterial Sludge can later be obtained in the byproducts of getting Stem Cells.",
+          "desc:8": "nomifactory.quest.db.839.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42938,7 +42939,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Crystal Growing",
+          "name:8": "nomifactory.quest.db.839.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42980,7 +42981,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Advanced Processing Array can handle up to 64 parallel recipes at once.\n\nYou may need some 4A or 16A Energy Hatches to keep up with its power draw.",
+          "desc:8": "nomifactory.quest.db.840.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42991,7 +42992,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Advanced Processing Array",
+          "name:8": "nomifactory.quest.db.840.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43031,7 +43032,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Made by adding some Cobalt, Manganese and Silicon to your HSS-G.",
+          "desc:8": "nomifactory.quest.db.841.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43042,7 +43043,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "High Speed Steel Type E",
+          "name:8": "nomifactory.quest.db.841.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43083,7 +43084,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Use the Stem Cells and more advanced materials to build a Neuro Processing Unit. This is used in the first Wetware Circuit.",
+          "desc:8": "nomifactory.quest.db.842.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43094,7 +43095,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Neuro Processing Unit",
+          "name:8": "nomifactory.quest.db.842.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43134,7 +43135,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2There are 3 materials you will need from processing Naquadah: Enriched Naquadah (Nq+), Naquadria (Nq*), and Trinium (Ke). And there are 3 different ways to process Naquadah, each resulting in different materials.§r\n\nFirst is by §dprocessing ores§r from the §6Tier Five Micro Miner§r. §6Kaemanite Ore§r yields §6Trinium§r.\n\nSecond is by combining §6Naquadah Dust§r with certain heavy elements and EnderIO crystal grains. This can provide §6Enriched Naquadah§r and §6Naquadria§r.\n\nFinally, you can do the full CEu processing of §6Naquadah Dust§r with §9Fluoroantimonic Acid§r, the strongest acid known to man. This is a decently involved process, but not only does it yield all 3 Nq materials, it also grants byproducts of §6Titanium, Sulfur, Indium, Phosphorus, Barium, and Gallium§r.",
+          "desc:8": "nomifactory.quest.db.843.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43149,7 +43150,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Naquadah Processing",
+          "name:8": "nomifactory.quest.db.843.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43187,7 +43188,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Trinium Coils§r are the eighth coil material available, increasing your EBF\u0027s operating temperature to 9001K so it can process more advanced materials.\n",
+          "desc:8": "nomifactory.quest.db.844.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43198,7 +43199,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Trinium Coils",
+          "name:8": "nomifactory.quest.db.844.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43239,7 +43240,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A heavy Naquadah isotope with more nuclear capability.\n\n§r§6Enriched Naquadah§r is meant to be used in as-of-yet-unimplemented CEu-native reactors. It\u0027s used in small amounts for §3Trinium Coil blocks§r, or in Nomi reactors, though Naquadria is better for that purpose.\n\nAt least it\u0027s the easiest to obtain, and you can get it by mixing, the full Naquadah chain, or by passing Purified Naquadah Dust through an Electromagnetic Separator.",
+          "desc:8": "nomifactory.quest.db.845.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43250,7 +43251,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Enriched Naquadah",
+          "name:8": "nomifactory.quest.db.845.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43290,7 +43291,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A lighter and unstable Naquadah isotope.\n\n§r§6Naquadria§o§r is used in the construction of §6UV components§r, the §3Fusion Reactor Mk2§r, and in fusing §6Neutronium§r. Each piece of Naquadria also makes §d4 times§r more power than §6Enriched Naquadah§r in §3Naquadah Reactors§r.",
+          "desc:8": "nomifactory.quest.db.846.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43301,7 +43302,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Naquadria",
+          "name:8": "nomifactory.quest.db.846.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43342,7 +43343,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A strong heavy element obtained from the Naquadah chain.\n\n§r§6Trinium§r can come from §6Kaemanite Ore§r, but you will probably want to bolster its production with §6Naquadah Dust§r processing. It comes out at the second stage, so if you don\u0027t mind storing the intermediates and have Fluorine under control, you can hold off doing the full chain if you don\u0027t need to yet. You get §d1 Trinium per 6 Naquadah processed§r.\n\nThis will be required in large quantities for §6Trinium Coils§r, §6Superconducting Coil Blocks§r, §6Naquadah Alloy§r, among other things. You will need 14 stacks at least for a §3Fusion Reactor Mk1§r, so stock up on it.",
+          "desc:8": "nomifactory.quest.db.847.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43353,7 +43354,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Trinium",
+          "name:8": "nomifactory.quest.db.847.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43393,7 +43394,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Naquadah Alloy is different in CEu, it requires Naquadah, Osmiridium and Trinium.",
+          "desc:8": "nomifactory.quest.db.848.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43404,7 +43405,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Naquadah Alloy",
+          "name:8": "nomifactory.quest.db.848.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43444,7 +43445,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Used for Advanced SMD components.",
+          "desc:8": "nomifactory.quest.db.849.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43455,7 +43456,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2IV Assembling Machine",
+          "name:8": "nomifactory.quest.db.849.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43498,7 +43499,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Advanced SMD Components are new to CEu and are required for Crystal and Wetware circuits. They can also be substituted for the equivalent of 4 normal SMD components in Nano and Quantum circuits.\n\nAll of these components require IV power and liquid PBI.\n\nAdvanced SMD Transistor: Vanadium-Gallium Foil and Fine HSS-G Wire\n\nAdvanced SMD Resistor: Graphene Dust and Fine Platinum Wire\n\nAdvanced SMD Capacitor: Thin PBI Sheet and HSS-S Foil\n\nAdvanced SMD Diode: Small Pile of InGaP Dust and Fine Niobium-Titanium Wire\n\nAdvanced SMD Inductor: HSS-E Ring and Fine Palladium Wire\n\nAs with the normal SMD components, invest in an extremely robust automation system for these, as you won\u0027t stop needing them.",
+          "desc:8": "nomifactory.quest.db.850.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43509,7 +43510,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Advanced SMD Components",
+          "name:8": "nomifactory.quest.db.850.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43573,7 +43574,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Made by adding some Iridium and Osmium to your HSS-G.",
+          "desc:8": "nomifactory.quest.db.851.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43584,7 +43585,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "High Speed Steel Type S",
+          "name:8": "nomifactory.quest.db.851.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43625,7 +43626,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You can get Americium from NuclearCraft progression, but you can also fuse it. First combine Lanthanum with Silicon to make Lutetium, then combine it with Chrome to get Americium.\n\n§2Americium is used in larger quantities in CEu progression. You cannot convert this form of Americium to NuclearCraft Americium isotopes.",
+          "desc:8": "nomifactory.quest.db.852.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43636,7 +43637,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Americium Ingot",
+          "name:8": "nomifactory.quest.db.852.title",
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43676,7 +43677,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Ruridit is a Ruthenium-Iridium alloy used in LuV machine components.",
+          "desc:8": "nomifactory.quest.db.853.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43687,7 +43688,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Ruridit",
+          "name:8": "nomifactory.quest.db.853.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43727,7 +43728,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Tritanium Coils are the final coil material. At 10800K, it\u0027s capable of smelting every material.",
+          "desc:8": "nomifactory.quest.db.854.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43738,7 +43739,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Tritanium Coils",
+          "name:8": "nomifactory.quest.db.854.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43778,7 +43779,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The final Boule. It grants the most wafers, and is required for Highly Advanced Systems-on-Chip.",
+          "desc:8": "nomifactory.quest.db.855.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43789,7 +43790,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Neutronium Boules",
+          "name:8": "nomifactory.quest.db.855.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43829,7 +43830,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2For making Wetware Circuits more easily. You need UV-tier power to make them that way.",
+          "desc:8": "nomifactory.quest.db.856.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43840,7 +43841,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Highly Advanced SoCs",
+          "name:8": "nomifactory.quest.db.856.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43880,7 +43881,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Used in building the Alloy Blast Smelter. \n\n§r§6Tantalum§r is obtained from §6Tantalite Ore§r, or in small quantities from centrifuging §eLava§r.\n\n§6Molybdenum§r is obtained from §6Molybdenum, Molybdenite, Powellite, and Wulfenite ores§r. They spawn together in the §eNether§r rarely, or some of them come from §3Tier One§r and §3Five Micro Miners§r.\n\n§2Remember, you need an appropriately tiered Mixer (HV for HSLA Steel, and EV for the others).",
+          "desc:8": "nomifactory.quest.db.857.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43891,7 +43892,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Advanced Alloys",
+          "name:8": "nomifactory.quest.db.857.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43950,7 +43951,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Alloy Blast Smelter directly smelts dust combinations into molten Alloys, skipping the Mixer step. Some molten alloys may need to be cooled in a Vacuum Freezer before being usable.\n\n§rThis is the only way to create some of the advanced alloys used in multiblock machines. You can also use it for most normal alloys if you want. In particular, the yield of §6Energetic Alloy§r and §6Vibrant Alloy§r is §ddoubled§r.",
+          "desc:8": "nomifactory.quest.db.858.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43961,7 +43962,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Alloy Blast Smelter",
+          "name:8": "nomifactory.quest.db.858.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44014,7 +44015,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2With advanced alloys from the Alloy Blast Smelter and IV Machines, you can make large versions of most GT machines.\n\n§rThese are formed like multiblocks. You can add a §3Parallel Control Hatch§r in order to allow them to process §dmore recipes§r at the same time, similarly to a §3Processing Array§r. The highest tier of Parallel Control Hatch can facilitate processing §d256 recipes§r at once!\n\nSearch \"@gregicality\" or look up the usages of Parallel Hatches in JEI to see details of all the multiblock machines.",
+          "desc:8": "nomifactory.quest.db.859.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44025,7 +44026,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Gregicality Multiblocks",
+          "name:8": "nomifactory.quest.db.859.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44143,7 +44144,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Upgraded forms of the EBF and Vacuum Freezer. Can run up to 2,048 recipes in parallel.\n\nThe Rotary Hearth Furnace is quite big!",
+          "desc:8": "nomifactory.quest.db.861.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44154,7 +44155,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Upgraded EBF and Freezer",
+          "name:8": "nomifactory.quest.db.861.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44200,7 +44201,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium. §e",
+          "desc:8": "nomifactory.quest.db.862.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 64,
@@ -44211,7 +44212,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 041: Niobium",
+          "name:8": "nomifactory.quest.db.862.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44251,7 +44252,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.863.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44262,7 +44263,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 042: Molybdenum",
+          "name:8": "nomifactory.quest.db.863.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44302,7 +44303,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.864.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44313,7 +44314,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 044: Ruthenium",
+          "name:8": "nomifactory.quest.db.864.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44353,7 +44354,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.865.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44364,7 +44365,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 045: Rhodium",
+          "name:8": "nomifactory.quest.db.865.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44404,7 +44405,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.866.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44415,7 +44416,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 048: Cadmium",
+          "name:8": "nomifactory.quest.db.866.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44455,7 +44456,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.867.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44466,7 +44467,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 055: Caesium",
+          "name:8": "nomifactory.quest.db.867.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44506,7 +44507,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.868.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44517,7 +44518,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 056: Barium",
+          "name:8": "nomifactory.quest.db.868.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44557,7 +44558,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.869.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44568,7 +44569,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 058: Cerium",
+          "name:8": "nomifactory.quest.db.869.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44608,7 +44609,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.870.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44619,7 +44620,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 060: Neodymium",
+          "name:8": "nomifactory.quest.db.870.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44659,7 +44660,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.871.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44670,7 +44671,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 062: Samarium",
+          "name:8": "nomifactory.quest.db.871.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44710,7 +44711,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.872.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44721,7 +44722,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 063: Europium",
+          "name:8": "nomifactory.quest.db.872.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44761,7 +44762,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.873.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44772,7 +44773,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 071: Lutetium",
+          "name:8": "nomifactory.quest.db.873.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44812,7 +44813,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.874.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44823,7 +44824,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 073: Tantalum",
+          "name:8": "nomifactory.quest.db.874.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44863,7 +44864,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium. (It wasn\u0027t before!)",
+          "desc:8": "nomifactory.quest.db.875.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44874,7 +44875,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 082: Lead",
+          "name:8": "nomifactory.quest.db.875.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44914,7 +44915,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.876.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44925,7 +44926,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 119: Tritanium",
+          "name:8": "nomifactory.quest.db.876.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44965,7 +44966,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.877.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44976,7 +44977,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 120: Duranium",
+          "name:8": "nomifactory.quest.db.877.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45016,7 +45017,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.878.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45027,7 +45028,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 125: Trinium",
+          "name:8": "nomifactory.quest.db.878.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45067,7 +45068,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.879.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45078,7 +45079,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 174: Naquadah",
+          "name:8": "nomifactory.quest.db.879.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45118,7 +45119,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Configurable to output any number of GT Volts and Amps.",
+          "desc:8": "nomifactory.quest.db.880.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45129,7 +45130,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Infinite GT EU Emitter",
+          "name:8": "nomifactory.quest.db.880.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45169,7 +45170,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+          "desc:8": "nomifactory.quest.db.881.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45180,7 +45181,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Polyphenylene Sulfide",
+          "name:8": "nomifactory.quest.db.881.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45251,7 +45252,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.883.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45262,7 +45263,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 110: Darmstadtium",
+          "name:8": "nomifactory.quest.db.883.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45302,7 +45303,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.884.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45313,7 +45314,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 149: Draconium",
+          "name:8": "nomifactory.quest.db.884.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45353,7 +45354,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Do you remember Darmstadtium tools in CE? Well you can make their material now!\n\nIt is formed by fusing Arsenic and Ruthenium, and is the main material for UV machines.",
+          "desc:8": "nomifactory.quest.db.885.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45364,7 +45365,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Darmstadtium",
+          "name:8": "nomifactory.quest.db.885.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45404,7 +45405,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Portable Scanner, or Tricorder, is GTCEu\u0027s debug tool. §rIt shows you a block\u0027s details, the details of the energy network, its current status and contents, and its impact on performance.\n\nUsing this anywhere will also display a percentage of fluid remaining in the fluid vein, for the §3Fluid Rigs§r.",
+          "desc:8": "nomifactory.quest.db.886.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45415,7 +45416,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Debug Scanner",
+          "name:8": "nomifactory.quest.db.886.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45456,7 +45457,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A new, oily path to Polyethylene is available in GTCEu. §rCrack §9Light Fuel§r to §9Severely Steam-Cracked Light Fuel§r in a §3Chemical Reactor§r, then distill it to §eEthylene§r.\n\nThe advantage of this path is that it requires §6no MV machines§r. You lose a few Oil byproducts, but you get so much Oil from future processes that the loss is insignificant.",
+          "desc:8": "nomifactory.quest.db.887.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45471,7 +45472,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Patriot\u0027s Plastic",
+          "name:8": "nomifactory.quest.db.887.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45510,7 +45511,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Gasoline is a powerful combustion fuel, generating 1600 EU per mB of fluid.\n\nGasoline is made of:\n- 16 parts Naphtha\n- 2 parts Refinery Gas\n- 1 part Toluene\n- 1 part Methanol\n- 1 part Acetone\n\nTo get the most out of this, run it in an Extreme Combustion Engine with Liquid Oxygen.",
+          "desc:8": "nomifactory.quest.db.888.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45525,7 +45526,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Gasoline",
+          "name:8": "nomifactory.quest.db.888.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45595,7 +45596,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§dGregTech Power§r can be tricky to handle. Luckily, there are several tools you can use to tackle some of the problems.\n\n- §aDiode§r: A block which accepts energy on 5 sides, and outputs it on a single side. Its main purpose is to limit Amperage flow through it - adjust it by right-clicking it with a Soft Hammer. Not to be confused with the Diodes used as crafting components.\n\n- §aTransformer§r: A block which changes between 4A of a lower voltage and 1A of a voltage one tier higher.\n\n- §2Adjustable Transformer§r: Similar to the Transformer, but can be configured to transform up to 64A Low \u003c-\u003e 16A High.\n\n- §aBattery Buffer§r: A block which can hold GregTech Batteries. Each battery accepts up to 2A and can provide up to 1A. §2They have been reworked in CEu to not be as terrible to use.",
+          "desc:8": "nomifactory.quest.db.890.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45606,7 +45607,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2GT Power Management",
+          "name:8": "nomifactory.quest.db.890.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45681,7 +45682,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Large Ore Drilling Plants mine ores from under them in a large radius. They require Drilling Fluid to operate.\n\nThey automatically macerate the ores, yielding 3 times more crushed ore than a normal Macerator, plus the normal amount of byproduct.",
+          "desc:8": "nomifactory.quest.db.892.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45692,7 +45693,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Large Miners",
+          "name:8": "nomifactory.quest.db.892.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -45745,7 +45746,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Certain multiblocks in CEu will require a Maintenance Hatch and/or Muffler Hatch. These cannot be shared between multiblocks. If you knew Maintenance in GT5u, fret not - Maintenance mechanics are far less punishing in CEu.\n\n§r- §aMuffler§r: This hatch must be §cunobstructed§r so it can output its beautiful smoke particles. When a recipe is performed, there is a small chance for the §3Muffler Hatch§r to give bonus items, typically tiny Dusts of Ash. It voids excess when full, so do not worry about it stopping machines from running.\n\n- §aMaintenance§r: You will need to do Maintenance for the Multiblock to begin operating. This is done by having a §9Wrench§r, a §9Screwdriver§r, a §9Soft Mallet§r, a §9Hammer§r, a §9Wire Cutter§r, and a §9Crowbar§r in your inventory, opening the Maintenance Hatch and §eclicking the center spot once§r. §cNo need to move tools individually§r. Alternatively, you can fix problems by placing §9Tape§r in the Maintenance Hatch. \n\nMaintenance problems may occur after §d48 real hours of activity§r. Needless to say, they are very rare. Each problem increases the recipe durations by 10%. Fixing the problems is done the same way as above.\n\nLater, you will unlock other Maintenance Hatches that do not enforce fixing the problems manually. Both start with §6no Maintenance required§r:\n\n- §3Automatic Maintenance Hatch§r (§1IV§r): Eliminates the need for Maintenance, §6forever§r.\n\n- §3Configurable Maintenance Hatch§r (§6HV§r): You can configure it to cut off §a10% duration§r on recipes, at the cost of making Maintenance issues happen three times as fast. That is §d16 real hours§r of activity. §9Tape§r can fix problems in this Hatch as well.\n",
+          "desc:8": "nomifactory.quest.db.893.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45756,7 +45757,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Maintenance and Muffler Mechanics",
+          "name:8": "nomifactory.quest.db.893.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45783,7 +45784,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2With the MV Assembling Machine, you can assemble a few necessary parts for the next Circuit tier.",
+          "desc:8": "nomifactory.quest.db.894.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45794,7 +45795,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2MV Assembling Machine",
+          "name:8": "nomifactory.quest.db.894.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45835,7 +45836,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The MV Assembling Machine allows you to craft Medium Voltage Coils, and your Precision Laser Engraver can make Ultra Low Power ICs with a Sapphire Lens.\n\nCombine them with some MV parts and you can finally craft an MV Energy Hatch.\n\nHigher tiers of energy hatch will require similar resources.\n\nNote: For extracting energy from GT multiblock generators, you will need Dynamo Hatches instead. Those are crafted similarly to Energy Hatches, but with Springs in place of 1x Cables.",
+          "desc:8": "nomifactory.quest.db.895.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45846,7 +45847,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2MV Energy Input",
+          "name:8": "nomifactory.quest.db.895.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45892,7 +45893,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Sodium Potassium is an alloy of... take a guess. \n\nIt\u0027s used in the construction of HV and above Energy and Dynamo hatches.",
+          "desc:8": "nomifactory.quest.db.896.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45907,7 +45908,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Sodium Potassium",
+          "name:8": "nomifactory.quest.db.896.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45945,7 +45946,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2With Silver, LPICs, NaK, and an HV Assembler, you can finally make HV Energy and Dynamo hatches.\n\nYou should get the gist of making these now, so there will not be further quests on Energy and Dynamo hatches.",
+          "desc:8": "nomifactory.quest.db.897.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45956,7 +45957,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2HV Energy Hatch",
+          "name:8": "nomifactory.quest.db.897.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46054,7 +46055,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Hydrofluoric Acid is a dangerous acid made by mixing Hydrogen and Fluorine. It is used in the production of Polytetrafluoroethylene, and in Uranium and Naquadah processing.\n\nFluorine is best obtained from Topaz or Bastnasite Ore processing from their Microminer missions, or in small amounts from renewable Black Granite.",
+          "desc:8": "nomifactory.quest.db.899.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46069,7 +46070,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Hydrofluoric Acid",
+          "name:8": "nomifactory.quest.db.899.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46106,7 +46107,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2High-Octane Gasoline is the most powerful combustion fuel, generating 3200 EU per mB of fuel. This is required for production of Draconium.\n\nTo refine Gasoline to High-Octane Gasoline, you will need:\n- 20 parts Gasoline\n- 2 parts Octane\n- 2 parts Nitrous Oxide\n- 1 part Toluene\n- 1 part Ethyl Tert-Butyl Ether\n\nTo get the most out of this, run it in an Extreme Combustion Engine with Liquid Oxygen.",
+          "desc:8": "nomifactory.quest.db.900.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46121,7 +46122,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2High-Octane Gasoline",
+          "name:8": "nomifactory.quest.db.900.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46192,7 +46193,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Tablet device you spawned with is very valuable to do plenty of tasks in GregTech.§r\n\nThis Quest explains how you can use the §4Terminal§.. §bThis is merely basic information, you can skip this for a while as the Terminal isn\u0027t used much in the early game§r.\n\nThe Terminal runs on §4GregOS™§r (not an actual Trademark), an operating system which works with §5Applications§r.\n\n§9Machines Guides§r, §9Multiblock Guides§r, §9Item Guides§r, §9§9Tutorials§r are what they sound like. Note that they are currently still being worked on.\n\n§9System Settings§r changes... settings (duh) related to the Terminal. You can §bset your own background picture§r, remove the double confirmation on exit, and more. Most of the keybinds apply to the §5Home§r button. Double clicking by default exists any open Application.\n\n§9Multiblock Helper§r is split into two functionalities. The first one requires a requires a §dLV§r Battery and a §dCamera§r mounted to enable §bVR visualization§r of multiblock structures. The upgrade unlocked at §6HV§r allows you to §6debug§r and §6auto-build§r.\n\n§9Battery Manager§r, assuming you have a Battery mounted, checks the Energy level and indicates energy usage of other Apps.\n\n§9Hardware Manager§r is used to mount Hardwares, such as Battery, to enable other Apps.\n\n§9App Store§r (not exactly a Store) adds Apps to your collection, and allows upgrades for some of them. Keep in mind Apps may still require specific mounted devices to function.\n\n§9Ore Prospector§r works the same way as the portable §dProspector§r and can be upgraded several times.\n\n§9Fluid Prospector§r works the same way as the portable §dProspector§r (but for fluids!) and can be upgraded several times.\n\n§9Recipe Chart§r is a wonderful chart planner to build Recipe Chains and visualize them.\n\n§9GT Console§r configures machines as if you were using regular tools, but without using them! This is similar to the remote access from the §3Central Monitor§r.\n\n§9World Prospector§r is a §dX-Ray VR§r for filtered blocks.\n\n§9Virtual Tank Viewer§r is used in combination with §3Ender Fluid Covers§r. It stores information about all your §dVirtual Tanks§r.\n\n§9Cape Selector§r lets you become fancy! You can have your characters wear a fancy §dCape§r.\",\n",
+          "desc:8": "nomifactory.quest.db.902.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46208,7 +46209,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Terminal",
+          "name:8": "nomifactory.quest.db.902.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46236,7 +46237,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The coil recipes are harder in CEu, not only do they require their base material, they also need some extra material types and they must be made in Assembling Machines of their tier.\n\nFor Cupronickel Coils, you will need 8 Cupronickel, 2 Bronze, and 1 Tin Alloy for each coil. You need 16 for the Electric Blast Furnace and 16 for the Pyrolyse Oven. That totals to 176 Copper, 128 Nickel, 32 Tin, and 16 Iron.",
+          "desc:8": "nomifactory.quest.db.903.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46247,7 +46248,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Cupronickel Coils",
+          "name:8": "nomifactory.quest.db.903.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46287,7 +46288,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Bacterial Sludge will be used in the Crystal and Wetware processes.\n\nPlant matter in Plant Ball can be broken down to Bio Chaff, and broken down to Bacteria. Then, combine it with your Biomass to get Bacterial Sludge.\n\nYou will also get a bit back from growing Stem Cells later.",
+          "desc:8": "nomifactory.quest.db.904.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46302,7 +46303,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Bacterial Sludge",
+          "name:8": "nomifactory.quest.db.904.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46339,7 +46340,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Use §cCalifornium-252 §rto enrich Bacterial Sludge, and distill it to Mutagen.\n\nMutagen is used in Growth Medium production.",
+          "desc:8": "nomifactory.quest.db.905.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46354,7 +46355,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Mutagen",
+          "name:8": "nomifactory.quest.db.905.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46391,7 +46392,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Multiblock version of the Circuit Assembler. Can accept Parallel Control Hatches, and allows tiering it up more easily.",
+          "desc:8": "nomifactory.quest.db.906.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46402,7 +46403,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Large Circuit Assembler",
+          "name:8": "nomifactory.quest.db.906.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46534,7 +46535,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A mixture of §6Clay, Brick, §cQuartz Sand, Calcite, Gypsum, Stone Dust§r produces §6Firebricks§r, used in building the §3Primitive Blast Furnace§r. This allows you to make §6Steel§r from §6Wrought Iron§r, which forms the basis of LV Machine Hulls.",
+          "desc:8": "nomifactory.quest.db.909.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46545,7 +46546,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2§2Primitive Steelworks",
+          "name:8": "nomifactory.quest.db.909.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46598,7 +46599,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Rhodium Plated Lumium-Palladium is a mixture of Rhodium, Lumium and Palladium. It forms the basis of LuV Machine Hulls.",
+          "desc:8": "nomifactory.quest.db.910.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46609,7 +46610,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Rhodium Plated Lumium-Palladium",
+          "name:8": "nomifactory.quest.db.910.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46649,7 +46650,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Battery Buffer§r is a machine which can hold §6Batteries§r for energy storage. Each Battery accepts up to 2 amps and outputs up to 1 amp.\n\nYou can also charge §6Electric tools§r in them.\n\n§cRF batteries such as Flux Capacitors cannot be drained by Battery Buffers!",
+          "desc:8": "nomifactory.quest.db.911.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46660,7 +46661,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "LV Battery Buffer",
+          "name:8": "nomifactory.quest.db.911.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -46703,14 +46703,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "GregTech §7Low Voltage§r Tier: start building a factory!\n\nUnlock access to §bDeep Mob Learning§r, early §bEnderIO§r tech, and §bApplied Energistics 2§r Digital Storage.\n\nBuild an §3Electric Blast Furnace§r for smelting advanced materials and alloys.",
+          "desc:8": "nomifactory.quest.line.0.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 1001,
             "OreDict:8": "",
             "id:8": "gregtech:machine"
           },
-          "name:8": "The Beginning",
+          "name:8": "nomifactory.quest.line.0.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -47158,14 +47158,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "GregTech §bMedium Voltage§r Tier: new machines and rudimentary ore processing.\n\nOrganic Chemistry for §6Plastics§r, and build a §3Distillation Tower§r.\n\n§bApplied Energistics 2§r automation. Explore §bActually Additions§r.",
+          "desc:8": "nomifactory.quest.line.1.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 625,
             "OreDict:8": "",
             "id:8": "gregtech:meta_item_1"
           },
-          "name:8": "Early Game",
+          "name:8": "nomifactory.quest.line.1.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -47935,14 +47935,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "GregTech §6High Voltage§r, §5Extreme Voltage§r, and §1Insane Voltage§r tiers:\n\n§6§3Cryogenic Distillation§r, and petrochemistry for §6Epoxy§r and §9Nitro Diesel§r.\n\nCraft §6Nether Stars§r and unlock §bThermal Expansion§r machines.\n\nBuild a§b NuclearCraft§r fission reactor to obtain new materials.\n\nBuild a Space Station and Warp Core.",
+          "desc:8": "nomifactory.quest.line.2.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 2,
             "OreDict:8": "",
             "id:8": "gregtech:warning_sign"
           },
-          "name:8": "Mid Game",
+          "name:8": "nomifactory.quest.line.2.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -48964,14 +48964,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "It\u0027s always rewarding to take a step forward.\n\nThis tab outlines the progression of various things in §5Nomifactory§r.\n\nCircuits are the primary measure of your progress.",
+          "desc:8": "nomifactory.quest.line.3.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 0,
             "OreDict:8": "",
             "id:8": "questbook:itemquestbook"
           },
-          "name:8": "Progression",
+          "name:8": "nomifactory.quest.line.3.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -49678,14 +49678,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "GregTech §dLuV§r, ZPM, §3UV§r, §4UHV§r tiers:\n\nBuild §3Assembly Lines§r, §3Fusion Reactors§r, and more!\n\nAutomate in style with §bPackagedAuto§r. Climb the tiers of §6Micro Miners§r.\n\n§bDraconic Evolution§r for fusion crafting and energy storage.",
+          "desc:8": "nomifactory.quest.line.4.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 647,
             "OreDict:8": "",
             "id:8": "gregtech:meta_item_1"
           },
-          "name:8": "Late Game",
+          "name:8": "nomifactory.quest.line.4.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -50581,14 +50581,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "You\u0027re in the endgame now...\n\nHarvest entire microverses and unlock the §dCreative Portable Tank§r.\n\nPut your automation to the ultimate test as you progress towards the final goal: the §dCreative Vending Upgrade§r.",
+          "desc:8": "nomifactory.quest.line.5.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 0,
             "OreDict:8": "",
             "id:8": "contenttweaker:heartofauniverse"
           },
-          "name:8": "End Game",
+          "name:8": "nomifactory.quest.line.5.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -51512,14 +51512,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Welcome to §5Nomifactory§r, I\u0027ll be your guide.",
+          "desc:8": "nomifactory.quest.line.6.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 0,
             "OreDict:8": "",
             "id:8": "minecraft:iron_ingot"
           },
-          "name:8": "Genesis",
+          "name:8": "nomifactory.quest.line.6.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -51925,14 +51925,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Get your feet wet with §bExtra Utilities§r and §bExtended Crafting§r.\n\nConquer The End or invest in §bEnderIO §rfor teleportation technologies.\n\nBuild a rocket and go to the Moon (or don\u0027t, but it\u0027s fun).\n\nEither way, it\u0027s time to start mining §emicroverses§r.",
+          "desc:8": "nomifactory.quest.line.7.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 0,
             "OreDict:8": "",
             "id:8": "contenttweaker:tieroneship"
           },
-          "name:8": "Into The Microverse",
+          "name:8": "nomifactory.quest.line.7.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -52338,14 +52338,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Create new elements and power your base with doughnuts!",
+          "desc:8": "nomifactory.quest.line.8.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 1022,
             "OreDict:8": "",
             "id:8": "gregtech:machine"
           },
-          "name:8": "Fun With Fusion",
+          "name:8": "nomifactory.quest.line.8.title",
           "visibility:8": "ALWAYS"
         }
       },
@@ -52471,14 +52471,14 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Convert between matter and energy with §bApplied Energistics§r§r.\n\nAutomate ALL the things! o/",
+          "desc:8": "nomifactory.quest.line.10.desc",
           "icon:10": {
             "Count:3": 1,
             "Damage:2": 2,
             "OreDict:8": "",
             "id:8": "chisel:futura"
           },
-          "name:8": "Matter-Energy",
+          "name:8": "nomifactory.quest.line.10.title",
           "visibility:8": "ALWAYS"
         }
       },

--- a/overrides/config/betterquesting/saved_quests/ExpertQuests.json
+++ b/overrides/config/betterquesting/saved_quests/ExpertQuests.json
@@ -1,4 +1,5 @@
 {
+  "build:8": "4.0.2",
   "format:8": "2.0.0",
   "questDatabase:9": {
     "0:10": {
@@ -9,7 +10,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The main purpose for this device is to turn §6Activated Certus Quartz Crystal§r into §6Charged Certus Quartz Crystal§r.\n\nThis device can be powered with RF via energy conduits or use AE energy from a network via ME conduits or cables.\n\nIt accepts power from two sides. Which two sides? It\u0027s pretty easy to guess.\n\n\n\n\n\n\n\n\nOk, ok. It\u0027s the top and bottom.\n\n",
+          "desc:8": "nomifactory.quest.db.0.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20,7 +21,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Charging Quartz",
+          "name:8": "nomifactory.quest.db.0.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -73,7 +74,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Crystal Growth Chamber§r allows you to perform §bApplied Energistics§r\u0027s world crafting recipes inside of a machine. Hooray, you never have to drop more things in water again!\n\nIt is used for growing §6Crystal Seeds§r into §6Pure Crystals§r, and also for creating §6Fluix Crystals§r.\n\nJEI doesn\u0027t show the Chamber\u0027s recipes directly, so we\u0027ll explain it here:\n\nSeeds are made by pulverizing any of the three crystal types and mixing the dust with sand. A seed grows into the corresponding Pure Crystal, which is substitutable for the original crystal in most recipes. Using Pure Crystals lets you effectively double your material efficiency, which is nice. And no, you can\u0027t grind down Pure Crystals to further multiply your resources. Sorry.\n\nFluix Crystals you\u0027ve already had to make in a pool of water by now, and it\u0027s the same ingredients here: insert one each of a §6Redstone Dust§r, §6Charged Certus Quartz Crystal§r, and a §6Nether Quartz§r to produce two Fluix Crystals.",
+          "desc:8": "nomifactory.quest.db.1.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -84,7 +85,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crystal Growth Chamber",
+          "name:8": "nomifactory.quest.db.1.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -170,7 +171,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts both LV and MV Canning Machines.\n\n§aLV Batteries§r were very simple to make, but more effective forms of power storage will be more complex to build, so we\u0027ll need to lay the groundwork now.\n\nPut your §3Centrifuge§r to work for the §6Antimony§r you\u0027ll need, which comes in tiny piles from processing §6Tetrahedrite Ore§r and §6Stibnite Ore§r.\n\n",
+          "desc:8": "nomifactory.quest.db.2.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -181,7 +182,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Canning Machine and Assorted Stuff",
+          "name:8": "nomifactory.quest.db.2.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -232,7 +233,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Welcome to §5Nomifactory§f §2GTCEu-§cSTE§r!\n\nThis pack is intended to be played in a §bLost Cities / Overworld dimension§f.\n\nIf you\u0027re playing with friends, don\u0027t forget to invite them to the §equestbook party§f.\n\n§fIf you wish to build your base in a skyblock world, place the §6Void World Cake§f down on the ground, and eat a slice to be sent to the void. Please note that you\u0027ll still need to return to the Lost Cities / Overworld dimension to mine, but you can freely build in complete safety in the §eVoid World§f.\n\nFeatures new to §2CEu§r and quests with new content will be highlighted in §2dark green (colour 2)§r.",
+          "desc:8": "nomifactory.quest.db.3.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -243,7 +244,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§cSTE-§2Genesis",
+          "name:8": "nomifactory.quest.db.3.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -314,7 +315,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§c§rOres in §5Nomifactory§f exist in large clusters, or \u0027§eveins§f\u0027. These veins are scattered around the world, and are relatively common. §2The upgraded HV Electric Prospector\u0027s Scanner you were given will tell you the types of ores you can find within a 7x7 chunk area!\n§r\nWhile the Scanner requires energy to work, you are unlikely to deplete its battery. That said, the quest book will later guide you towards making §2an HV Battery§r to charge §aHV tools §rin your inventory.\n\nIn order to proceed, you\u0027ll need to locate a source of §6Iron§f. You have a few options. §6Magnetite§f veins are higher up and contain large amounts of iron, as well as some §6Vanadium§f and §6Gold§f. Another good source of iron is §6Limonite§f veins, which contain several types of iron. Finally, §6Pyrite§f can be found paired with §6Copper§f in several types of veins.\n\n§6Wrought Iron§f is obtained simply by §esmelting Iron §cNuggets§e a second time§f. It has more durability than Iron, so it is better for making tools, but §cdo not convert your entire Iron supply over to Wrought Iron§f. The two materials are not interchangeable and you\u0027ll need Iron or Wrought Iron as demanded by various recipes.",
+          "desc:8": "nomifactory.quest.db.4.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -325,7 +326,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Iron Supply",
+          "name:8": "nomifactory.quest.db.4.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -372,7 +373,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aMining Hammers§r offer a relatively cheap way to mine out areas much faster. They clear a 3x3 of blocks and mine quickly, so they\u0027re absolutely worth investing your first few ingots of metal into§..\n\n§2GTCEu now has Mining Hammers natively! You can craft them with any GT tool material.",
+          "desc:8": "nomifactory.quest.db.5.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -388,7 +389,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mining Hammers",
+          "name:8": "nomifactory.quest.db.5.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -416,7 +417,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Before you continue, you\u0027ll need access to some more materials. \n\n§6Redstone§f: Found only deep in the world, in massive veins paired with §6Cinnabar§f and §6Ruby§f.\n\n§6Copper§f: Two primary sources. §6Tetrahedrite§f veins are higher up, while §6Chalcopyrite§f veins are lower, paired with some small amounts of §6Iron§f. You\u0027ll also find §6Malachite§f inside of Iron veins, this is another type of copper ore.\n\n§6Tin§f: Found essentially at ground level. §6Cassiterite§f is another type of tin ore, and they\u0027re always found together. If you cannot find a vein of tin, there are small amounts of tin inside veins of §6Aluminium§f and §6Rock Salt§f, which might be enough to hold you over until you find a proper tin vein.\n\n§6Coal§f: Found in relatively shallow depths. §6Lignite Coal§f is §2removed.\n\n§6Gold§f: Found inside of §6Magnetite§f veins, close to the surface.",
+          "desc:8": "nomifactory.quest.db.6.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -427,7 +428,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2More Materials",
+          "name:8": "nomifactory.quest.db.6.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -494,7 +495,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The most basic cables, such as these §6Red Alloy Cables§f, can be wrapped in their §6Rubber§f insulation by hand.\n\nMore advanced types of cables will require an §3Assembling Machine§f and liquid §9Rubber§f, but you can do it the simple way for now.\n\n§2GT cables now support RF conversion natively! You can plug an RF machine into an EU cable directly and it will convert the energy.",
+          "desc:8": "nomifactory.quest.db.7.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -505,7 +506,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Cables",
+          "name:8": "nomifactory.quest.db.7.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -607,7 +608,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "In most expert packs, you want to try to process as little ore as possible before you get access to ore doubling. It\u0027s a habit most of us pick up.\n\n§eYou shouldn\u0027t feel any pressure to do that in Nomifactory, though§f. Ore veins are massive, and mining is extremely fast with §aMining Hammers§f. What\u0027s more, even once you get access to §3Macerators§f, they initially process ore slowly and require power to operate.\n\nObvious exceptions would be rare materials §fbecause you can\u0027t find it. Those are worth doubling, if possible.\n\nBut at least for now, you shouldn\u0027t feel any guilt about smelting the more common ores without doubling them! §eOre doubling can be safely ignored until you have Medium Voltage machines or even later.§r",
+          "desc:8": "nomifactory.quest.db.9.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -618,7 +619,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ore Doubling?",
+          "name:8": "nomifactory.quest.db.9.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -647,7 +648,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Second Micro Miner!\n\nThis uses an §bExtended Crafting§r table so it\u0027s not possible to automate the Miner itself with §bApplied Energistics 2§r just yet (this requires more advanced technology not easy to access until the Tier Four Micro Miner). You can make it semi-automatically by prestocking the components you need, and filling up the Extended Crafting Table with §bJEI§r!\n\nThis Micro Miner can get you:§6\n* Bauxite Ore\n§2* Pyrochlore Ore§6\n§c* Tantalite Ore§2\n* Copper Ore\n* Tungstate Ore\n* Scheelite Ore\n* Cassiterite Ore\n* Radium Salt§r\n\nAs well as the §6Stellar Creation Data§r, which will be useful much, much later.",
+          "desc:8": "nomifactory.quest.db.10.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -658,7 +659,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Two Micro Miner",
+          "name:8": "nomifactory.quest.db.10.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -701,7 +702,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A \"§esubstrate§f\" is the \"board\" part of a circuit board... the backing that the circuit components and wires are laid into. A good substrate needs to not conduct electricity, for obvious reasons. §6Wood§r coated in §6Sticky Resin§r is a primitive but effective material to use as your first substrate.\n\n§2CEu circuit progression means you also have to put wires on your substrates for them to be usable. In this case, use some Copper Wires.§r\n\nYou\u0027ll also need to make §6Vacuum Tubes§f, as well as some primitive §6Resistors§r. §6Paper§r will work as a material for these, for now.\n\nMake sure to code these recipes into a §3Crafting Station§r... you\u0027ll be making a LOT of these things.",
+          "desc:8": "nomifactory.quest.db.11.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -712,7 +713,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Electronics Subcomponents",
+          "name:8": "nomifactory.quest.db.11.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -765,7 +766,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "One of the eccentricities of the pack you\u0027ll need to get used to is the way the tools are displayed. Most tools can be made out of nearly any metal, and §bJEI§f will display a huge number of options... every combination of every tool with every material. However, the pattern to make the tool is always identical, so §ejust arrange the plates and ingots in the same manner as the examples, ignoring whatever material it says§f. Rods where rods go, plates where plates, etc. The only restriction is that tools §emust be made from all of the same material§f... you cannot mix and match different metals in a single item.\n\nRecipes will default to showing a §6Neutronium tool §rof the appropriate type if a tool is required, but the correct type of tool made out of any metal will work. Just ignore the tool\u0027s material in the recipes: it can be whatever you\u0027d like.\n\nFor now, make a §aHammer§f (not a §aMining Hammer§f, mind you... six ingots, not five). Hammers can be used to turn §etwo ingots into one plate§f. §6Plates§f can make a §aFile§f, Files can make §6Rods§f, etc. Use JEI to work your way down the list of tools.\n\n§6Wrought Iron§f is probably your best bet for a tool material right now, but better materials will become available as you progress.",
+          "desc:8": "nomifactory.quest.db.12.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -781,7 +782,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Some Starter Tools",
+          "name:8": "nomifactory.quest.db.12.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -893,7 +894,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "If you try to craft each item only when you need it, you\u0027ll go insane. It is far more effective to §ebatch-craft§f frequently used items so you don\u0027t have to do it as often. It is very satisfying to get all the ingredients together then craft §ea stack of items§f all at once.\n\n§3Crafting Stations§f are an indispensable tool for batch-crafting. They can save recipes for all the steps in production chains for things like tools, circuits, machine casings, and more. You will want to §emake several of them§r§r for the convenience they offer.\n\nEach Crafting Station comes with some inventory space for general items, as well as a dedicated row specifically for holding §bGregTech§r tools. In addition, Crafting Stations can §einteract with adjacent inventories§r, so you can keep common materials in a container between them. This includes access points to large virtual inventories, like a §aDrawer Controller§r§r, which you will be able to make later.\n\nTo use the Crafting Station, you must either manually set up a recipe in the pattern area, or click-in a table recipe from §bJEI§r. Place the ingredients inside the Crafting Station or an adjacent container, then you can click the resulting item to craft it. Once an item is crafted, the recipe will appear on the top-right in the history pane. As usual, Shift-clicking the output item will craft up to a stack of it.\n\nEach Crafting Station will remember §eup to the last nine recipes§r you made in them, which can be recalled by clicking the item in the top-right recipe history pane. Old recipes will be cycled out, so if you want to ensure a recipe doesn\u0027t ever get replaced by a different one, §eShift-click the recipe in the history pane to lock it§r.\n\nThe available ingredients from neighboring inventories are visible through the §eStorage§r tab on the Crafting Station, and you can also place items into this tab to send them to available neighboring inventories.",
+          "desc:8": "nomifactory.quest.db.13.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -904,7 +905,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Batch Crafting In Style",
+          "name:8": "nomifactory.quest.db.13.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -945,7 +946,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Iron Furnaces§f can smelt an item in §a150 ticks§f, which is somewhat faster than a vanilla §6Furnace§f, which takes §a200 ticks§f. The fuel efficiency remains the same for all furnaces.",
+          "desc:8": "nomifactory.quest.db.14.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -956,7 +957,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v2.0",
+          "name:8": "nomifactory.quest.db.14.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -997,7 +998,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Copper Furnaces§f are another step up in speed, taking §a100 ticks§f to smelt an item.",
+          "desc:8": "nomifactory.quest.db.15.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1008,7 +1009,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v3.0",
+          "name:8": "nomifactory.quest.db.15.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1049,7 +1050,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Silver Furnaces§f are another step up in speed, taking a mere §a60 ticks§f to smelt an item.",
+          "desc:8": "nomifactory.quest.db.16.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1060,7 +1061,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v4.0",
+          "name:8": "nomifactory.quest.db.16.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1101,7 +1102,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Gold Furnaces§f are yet another step up in speed, taking only §a40 ticks§f to smelt an item.",
+          "desc:8": "nomifactory.quest.db.17.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1112,7 +1113,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v5.0",
+          "name:8": "nomifactory.quest.db.17.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1153,7 +1154,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "While §3Obsidian Furnaces§f are the same speed as §3Diamond Furnaces§f, they have twice the throughput since they can §esmelt two items at once§f.\n\nYou may find that Diamond Furnaces suit your needs better than Obsidian, but they\u0027ll both be crafting ingredients in various machines soon enough, so crafting one is not a waste, even if you don\u0027t use it.",
+          "desc:8": "nomifactory.quest.db.18.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1164,7 +1165,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v7.0",
+          "name:8": "nomifactory.quest.db.18.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1206,7 +1207,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Benzene§r is a common reagent which can be obtained from §9Wood Tar§r or §9Oil§r. Apart from that, it is a potent fuel which generates §d352 EU/mB§r in a §3Gas Turbine§r.\n\nLater, you can use an HV §3Chemical Reactor§r to upgrade it to §9Nitrobenzene§r, which has a greatly improved fuel density.",
+          "desc:8": "nomifactory.quest.db.19.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1221,7 +1222,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Benzene",
+          "name:8": "nomifactory.quest.db.19.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -1258,7 +1259,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Diamond Furnaces§f are the fastest available, taking only §a25 ticks§f to smelt an item.",
+          "desc:8": "nomifactory.quest.db.20.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1269,7 +1270,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Furnace v6.0",
+          "name:8": "nomifactory.quest.db.20.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1310,7 +1311,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You already have §6Steel§r, but it can be made much faster in the §3Blast Furnace§r, at the cost of EU and §9Oxygen§r.",
+          "desc:8": "nomifactory.quest.db.21.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1321,7 +1322,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Steel",
+          "name:8": "nomifactory.quest.db.21.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1362,7 +1363,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The main function of this oven is to increase the fuel values of your wood and coal while also recovering some of the various potentially useful waste products.\n\nTurning §6Coal§r into §6Coal Coke§r will not only make it more useful as fuel, but will also produce §9Phenol§r, which you\u0027ll need for circuits.\n\nThe Pyrolyse Oven is also the source of several other fluids that can be distilled for useful ingredients.\n\nYou can §6sneak-right click§r the controller to enable the in-world preview.\n\n§2As stated in the tooltip, higher tier coils will make this faster.\n",
+          "desc:8": "nomifactory.quest.db.22.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1373,7 +1374,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Pyrolyse Oven",
+          "name:8": "nomifactory.quest.db.22.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1468,7 +1469,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need §6Obsidian§r to make §6Dark Steel§r. Most of the tools you can make cannot mine Obsidian, but you do have a few potential options for ones that will work. The options you\u0027re most likely to have access to at this point are:\n\n1) A §aDiamond Pickaxe§r or §aDiamond Mining Hammer§r.\n\n2) A §aPlatinum Mining Hammer§r (not pickaxe though).",
+          "desc:8": "nomifactory.quest.db.23.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1479,7 +1480,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Obsidian",
+          "name:8": "nomifactory.quest.db.23.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1521,7 +1522,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your first major crafting project!\n\nYou\u0027ll need a small bit of §6Silver§f for this dynamo. You won\u0027t need a ton of silver and lead just yet, so it won\u0027t bankrupt you.\n\nKeep in mind that §eDynamos only output power when burning through fuel, and only the block attached directly to the coil will get provided with power§f.",
+          "desc:8": "nomifactory.quest.db.24.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1538,7 +1539,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Steam Dynamo",
+          "name:8": "nomifactory.quest.db.24.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1585,7 +1586,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This quest is repeatable once per hour and gives you a free cake to the Void World or Overworld. You can also refill your cakes with the items indicated in their tooltips.",
+          "desc:8": "nomifactory.quest.db.25.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1596,7 +1597,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Cake Based Dimensional Transit",
+          "name:8": "nomifactory.quest.db.25.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1648,7 +1649,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Steel§r alloyed with §6Obsidian§r makes §6Dark Steel§r, which is needed for many of the machines in §bEnderIO§r and §bApplied Energistics§r.\n\nLater, you can use §6Void Crystal§r instead of Obsidian.",
+          "desc:8": "nomifactory.quest.db.26.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1659,7 +1660,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dark Steel",
+          "name:8": "nomifactory.quest.db.26.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1700,7 +1701,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The place for your very first chemical reactions, namely making some improved substrates.",
+          "desc:8": "nomifactory.quest.db.27.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1711,7 +1712,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Chemical Reactor",
+          "name:8": "nomifactory.quest.db.27.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1752,7 +1753,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Pulsating Dust§r is a mysterious magical material that taps into the power of Ender. It has all sorts of strange and potentially dangerous applications, including the ability to make §6Pulsating Ingots§r and §6Ender Pearls§r.\n\nYour first source of Pulsating Dust is §6Uraninite§r, which you can get from §6Uraninite Ore§r. Later on, you\u0027ll be able to produce Pulsating Dust by smelting §6Resonant Clathrates§r.\n\n§cPlease note that the Enderpearl Dust electrolysis recipe requires an EV Electrolyzer, and is most likely not worth it.§r",
+          "desc:8": "nomifactory.quest.db.28.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1763,7 +1764,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pulsating Dust",
+          "name:8": "nomifactory.quest.db.28.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1810,7 +1811,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §bEnder IO§r alloy.\n\nMade from §6Pulsating Dust§r and an §6Iron Ingot§r.\n\nIf you can\u0027t find one otherwise, §6Ender Pearls§r can be crafted using Pulsating Dust and a §6Diamond§r in an §3Alloy Smelter§r.",
+          "desc:8": "nomifactory.quest.db.29.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1821,7 +1822,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pulsating Iron and Ender Pearls",
+          "name:8": "nomifactory.quest.db.29.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1869,7 +1870,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §bEnderIO§r alloy, made from §6Silicon Dust§r and a §6Steel Ingot§r.\n\nThis material is frequently used in electronics and digital equipment.",
+          "desc:8": "nomifactory.quest.db.30.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1880,7 +1881,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Electrical Steel",
+          "name:8": "nomifactory.quest.db.30.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1922,7 +1923,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Two §aAdvanced Capacitor Banks§r can be grafted together with a §6Vibrant Crystal§r and §6Vibrant Alloy Plates§r to create a §aVibrant Capacitor Bank§r, which stores five times as much RF as the advanced bank, for a total of twenty-five times as much as the basic bank.",
+          "desc:8": "nomifactory.quest.db.31.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1936,7 +1937,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vibrant Capacitor Bank",
+          "name:8": "nomifactory.quest.db.31.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -1978,7 +1979,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Two §aCapacitor Banks§r can be grafted together with a §6Double-Layer Capacitor§r and §6Electrical Steel§r to create an §aAdvanced Capacitor Bank§r, which stores five times as much RF as the basic bank.",
+          "desc:8": "nomifactory.quest.db.32.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1992,7 +1993,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Capacitor Bank",
+          "name:8": "nomifactory.quest.db.32.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2033,7 +2034,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Expandable multi-block storage for RF power.\n\nThis first tier isn\u0027t much, but you can upgrade them over time to hold substantial amounts of power.",
+          "desc:8": "nomifactory.quest.db.33.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2047,7 +2048,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basic Capacitor Bank",
+          "name:8": "nomifactory.quest.db.33.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2089,7 +2090,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §bEnderIO§r alloy, made from §2mixing§r §22 Gold Dust, 1 Redstone Dust, and 1 Glowstone Dust§r §2and putting it §rin your new §3Electric Blast Furnace§r.\n\nThrow §2the prepared dust into the input bus§r and in twenty seconds your §6Energetic Alloy Ingot§r will be in the output bus.\n\n§2In EV Age, you can build an Alloy Blast Smelter which doubles the yield.",
+          "desc:8": "nomifactory.quest.db.34.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2100,7 +2101,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Energetic Alloy",
+          "name:8": "nomifactory.quest.db.34.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2141,7 +2142,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An EnderIO alloy.\n\n§2In EV Age, you can build an Alloy Blast Smelter which doubles the yield.",
+          "desc:8": "nomifactory.quest.db.35.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2152,7 +2153,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Vibrant Alloy",
+          "name:8": "nomifactory.quest.db.35.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2230,7 +2231,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Going out in search of a §6Rubber Tree§f is a viable option for sure. However, if this isn\u0027t appealing, you can also §eshear leaves§f and make §6Plantballs§f out of them. Plantballs smelt into §6Slime§f, and Slime smelts into §6Sticky Resin§r.\n\nYou\u0027ll want to transition to Rubber Trees at some point, though, since the §eratio of leaves to rubber is quite poor§f.\n\nUse the §3Steam Extractor§r to extract §6Raw Rubber Pulp§r from the resin, then \"alloy\" with §6Sulfur§r for the §6Rubber§r. It\u0027s quite inefficient to do it this way, but such is the life of early game §bGregTech§f. At least rubber isn\u0027t particularly hard to come by.",
+          "desc:8": "nomifactory.quest.db.37.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2241,7 +2242,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Rubber Sheets",
+          "name:8": "nomifactory.quest.db.37.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2291,7 +2292,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§oNote: this quest accepts any §2§oLV Energy Converter§r§o.\n\n§r§aRF power§r and §bGregTech§r §aEU power§r is incompatible. With your first §6circuit§r in hand, you are ready to build a §eLow Voltage (LV) §3§2Energy Converter§r.\n\nThe §2Energy Converter§r is a special device that §econverts §2between §aRF power§r and §aEU power§r. They come in §2four sizes: 1A, 4A, 8A, and 16A.\n\n§aRF§r converts into §aEU§r at a §e4 to 1 ratio§r. §a100 RF§r becomes §a25 EU§r, and vice-versa. §2Use a Soft Hammer to change the conversion direction.",
+          "desc:8": "nomifactory.quest.db.38.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2302,7 +2303,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Power",
+          "name:8": "nomifactory.quest.db.38.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2344,7 +2345,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Item conduits are useful for moving items between inventories over moderate distances.\n\nCrafting them in an Assembling Machine instead of by hand gives twice as many conduits.",
+          "desc:8": "nomifactory.quest.db.39.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2355,7 +2356,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Item Conduits",
+          "name:8": "nomifactory.quest.db.39.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2396,7 +2397,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The most basic tier of §aRF§r energy conduits from §bEnderIO§r.\n\nThese can be used to transport energy from your §3Steam Dynamos§r to various destinations.",
+          "desc:8": "nomifactory.quest.db.40.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2407,7 +2408,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Conductive Iron Energy Conduits",
+          "name:8": "nomifactory.quest.db.40.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2448,7 +2449,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have §6Energetic Alloy§r, it\u0027s time to make some better conduits!\n\nEach time you upgrade your conduits, you\u0027ll also get more of them. Neat!\n\nIf you don\u0027t have an §3Assembling Machine§r, you\u0027ll have to make them by hand. This method isn\u0027t as efficient as the machine, but you\u0027ll make one soon enough.",
+          "desc:8": "nomifactory.quest.db.41.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2459,7 +2460,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Energetic Alloy Energy Conduits",
+          "name:8": "nomifactory.quest.db.41.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2501,7 +2502,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Conduits to carry even MORE RF power.\n\nYou\u0027re making these in the §3Assembling Machine§r, right?",
+          "desc:8": "nomifactory.quest.db.42.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2512,7 +2513,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vibrant Alloy Energy Conduits",
+          "name:8": "nomifactory.quest.db.42.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2591,7 +2592,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Combining §6Basic RF Capacitors§r with some §6Coal Dust§r and §6Energetic Alloy§r produces a §6Double-Layer RF Capacitor§r.\n\nThis is a tier two capacitor. Higher tier RF Capacitors will make §bEnderIO§r machines process faster and depending on the machine will expand their capabilities further (like area of effect).",
+          "desc:8": "nomifactory.quest.db.44.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2602,7 +2603,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Double Capacitor",
+          "name:8": "nomifactory.quest.db.44.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2643,7 +2644,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Being able to fly is nice. This is the first jetpack that uses §bEnderIO§r materials.\n\nThere\u0027s also a quest chain for §bThermal Expansion§r material Jetpacks (starting with the §6Leadstone Jetpack§r). Eventually you\u0027ll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really really like flying.\n\nIf the §6Jetpack§r overview and information from §bThe One Probe§r conflict, they can be adjusted through the §bSimply Jetpacks 2§r §eConfiguration file§r or the command §6/topcfg§r respectively.",
+          "desc:8": "nomifactory.quest.db.45.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2658,7 +2659,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ironman",
+          "name:8": "nomifactory.quest.db.45.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2739,7 +2740,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Flying faster, even nicer.",
+          "desc:8": "nomifactory.quest.db.47.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2754,7 +2755,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ironman 3",
+          "name:8": "nomifactory.quest.db.47.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2797,7 +2798,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Flying faster is nice.",
+          "desc:8": "nomifactory.quest.db.48.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2812,7 +2813,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ironman 2",
+          "name:8": "nomifactory.quest.db.48.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2855,7 +2856,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts LV/MV/HV Centrifuge.\n\nCentrifuging air is a reliable way to get §9Nitrogen§r before you have access to §3Cryogenic Distillation§r.\n\n",
+          "desc:8": "nomifactory.quest.db.49.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2866,7 +2867,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Air Centrifuging",
+          "name:8": "nomifactory.quest.db.49.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2907,7 +2908,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§b§2GTCEu Fluid Pipes have been reworked and work much better now. There are also Quadruple and Nonuple pipes for transporting multiple fluid types through the same block. Their advantage over EnderIO Fluid Conduits is their higher throughput - 414 mB/t for a low-tier (Normal Potin) pipe.\n\n§rHowever, EnderIO Fluid Conduits still have the advantage of being EnderIO Conduits, allowing them to fit in the same block as other Conduits. Pick your poison.",
+          "desc:8": "nomifactory.quest.db.50.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2918,7 +2919,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Fluid Transport",
+          "name:8": "nomifactory.quest.db.50.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -2961,7 +2962,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Inscribers§r are machines used to make §6inscribed circuits§r for §bApplied Energistics§r.",
+          "desc:8": "nomifactory.quest.db.51.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2972,7 +2973,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Inscriber",
+          "name:8": "nomifactory.quest.db.51.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3011,7 +3012,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Coming soon!",
+          "desc:8": "nomifactory.quest.db.52.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3022,7 +3023,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Cleanroom",
+          "name:8": "nomifactory.quest.db.52.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -3049,7 +3050,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Wiremill§r is a major efficiency boost, giving you a much greater yield of §6wires§r for your ingots. But first, you\u0027ll need to make some §6Motors§r.\n\n§bGregTech§r machines are built from a number of components, many of which are shared between the machines. Motors§r are used in a great number of recipes, even including other components.\n\nMake sure to encode the recipes needed for motors into a §3Crafting Station§r. You\u0027ll need quite a lot of them.\n\nAfter you make the Wiremill, §econsider making a few stacks§r of LV motors. This might sound extreme, but §ebatch crafting§r in this manner is an important habit to pick up. This way you won\u0027t have to craft more for a while, and you §owill §ruse all those motors eventually, so you\u0027re not wasting materials.\n\nAs you get access to more machinery you will no longer need to craft things manually. Instead, you will engineer factories to automate the production for you. It is useful to keep a stockpile of frequently used things like circuits and components crafted so you don\u0027t have to wait for them when you need them.\n\n§2If the machine sounds start to get on your nerves, you can mute GT machines with a GT Hammer.",
+          "desc:8": "nomifactory.quest.db.53.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3060,7 +3061,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Wiremill",
+          "name:8": "nomifactory.quest.db.53.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3107,7 +3108,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "When §6Ender Eyes§r just aren\u0027t creepy enough.\n\nYou\u0027ll need an HV or better §3Chemical Bath§r to make these. The recipe is quite slow, so invest in the highest tier Chemical Baths you can and consider parallelizing the recipe.",
+          "desc:8": "nomifactory.quest.db.54.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3118,7 +3119,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Quantum Eyes",
+          "name:8": "nomifactory.quest.db.54.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3160,7 +3161,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Centrifuges§r provide you with §21 tiny pile§r of additional materials when processing ore dusts (§e9 tiny piles \u003d 1 dust§r). Sometimes it\u0027s the main dust, but often it\u0027s a different useful material that is otherwise unobtainable.\n\nInstead of washing §6impure dusts§r (made from macerating or hammering ores) in a cauldron, you can get more out of each dust by centrifuging it. The same is true of §6pure dusts§r, when you eventually make a §3Washer§r or §3Chemical Bath§r. Note however that pure and impure dusts will usually give different byproducts (always check in §bJEI§r).\n\nCentrifuges also have other uses like unmixing compound dusts and fluids, or getting §6Rubber Pulp§r, which can be chemically reacted with §6Sulfur§r to efficiently make §9liquid Rubber§r.\n\n",
+          "desc:8": "nomifactory.quest.db.55.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3171,7 +3172,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Centrifuge",
+          "name:8": "nomifactory.quest.db.55.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3212,7 +3213,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have everything you need to power your machines, it\u0027s time to put it all together.\n\nYour Steam Dynamo needs burnable fuel (like §6Coal§r) and §9water§r. It will output RF power through the Excitation Coil (the red bit at the top). The orientation of the Steam Dynamo can be adjusted with a §aCrescent Hammer§r, if needed.\n\n§6Energy Conduits§r can be used to transfer that RF power, but the dynamo can also output RF directly into an Energy Converter by making the Excitation Coil touch the Energy Converter.\n\nThe Energy Converter transforms RF power into EU, outputting the resulting EU through the side with a red dot. The orientation can be adjusted using a §aWrench§r. Attach your §6Conductive Iron Cables§r to the output side of the Energy Converter.\n\nNow all you need are some §bGregTech§r machines to hook up to the cables! You can make whatever you want, but its recommended that you get these two first:\n\nThe §6Wiremill§r will make crafting wires much, much easier.\n\nThe §2Metal Bender§r will make Plates from one ingot instead of two.",
+          "desc:8": "nomifactory.quest.db.56.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3223,7 +3224,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Putting It All Together",
+          "name:8": "nomifactory.quest.db.56.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3252,7 +3253,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aEnder Fluid Conduits§r are the most powerful fluid transportation mechanism offered by §bEnderIO§r.\n\nNot only are these faster than §aPressurized Fluid Conduits§r, but because they teleport fluids instead of flowing them in the conduits, it possible to have a large number of fluids moving through a single line.\n\nIn addition to §aFilters§r they also have multiple channels which can be used to direct fluids through the same conduits to various destinations.\n\nIf you don\u0027t want to (or haven\u0027t unlocked access to) routing fluids through §bAE§r, these are your best alternative.",
+          "desc:8": "nomifactory.quest.db.57.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3263,7 +3264,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ender Fluid Conduits",
+          "name:8": "nomifactory.quest.db.57.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3304,7 +3305,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Batteries§r are §bGregTech §rpower storage for §aEU§r energy.\n\nThere are several types of rechargeable batteries you can make; §2Lithium Batteries§r are the best ones, followed by §6Cadmium§r and §6Sodium§r.\n\n§6Lithium§r is possible to find inside of §6Tungsten§r veins, however, they only spawn in §eThe End§r§r. §6Cadmium§r comes from various §6Refined Ores§r, and §6Sodium§r is the easiest - from §6Salt§r, §6Clay§r, and many other minerals.",
+          "desc:8": "nomifactory.quest.db.58.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3318,7 +3319,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Power Storage",
+          "name:8": "nomifactory.quest.db.58.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3359,7 +3360,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Nickel comes from several different ores, including Pentlandite and Garnierite, but they\u0027re all found in the same vein.\n\nNickel is used mostly for several very important alloys, including Invar and Cupronickel.",
+          "desc:8": "nomifactory.quest.db.59.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3370,7 +3371,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Copper... Nickel... Cupronickel?",
+          "name:8": "nomifactory.quest.db.59.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -3425,7 +3426,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Electric Blast Furnace§r is a major, major milestone in your §bGregTech§r career. It has the power to smelt more advanced materials. The first of which, §6Aluminium§r, is going to be important in the immediate future.\n\nThere is a diagram of how to build the EBF in §bJEI§r. The second and third levels must be a 3x3 square shape of Coil Blocks (§6Cupronickel§r is the only type of coil block you have access to for now) with an empty center. You can also §6sneak-right click§r the controller to enable the in-world preview.\n\nHowever, the bottom and top layers are very flexible. The §6EBF Controller§r must be on the §ebottom layer§r of the structure, and on the §emiddle of an outer edge§r; the §6Muffler Hatch§r must be in the §eexact middle of the top layer§r. Otherwise, you can put the hatches and buses wherever you want, filling in all gaps in each layer with §6Heatproof Machine Casings§r. It\u0027s worth noting that you must §euse at least §29§e Heatproof Machine Casings in your layout or the structure will not form§r.\n\nThis quest calls for a §2maintenance hatch§r, two energy hatches, a fluid input and output, and an item input and output, which is a total of 7 positions. Their specific order and placement don\u0027t matter, as long as you can access them. The 8th position is your EBF controller, leaving 9 gaps to be filled by Heatproof Machine Casings. If you did everything right, the structure will form: the colors on its hatches and casings will unify, and the controller will say \"Idling.\"\n\nYou\u0027ll most likely want to locate your power quite near to the EBF. It is very power hungry, and if it cannot get enough energy, progress on the current item smelting will start to regress. Be careful to ensure the EBF has enough power, and keep a Soft Hammer nearby to pause it by tapping the controller if you run out of power.\n\n§2In GTCEu, all hatches except Maintenance can be shared between Multiblocks!",
+          "desc:8": "nomifactory.quest.db.60.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3436,7 +3437,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Blast Furnace Fun",
+          "name:8": "nomifactory.quest.db.60.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3531,7 +3532,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Some Micro Miner missions use a §6Gemstone Sensor§r to scout out gems instead of ores.\n\n§6§2Perfect Gems§r can be obtained from such missions.",
+          "desc:8": "nomifactory.quest.db.61.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3542,7 +3543,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Gemstone Sensor",
+          "name:8": "nomifactory.quest.db.61.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3583,7 +3584,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Access all of your items on a single screen. Soon, anyway.\n\nPlease note that all four variants of §6ME Terminals§r are §emicroparts§r, which means they need to be attached to an §6ME Cable§r (not conduit) to function.",
+          "desc:8": "nomifactory.quest.db.62.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3594,7 +3595,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Terminal",
+          "name:8": "nomifactory.quest.db.62.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3635,7 +3636,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aME Chest§r is somewhat impractical to use on its own, but it\u0027s a necessary ingredient for the much more useful §6ME Drive§r.\n\nThis is a rudimentary digital item storage device. By placing a §6Storage Cell§r inside it, you can access the contents as though you were looking through a chest. You can carry the disk to another location and place it down in a different ME Chest if you want, and the items will come with it.\n\n§cDon\u0027t put Storage Cells inside other portable mod inventories like a Satchel, (or vice-versa) as you risk corrupting the contents of the Satchel and the Storage Cell.§r There\u0027s technical reasons why this happens (NBT overflow), and it\u0027s not unique to these items, but that\u0027s not really worth going into.\n\n",
+          "desc:8": "nomifactory.quest.db.63.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3646,7 +3647,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ME Chest",
+          "name:8": "nomifactory.quest.db.63.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3687,7 +3688,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bApplied Energistics§r uses §6Storage Cells§r as its primary means of digital item and fluid storage.\n\nAll unformatted Storage Cells are limited to at most 63 distinct item types, with the first item of each new type taking up a chunk of the total bytes of cell storage, and subsequent items of existing types taking a small number of bytes thereafter.\n\nA §61k ME Storage Cell§r is the first and smallest cell for storing items. If you are going to be storing many different kinds of items in your network, you will need to make an §6ME Drive§r and fill it with multiple Storage Cells.\n\nThe §64k ME Storage Cell§r is the next size up. With four times the bytes it holds substantially more items per type, but it requires a more advanced technology than you currently have available: AE §6Processors§r made in an §3Inscriber§r.",
+          "desc:8": "nomifactory.quest.db.64.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3699,7 +3700,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Digital Storage At Last",
+          "name:8": "nomifactory.quest.db.64.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3753,7 +3754,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Third Micro Miner.\n\nThis one can get you:\n§6* Tetrahedrite Ore\n* Cassiterite Ore\n* Tungstate Ore\n* Scheelite Ore\n* Redstone Ore\n* Quartz Ore\n* Vanadium Magnetite Ore\n§2* Ilmenite Ore§6\n* Tin Ore\n* Sapphire Ore§r\n§6* Almandine Ore§r\n\nor:\n§6* Dense Magma Block§r\n\nWhen equipped with Gemstone Sensor:\n§6§2* Perfect Emeralds\n* Perfect Diamonds\n* Perfect Rubies\n* Perfect Topaz\n§6* Silver Ore\n* Gold Ore",
+          "desc:8": "nomifactory.quest.db.65.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3764,7 +3765,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Three Micro Miner",
+          "name:8": "nomifactory.quest.db.65.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3806,7 +3807,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Alloy Smelter§f\n\n§3Smelt§f it into ingots, §ahammer§f it into §6Plates§f, and §acut§f them into §6Wires§f.",
+          "desc:8": "nomifactory.quest.db.66.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3817,7 +3818,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "From Dusts To Wires",
+          "name:8": "nomifactory.quest.db.66.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -3883,7 +3884,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A pair of §6Double-Layer RF Capacitors§r combined with some §6Vibrant Alloy§r and §6Glowstone§r creates an §6Octadic RF Capacitor§r, which is a tier three §bEnderIO§r capacitor.",
+          "desc:8": "nomifactory.quest.db.67.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3894,7 +3895,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Octadic Capacitor",
+          "name:8": "nomifactory.quest.db.67.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3936,7 +3937,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Experience Obelisk§r is a mass storage device for player experience in the form of §9Liquid XP§r.\n\nVia the GUI you can insert or extract levels as needed, as well as configure interactions with neighboring blocks (as is typical of §bEnderIO§r machines).\n\nLiquid XP can also be pumped in directly from your automation such as §3Fluid Extractors§r.",
+          "desc:8": "nomifactory.quest.db.68.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3947,7 +3948,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Experience Obelisk",
+          "name:8": "nomifactory.quest.db.68.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -3989,7 +3990,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your EBF running, start to create a supply of §6Aluminium Ingots§r. These are crucial ingredients for MV machines, including §bApplied Energistics§r.\n\n§2With LV power, you can only get Aluminium Dust from electrolyzing Sapphire Dust or Green Sapphire Dust. Once you make an MV Electrolyzer, you can get it from a plethora of other raw resources.§r\n\nIf you find your power supply is faltering, you may want to make additional dynamos and turn them into steam boilers and turbines. Upgrading your dynamos is also advisable.\n\nHowever, you\u0027re also about to reach MV. You\u0027re bound to discover a better power source than steam before long.\n\n§2You can cut by a third the smelting time of Aluminium and some other smelting processes with Nitrogen gas. Higher-tier processes may take different gases.",
+          "desc:8": "nomifactory.quest.db.69.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4000,7 +4001,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Aluminium Ingots",
+          "name:8": "nomifactory.quest.db.69.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4042,7 +4043,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aMV Batteries§r function essentially the same as §aLV Batteries§r, only stronger. They also need to be put into an §3MV Machine§r or §3MV Battery Buffer§r.",
+          "desc:8": "nomifactory.quest.db.70.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4056,7 +4057,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Power Storage",
+          "name:8": "nomifactory.quest.db.70.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4098,7 +4099,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §3MV Electrolyzer§r allows you to process recipes that require up to 128 EU/t, and can optionally overclock recipes costing at most 32 EU/t.\n\nThis means you can split more kinds of things for useful products.\n",
+          "desc:8": "nomifactory.quest.db.71.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4109,7 +4110,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Electrolyzer",
+          "name:8": "nomifactory.quest.db.71.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4152,7 +4153,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Assembling Machines come early in CEu! Circuit recipes are handled through a separate machine, the Circuit Assembler. §r\n\nAssembling Machines open up a plethora of §eequal or more efficient recipes that don\u0027t require hand tools§r. §2For example, you can make up to 6 Vacuum Tubes in a single craft! Many of its recipes will require fluids.§r Hand tool recipes also don\u0027t play nice with §bApplied Energistics§r.\n\nTake advantage of Assembling Machines: §cphase out all use of hand tools for crafting items in your automation going forward.§r Once you have all the important machines, you will never need hand tools for crafting.",
+          "desc:8": "nomifactory.quest.db.72.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4163,7 +4164,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Assembling Machine",
+          "name:8": "nomifactory.quest.db.72.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4205,7 +4206,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6ME Conduits§r have the advantage of being able to share a block space with other conduit types. Oh, and they\u0027re relatively cheaper to make.\n\nThe only downside is that §ethey will not connect to §bApplied Energistics§r §emicroparts§r like slab-form §6Interfaces§r or §6Level Emitters§r, so you have to use AE cables like §6Fluix Cable§r for those.",
+          "desc:8": "nomifactory.quest.db.73.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4216,7 +4217,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ME Conduit",
+          "name:8": "nomifactory.quest.db.73.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4257,7 +4258,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Quartzite Ore§r is found in... quartzite veins in the Overworld.\n\n§6Quartzite Dust§r can be electrolyzed into §6Crushed Black Quartz§r, which can be crystallized into §6Black Quartz§r in an §3Autoclave§r.\n\nBlack Quartz and §6Aluminium Plates§r will make §6Aluminium Casings§r, which are used for making machines from §bActually Additions§r.",
+          "desc:8": "nomifactory.quest.db.74.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4268,7 +4269,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Aluminium Casing",
+          "name:8": "nomifactory.quest.db.74.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4315,7 +4316,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Machine Block§r is the first step into a mod called §bExtra Utilities 2§r.",
+          "desc:8": "nomifactory.quest.db.75.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4326,7 +4327,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Machine Block",
+          "name:8": "nomifactory.quest.db.75.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4369,7 +4370,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your first §6Tier Two Circuits§r will require §2two §6Tier One Circuits§r plus §2two §6Diodes§r.\n\nThese are rather expensive... Always be on the lookout for a cheaper way to make your circuits - new sets of recipes become available each time you make a new tier of §2Circuit Assembler§r. Conveniently, this tier of Circuit unlocks one now!",
+          "desc:8": "nomifactory.quest.db.76.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4380,7 +4381,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Two Circuits",
+          "name:8": "nomifactory.quest.db.76.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4422,7 +4423,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Perfect Gems are equivalent to 8 of the base gem.\n\n§211 Perfect Diamonds are used in crafting each Crystal Matrix Ingot.",
+          "desc:8": "nomifactory.quest.db.77.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4433,7 +4434,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Perfect Gems",
+          "name:8": "nomifactory.quest.db.77.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4475,7 +4476,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Initial circuit components are a bit more difficult in CEu, and you need Arsenic in addition to Gallium.§r\n\nFor §dGallium§r, you may, ranged from worst to best:\n\n- §3Electrolyze §aSphalerite§r for a low chance of small dust. Note that you lose on direct smelting value.\n\n-§r Put §aCrushed Bauxite§r in the §3Chemical Bath§r. Note that this requires §9Sodium Persulfate§r. \n\n- Obtain it as a Byproduct of §aSphalerite§r Ore Processing, in the §3Thermal Centrifuge§r or §3Centrifuge§r.\n\n§2For Arsenic, you must centrifuge Realgar Dust, or (more involvedly) flash smelt Cobaltite Dust in the EBF, and electrolyse the resultant Arsenic Trioxide.\n\nCombine both in a Mixer to make Gallium Arsenide.",
+          "desc:8": "nomifactory.quest.db.78.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4486,7 +4487,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Gallium Arsenide",
+          "name:8": "nomifactory.quest.db.78.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4540,7 +4541,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Cuts things up.\n\nThe §3Cutting Machine§r is able to cut wafers, rods, wood, and various other things for you, making it a versatile crafting tool. Cutting blocks into 9 plates is much faster than using a §2Metal Bender §rto make them one at a time.\n\nThis quest accepts the LV or MV version. The LV version can cut §6Silicon Boules§r for easier §6Diodes§r, and can also cut plates and other components. The MV version is required for cutting §6Wafers§r.\n\nThe blade will require you to make §2Cobalt Brass§r (for LV) or §2Vanadiumsteel§r (for MV).\n\nCutting Machines work with plain §9Water§r for all recipes. You can also use §9Distilled Water§r which speeds up the processing somewhat, or §9Lubricant§r that speeds it up greatly (and uses very little per operation). These might be a little tricky to make right now, but are very worthwhile upgrades in the future.\n\nYou might consider waiting until you have §2Integrated Circuits§r before progressing too far down the path of MV machines, since these circuits are much easier to make than §2Electronic Circuits§r.",
+          "desc:8": "nomifactory.quest.db.79.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4551,7 +4552,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Cutting Machine",
+          "name:8": "nomifactory.quest.db.79.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4610,7 +4611,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A hefty amount of §6Silicon Dust§r and a pinch of §2Gallium Arsenide §rcooked in an §3EBF§r will net you a §6Silicon Boule§r, the starting point for §6Circuit Wafers§r.\n\nMake sure your power system is up to the task. These take §27.5 minutes and 1,080,000 EU§r to process.",
+          "desc:8": "nomifactory.quest.db.80.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4621,7 +4622,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Silicon Boules",
+          "name:8": "nomifactory.quest.db.80.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4663,7 +4664,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Wafers§r are thin pieces of silicon cut from a §6Silicon Boule§r.\n\nTheir primary purpose is engraving §6Circuit Wafers§r.\n\nYou\u0027ll be needing huge amounts of these Wafers for circuits. Silicon Boules currently take a very long time to craft, so consider parallelizing the recipe in multiple §3EBF§rs and making a stockpile of them.",
+          "desc:8": "nomifactory.quest.db.81.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4674,7 +4675,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Silicon Wafers",
+          "name:8": "nomifactory.quest.db.81.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4716,7 +4717,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Phenol§r is produced as a byproduct from making §6Coal Coke§r in a §3Pyrolyse Oven§r.\n\nThese boards will enable the next tier of circuits, as well as a much cheaper method of circuit production.",
+          "desc:8": "nomifactory.quest.db.82.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4727,7 +4728,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phenol Coated Substrate",
+          "name:8": "nomifactory.quest.db.82.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4771,7 +4772,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §3Precision Laser Engraver§r is used to engrave circuits onto §6Wafers§r.\n\nThe type of circuit will depend on the kind of wafer used and which §aLens§r is in the machine.",
+          "desc:8": "nomifactory.quest.db.83.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4782,7 +4783,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Precision Laser Engraver",
+          "name:8": "nomifactory.quest.db.83.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4825,7 +4826,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Circuit Wafers§r are batches of integrated circuits engraved onto a wafer of electronics-grade silicon.\n\nYou need to run these through the §3Cutting Machine§r to dice the wafers into individual integrated circuits (called dies).\n\nThese are important components and will be used for making more advanced Circuits.",
+          "desc:8": "nomifactory.quest.db.84.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4836,7 +4837,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Circuit Wafers",
+          "name:8": "nomifactory.quest.db.84.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4921,7 +4922,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Much easier to mass produce than §6Electronic Circuits§r, and they fulfill the same function in nearly all cases.\n\nYou should be batch crafting these.",
+          "desc:8": "nomifactory.quest.db.86.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4932,7 +4933,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier One Circuits",
+          "name:8": "nomifactory.quest.db.86.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -4973,7 +4974,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Two Integrated Circuits§r and various other components will create a §2Good Integrated Circuit.",
+          "desc:8": "nomifactory.quest.db.87.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4984,7 +4985,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Two Circuits",
+          "name:8": "nomifactory.quest.db.87.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5026,7 +5027,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need a variety of §alenses§r for use in §3Precision Laser Engravers§r, all of which are made in the §2Lathe§r.\n\nInitially you\u0027ll need a §a§3§2Ruby Lens§r. Soon you will need §2Diamond, Emerald, Topaz, and Sapphire Lenses§r. §2You can choose to use an MV Lathe to get a lens from a plate, or sift for an Exquisite Gem and use an LV Lathe.\n\n",
+          "desc:8": "nomifactory.quest.db.88.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5037,7 +5038,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Lenses",
+          "name:8": "nomifactory.quest.db.88.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5079,7 +5080,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your first tier three circuit, formed from §2two Good Integrated Circuits§r, §6RAM§r, and §6Transistors§r, among other ingredients.\n\nAs you\u0027ll realize is the pattern, it is expensive and unwieldy to make the first forms of each tier of circuits. Fortunately, you don\u0027t have to make many of them.\n\nPrioritize using these circuits to make things needed for unlocking the next theme of circuits, which require more infrastructure but are much cheaper to produce. Eventually each tier through six will have a circuit recipe instead of requiring processors, arrays, or mainframes.",
+          "desc:8": "nomifactory.quest.db.89.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5090,7 +5091,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Three Circuits",
+          "name:8": "nomifactory.quest.db.89.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5132,7 +5133,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With the §3Advanced Circuit Assembling Machine§r, a new theme of Circuits is available.",
+          "desc:8": "nomifactory.quest.db.90.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5143,7 +5144,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2MV Circuit Assembler",
+          "name:8": "nomifactory.quest.db.90.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5184,7 +5185,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Chrome§r is obtained by electrolyzing §6Ruby Dust§r.",
+          "desc:8": "nomifactory.quest.db.91.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5195,7 +5196,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chrome",
+          "name:8": "nomifactory.quest.db.91.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5237,7 +5238,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Farmer§r can be used to automate the planting and gathering of crops, including §6Potatoes§r, §6Canola§r, §6Carrots§r, and §6Beetroot§r.\n\nDoesn\u0027t do trees, though.",
+          "desc:8": "nomifactory.quest.db.92.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5248,7 +5249,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Farmer",
+          "name:8": "nomifactory.quest.db.92.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5290,7 +5291,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6HV Machine Hulls§r made, you\u0027ve made your first step towards §eHigh Voltage (HV)§r power machinery!\n\nWhile you can make these in a crafting table with §6Polyethylene Sheets§r, liquid §9Polyethylene§r can be used to craft these directly in an §3Assembling Machine§r.",
+          "desc:8": "nomifactory.quest.db.93.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5301,7 +5302,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "HV Machine Hulls",
+          "name:8": "nomifactory.quest.db.93.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5343,7 +5344,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Sulfuric Acid is mainly produced in a 3-step process:§r\n-§6 Sulfur§o§r added to §9Oxygen§r to produce §9Sulfur Dioxide§r. §9SO₂§r also can come from treating certain §6Sulfur-containing Dusts§r with §9Oxygen§r in the EBF, or by processing §eNether Air§r.\n- §9Sulfur Dioxide§r added to more §9Oxygen§r, with §cVanadium Pentoxide§r catalyst, to produce §9Sulfur Trioxide§r.\n- §9Sulfur Trioxide§r added to §9Water§r, to produce §eSulfuric Acid§r.\n\nThe shortcut Sulfur + Water reaction is locked behind the Large Chemical Reactor, unlocked at EV.\n\n§rYou\u0027ll need huge amounts of this for a whole range of chemical reactions, as it is a very common ingredient.\n\nSulfur can be electrolyzed from many things, but is also easily available via §bDeep Mob Learning§r\u0027s §aBlaze Model§r.",
+          "desc:8": "nomifactory.quest.db.94.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5358,7 +5359,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Sulfuric Acid",
+          "name:8": "nomifactory.quest.db.94.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -5397,7 +5398,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Ethylene§r is a hydrocarbon made from §2either cracking and distilling Light Fuel, or§r dehydrating §9Ethanol§r with §9Sulfuric Acid§r in a §3Chemical Reactor§r. It is an extremely important chemical in the production of plastics.\n\n§9Polyethylene (PE)§r is the most common category of plastic, made from polymers of §9Ethylene§r. Adding §9Oxygen§r in a §3Chemical Reactor§r recreates (with some artistic license) early accidental synthesis of Polyethylene.\n\nWhen you have large amounts of §6Rutile§r and §6Bauxite§r (probably after you visit the Moon) you can consider using §9Titanium Tetrachloride§r as a catalyst to improve your Polyethylene yields. For now it\u0027s not a great idea, as in addition to its Overworld rarity, you need it for §6Titanium§r.\n\n§cPhthalic Anhydride§r acts as an alternative to §9Titanium Tetrachloride§r for increasing plastic yields.",
+          "desc:8": "nomifactory.quest.db.95.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5412,7 +5413,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Ethylene and Polyethylene",
+          "name:8": "nomifactory.quest.db.95.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -5450,7 +5451,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Form §6Polyethylene Sheets§r using a §3Fluid Solidifier§r and a §aPlate Mold§r for use in crafting electronics components.",
+          "desc:8": "nomifactory.quest.db.96.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5461,7 +5462,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Plastic Sheets",
+          "name:8": "nomifactory.quest.db.96.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5560,7 +5561,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Stainless Steel§r will be your primary material for HV, in the same way that §6Aluminium§r was for MV and §6Wrought Iron§r was for LV.\n\n§6Manganese§r comes from electrolyzing §6Tantalite§r, §6Pyrolusite§r, or §6Spessartine Dusts§r. You already have §6Chrome§r.\n\nMix up a bunch of the dust in a §3Mixer§r and begin processing it through the §3Electric Blast Furnace§r. This may be a good time to reevaluate your power generation and storage infrastructure.",
+          "desc:8": "nomifactory.quest.db.98.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5571,7 +5572,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Stainless Steel",
+          "name:8": "nomifactory.quest.db.98.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5618,7 +5619,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With the §6Stabilized Einsteinium§r you harvested from a microverse, you should now have access to everything you need to synthesize your first §dMote of Omnium§r. §2Compared to the original pack, this requires 20 new elements.§r\n\nYou\u0027re gonna need to make at least 487 of these as you push into the End Game, so make sure your §eautomation is supplying you with a stock of all of the ingredients§r. That\u0027s what those quests in the End Game tab have been about all along!",
+          "desc:8": "nomifactory.quest.db.99.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5629,7 +5630,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Synthesizing Your First Omnium",
+          "name:8": "nomifactory.quest.db.99.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5676,7 +5677,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Engineering Processors§r are made from a §6Diamond Plate§r, a §6Silicon Plate§r, and any tier one circuit.\n\nRun the plates through the respective §3Inscribers§r with §aPresses§r to make the printed plates, then combine the plates and circuit to form the Engineering Processor.",
+          "desc:8": "nomifactory.quest.db.100.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5687,7 +5688,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Engineering Processor",
+          "name:8": "nomifactory.quest.db.100.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5730,7 +5731,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "*Slaps §6ME Drive§r* this bad boy can fit so many §6Storage Cells§r in it!\n\nWith ten slots for Storage Cells, you can store a huge number of items inside this single block, and search through them all with a §6Terminal§r. You just gotta make all those Storage Cells.\n\nIf you somehow run out of room, you can make another ME Drive for even more slots! So many cells, so many items!",
+          "desc:8": "nomifactory.quest.db.101.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5741,7 +5742,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Digital Storage For Days",
+          "name:8": "nomifactory.quest.db.101.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5782,7 +5783,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Logic Processors§r are made from a §6Gold Plate§r, a §6Silicon Plate§r, and any tier one circuit.\n\nRun the plates through the respective §3Inscribers§r with §aPresses§r to make the printed plates, then combine the plates and circuit to form the Logic Processor.",
+          "desc:8": "nomifactory.quest.db.102.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5793,7 +5794,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Logic Processor",
+          "name:8": "nomifactory.quest.db.102.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5835,7 +5836,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aPresses§r are needed for §3Inscribers§r.\n\nIf you like exploring you can find them in meteors with a §aMeteor Compass§r.\n\nIf you don\u0027t want to do that, or are having trouble finding one you need, feel free to etch them yourself with a §3Precision Laser Engraver§r.",
+          "desc:8": "nomifactory.quest.db.103.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5846,7 +5847,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Inscription Plates",
+          "name:8": "nomifactory.quest.db.103.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -5907,7 +5908,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aPatterns§r are used to encode a single crafting table or processing recipe for on-demand automation with §bApplied Energistics§r.\n\nEncode them in a §aPattern Terminal§r.\n\nNote that recipes encoded with Substitutions on will use existing equivalent items, but §ewill only automatically craft the exact item specified in the recipe.§r\n\nIt is also a §cvery bad idea§r to encode recipes that require GregTech hand tools (even worse with Substitutions on). They are not handled gracefully, causing your crafting computations to explode in complexity and memory requirement.\n\nUse recipes that use machines instead!\n\n",
+          "desc:8": "nomifactory.quest.db.104.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5918,7 +5919,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Autocrafting Patterns",
+          "name:8": "nomifactory.quest.db.104.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -5959,7 +5960,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Calculation Processors§r are made from a §6Certus Plate§r, a §6Silicon Plate§r, and any §6tier one circuit§r.\n\nRun the plates through the respective §3Inscribers§r with §aPresses§r to make the printed plates, then combine the plates and circuit to form the Calculation Processor.",
+          "desc:8": "nomifactory.quest.db.105.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5970,7 +5971,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Calculation Processor",
+          "name:8": "nomifactory.quest.db.105.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6012,7 +6013,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "As the name suggests, this terminal lets you encode recipes onto §aBlank Patterns§r.\n\nIt\u0027s a micropart, so you need to place it on §6ME Cable§r (not a conduit).",
+          "desc:8": "nomifactory.quest.db.106.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6023,7 +6024,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pattern Terminal",
+          "name:8": "nomifactory.quest.db.106.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6064,7 +6065,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Atomic Reconstructor§r is the cornerstone of §bActually Additions§r, using Crystal Flux (which automatically converts 1:1 with RF) to change items into other items.\n\nThis machine fires a laser out of the front that reconstructs standard materials into special variants.\n\nThe machine itself will give you further instructions on how to configure it.",
+          "desc:8": "nomifactory.quest.db.107.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6075,7 +6076,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Atomic Reconstructor",
+          "name:8": "nomifactory.quest.db.107.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6116,7 +6117,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This handy terminal allows you to see the pattern slots of all §aME Interfaces§r in your network in one place.\n\nThis means you don\u0027t have to run to your ME Interfaces each time you make a new pattern for them.",
+          "desc:8": "nomifactory.quest.db.108.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6127,7 +6128,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Interface Terminal",
+          "name:8": "nomifactory.quest.db.108.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6168,7 +6169,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aME Interfaces§r are extremely important for automation. You\u0027ll be making a lot of these, if you\u0027re playing the pack right.\n\nThese can be filled with encoded §aPatterns§r to perform on-demand autocrafting, and can be configured to stock up to 9 stacks of items for passive autocrafting, Any item pushed into an ME Interface is digitized and placed in your ME Network storage.\n\nWhen adjacent to one or more §aMolecular Assemblers§r, crafting table patterns can be crafted. It will use as many adjacent Molecular Assemblers as possible, restricted by availability and number of §aCo-processors§r in your crafting CPU multiblock.\n\nWhen adjacent to any other block, you can use processing patterns with a machine to insert items into the machine. Processing patterns require that the finished item is inserted back into the ME Network by way of an ME Interface (though it doesn\u0027t need to be the same ME Interface the Pattern is in).\n\nME Interfaces can be wrenched to ensure they only communicate with a particular adjacent block, or can be crafted into a micropart form to fit multiple in the same block space (each micropart only interacting with the adjacent block face).\n\n",
+          "desc:8": "nomifactory.quest.db.109.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6179,7 +6180,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ME Interfaces",
+          "name:8": "nomifactory.quest.db.109.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6222,7 +6223,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Autocrafting at last.\n\nWell, you need patterns too I guess.",
+          "desc:8": "nomifactory.quest.db.110.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6233,7 +6234,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crafting Units",
+          "name:8": "nomifactory.quest.db.110.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6280,7 +6281,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Crafting in a digital grid is heaven after using primitive wooden tables for so long.\n\nIt\u0027s a micropart, so you need to place it on §6ME Cable§r (not a conduit).",
+          "desc:8": "nomifactory.quest.db.111.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6291,7 +6292,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crafting Terminal",
+          "name:8": "nomifactory.quest.db.111.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6332,7 +6333,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "By placing them in the path of an §3Atomic Reconstructor§r\u0027s laser beam, §6Coal§r can be turned into §6Void Crystals§r, and §6Iron Ingots§r into §6Enori Crystals§r.\n\nKeep in mind you can efficiently do this with blocks, splitting them into nine base items as usual.",
+          "desc:8": "nomifactory.quest.db.112.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6343,7 +6344,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reconstruction Of Atoms",
+          "name:8": "nomifactory.quest.db.112.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6390,7 +6391,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Resonator§r is one of the primary crafting machines from §bExtra Utilities 2§r. It requires Grid Power in order to function, and produces special items like §6Stoneburnt§r and §6Red Coal§r.",
+          "desc:8": "nomifactory.quest.db.113.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6401,7 +6402,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Resonator",
+          "name:8": "nomifactory.quest.db.113.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6442,7 +6443,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§eGrid Power§r, or GP for short, is a power system used by §bExtra Utilities§r. It is generated by using a variety of §3Mills§r.\n\nIt deviates from most power systems in that Mills and GP consumers can be placed anywhere. It is globally available. However, Mills of each type incur §cdiminishing returns§r to massively punish excessive spamming of the same kind of Mills. Diversify!\n\nThe first Mill available is the §3Manual Mill§r, which is a hand crank that generates up to 15 GP. This is enough to get started so you can make better Mill types. Place it down and wind it up by holding right-click to generate GP.\n\nIf you are playing in a group, the command §e/xu_powersharing§r may be useful to allow for sharing GP between players. Simply run the command and select which players you want to share your GP with.",
+          "desc:8": "nomifactory.quest.db.114.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6453,7 +6454,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Manual Mill",
+          "name:8": "nomifactory.quest.db.114.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6495,7 +6496,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Red Coal§r is an important ingredient for §6Black Steel Dust§r.\n\nCareful with making an AE2 pattern with this one; due to the way §bExtra Utilities§r item generation works, you\u0027ll have to craft a piece of Red Coal to put into relevant §aPatterns§r manually.",
+          "desc:8": "nomifactory.quest.db.115.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6506,7 +6507,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Red Coal",
+          "name:8": "nomifactory.quest.db.115.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6548,7 +6549,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Black Steel§r will be used to make various items from §bExtended Crafting§r. It will also be the basis of other Steel types later on.",
+          "desc:8": "nomifactory.quest.db.116.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6559,7 +6560,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Black Steel",
+          "name:8": "nomifactory.quest.db.116.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6601,7 +6602,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The first digital fluid storage component, used to make §a1k Fluid Storage Cells§r.\n\nFluid cells can store up to five fluid types, but it\u0027s better to format all your disks to a single fluid each. This avoids the scenario where one fluid fills up a cell, preventing the other fluids from being stocked. Extra types also use up a chunk of storage, resulting in less overall storage per cell.",
+          "desc:8": "nomifactory.quest.db.117.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6612,7 +6613,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "1k Fluid Storage",
+          "name:8": "nomifactory.quest.db.117.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6654,7 +6655,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A component used primarily for making bigger §6Storage Cells§r.\n\nUnformatted disks always have a hard limit of 63 distinct types of items, but each step up has roughly four times the total storage space of the prior disk.",
+          "desc:8": "nomifactory.quest.db.118.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6665,7 +6666,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "4k Item Storage",
+          "name:8": "nomifactory.quest.db.118.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6706,7 +6707,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The penultimate component for AE item §6Storage Cells§r.",
+          "desc:8": "nomifactory.quest.db.119.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6717,7 +6718,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "16k Item Storage",
+          "name:8": "nomifactory.quest.db.119.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6758,7 +6759,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The ultimate item storage component in §bApplied Energistics§r.\n\nUsed for storing really big amounts of things, like in a §664k ME Storage Cell§r.",
+          "desc:8": "nomifactory.quest.db.120.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6769,7 +6770,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "64k Item Storage",
+          "name:8": "nomifactory.quest.db.120.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6810,7 +6811,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This compressor is needed for making §6Signalum Heavy Plating§r.",
+          "desc:8": "nomifactory.quest.db.121.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6821,7 +6822,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "IV Compressor",
+          "name:8": "nomifactory.quest.db.121.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6862,7 +6863,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The second fluid storage component, used for §a4k Fluid Storage Cells§r.",
+          "desc:8": "nomifactory.quest.db.122.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6873,7 +6874,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "4k Fluid Storage",
+          "name:8": "nomifactory.quest.db.122.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6914,7 +6915,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The third fluid storage component, used for §a16k Fluid Storage Cells§r.",
+          "desc:8": "nomifactory.quest.db.123.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6925,7 +6926,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "16k Fluid Storage",
+          "name:8": "nomifactory.quest.db.123.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -6966,7 +6967,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The largest fluid storage component, used for §a64k Fluid Storage Cells§r.",
+          "desc:8": "nomifactory.quest.db.124.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6977,7 +6978,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "64k Fluid Storage",
+          "name:8": "nomifactory.quest.db.124.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7018,7 +7019,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Stoneburnt§r is a key ingredient in crafting many things from Extra Utilities.\n\nBesides the Manual Mill, there are multiple ways to generate GP. Look up \"Mill\" in JEI for all possible mills.\n\nNote that the individual generators have been balanced differently than normal, so take that into account before building 16 Water Mills. It is a good idea to use several different kinds due to §bExtra Utilities§r implementing diminishing returns to prevent spamming one kind of Mill.\n\n",
+          "desc:8": "nomifactory.quest.db.125.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7029,7 +7030,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "GP Generation",
+          "name:8": "nomifactory.quest.db.125.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7072,7 +7073,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Surface Mounted Devices§r, or §6SMD§rs for short, are §2more efficient ways to produce the Circuit components you\u0027ve been making. They will be used until the second-to-last theme of circuits.§r\n\nAll SMD components must be produced in at least a §2HV Assembling Machine§r, and they all will require liquid §9Polyethylene§r.\n\nStart off with the §6SMD Transistor§r. These are simply a §6Gallium §2Foil§r and §6Fine Annealed Copper Wire§r.\n\nNext up are §6SMD Resistors§r, which are also simple: §6Carbon Dust§r and §6Fine Electrum Wire§r.\n\nNext up are §6SMD Diodes§r, which are fairly simple. §2Gallium Arsenide Dust§r and §6Fine Platinum Wire§r net you half a stack.§r\n\nThen are §6SMD Capacitors§r. You\u0027ll need sheets of §6Polyvinyl Chloride§r to make these, or they can also be made more slowly with §6Silicone Rubber§r. §2Using Tantalum Foil in place of Aluminium doubles your yield.\n\nFinally, and new to CEu, SMD Inductors. Made with Nickel Zinc Ferrite and Fine Cupronickel Wire.§r\n\nInvest in a robust system of automation for SMD components and all of their ingredients, since you\u0027ll never stop needing them. They will also work in place of the non-SMD versions you\u0027ve been using in all but the simplest of recipes.",
+          "desc:8": "nomifactory.quest.db.126.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7083,7 +7084,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2SMD Components",
+          "name:8": "nomifactory.quest.db.126.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7222,7 +7223,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2An expensive advanced component used in the construction of the MV Precision Laser Engraver and MV Circuit Assembler.\n\nProcess some Emerald Ore in the Sifter to get the Flawless Emerald required to craft this.",
+          "desc:8": "nomifactory.quest.db.129.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7233,7 +7234,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2MV Emitter",
+          "name:8": "nomifactory.quest.db.129.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -7279,7 +7280,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Annealed Copper§r is made §2in an Arc Furnace§r by treating §6Copper§r with §9Oxygen§r. It has less power loss than regular Copper when used as a cable, and is also required for more advanced electronic components.",
+          "desc:8": "nomifactory.quest.db.130.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7290,7 +7291,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Annealed Copper",
+          "name:8": "nomifactory.quest.db.130.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7332,7 +7333,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Vinyl Chloride§r is an industrial chemical made from chlorinating §9Ethylene§r (adding §9Chlorine§r at high temperature) in a §3Chemical Reactor§r. §9Ethane§r can be used as an alternative reagent.\n\nIt is used to create the plastic §9Polyvinyl Chloride§r, most well known as PVC. While it deviates from reality, in GregTech you chemically react Vinyl Chloride and §9Oxygen§r to polymerize it into PVC.\n\nLater, you can use §9Titanium Tetrachloride§r to catalyze this reaction as well for greater yield.\n\n§6PVC Sheets§r are superior to §6Polyethylene Sheets§r for making plastic substrates, producing twice as many §6Plastic Boards§r per craft.\n\n",
+          "desc:8": "nomifactory.quest.db.131.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7343,7 +7344,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Polyvinyl Chloride",
+          "name:8": "nomifactory.quest.db.131.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7385,7 +7386,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the first Tier Four circuit, which is used for EV-tier machinery. Requires some Vibrant Alloy.\n\n§2The HV Circuit Assembler only unlocks one circuit type, the Mainframe. There is no circuit theme associated with the HV Circuit Assembler; instead, the HV (non-Circuit) Assembler unlocks easier Circuit components. The next circuit theme is not until EV.",
+          "desc:8": "nomifactory.quest.db.132.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7396,7 +7397,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Four Circuits",
+          "name:8": "nomifactory.quest.db.132.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7439,7 +7440,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2You can start to churn out Microprocessors§r. These are the best kind of Tier One circuits you can make, and you won\u0027t unlock the better recipes for quite a while.\n\nYou should absolutely automate the production of these circuits, and §ekeep a stockpile automatically crafted§r so you don\u0027t have to wait around for them or bloat your crafting orders making them on-demand through AE.",
+          "desc:8": "nomifactory.quest.db.133.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7450,7 +7451,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third And Final Tier One Circuits",
+          "name:8": "nomifactory.quest.db.133.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7492,7 +7493,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Better substrates. Using §6Polyvinyl Chloride§r (PVC) instead of §6Polyethylene§r (PE) doubles your yield.\n\nThe third §2and fourth material options§r are§r much more difficult to make and probably not worth considering for now.",
+          "desc:8": "nomifactory.quest.db.134.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7503,7 +7504,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Plastic Substrate",
+          "name:8": "nomifactory.quest.db.134.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -7553,7 +7554,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Unique to this tier of Circuit, this MV circuit doesn\u0027t require the previous tier to craft.§r These are the best kind of Tier Two circuits you can make, and you won\u0027t unlock the better recipes for quite a while.\n\nYou should absolutely automate the production of these circuits, and §ekeep a stockpile automatically crafted§r so you don\u0027t have to wait around for them or bloat your crafting orders making them on-demand through AE.",
+          "desc:8": "nomifactory.quest.db.135.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7564,7 +7565,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third And Final Tier Two Circuits",
+          "name:8": "nomifactory.quest.db.135.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7605,7 +7606,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Another electronic component.\n\nMaking it inside an §3Assembling Machine§r is much, much cheaper than by hand, and using §6Nickel Zinc Ferrite§r bolts gives even better returns.",
+          "desc:8": "nomifactory.quest.db.136.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7620,7 +7621,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Small Coils",
+          "name:8": "nomifactory.quest.db.136.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7704,7 +7705,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6§2Rhodium Plated Lumium-Palladium§r,§6 Vanadium-Gallium§r, §2and Polyphenylene Sulfide§r, you can now make hulls for Ludicrous Voltage (LuV) §bGregTech§r machines.",
+          "desc:8": "nomifactory.quest.db.138.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7715,7 +7716,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LuV Machine Hulls",
+          "name:8": "nomifactory.quest.db.138.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7756,7 +7757,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Rare Earth§r comes from either centrifuging certain Impure Dusts, or processing those same Purified Dusts.\n\nThe sources are essentially §6Redstone§r, and everything inside of §6Bastnasite§r veins.",
+          "desc:8": "nomifactory.quest.db.139.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7767,7 +7768,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Rare Earth",
+          "name:8": "nomifactory.quest.db.139.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7808,7 +7809,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Advanced Inscribers§r are much easier to work with for automation purposes, since you can insert more than a single item at a time and you can lock §aPresses§r in place.\n\nYou can automate these nicely with processing patterns in an §aME Interface§r. They don\u0027t auto-eject items though, so you will need to pull the finished items out.",
+          "desc:8": "nomifactory.quest.db.140.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7819,7 +7820,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Inscriber",
+          "name:8": "nomifactory.quest.db.140.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -7860,7 +7861,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your initial method of §9Steam§r production, to fuel your first machines. They automatically output Steam on all faces except the bottom.\n\nOnce you get Steel, consider upgrading to HP Solar Boilers.",
+          "desc:8": "nomifactory.quest.db.141.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7871,7 +7872,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Steam Production",
+          "name:8": "nomifactory.quest.db.141.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -8004,7 +8005,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Centrifuge §6Rare Earth§r, and among other useful materials, you\u0027ll get some §6Yttrium§r.\n\nBecause this recipe has chanced outputs, use a §2high tier Centrifuge to increase output chances§r, and §eensure the output slots don\u0027t fill up or excess items will be voided§r.",
+          "desc:8": "nomifactory.quest.db.144.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8015,7 +8016,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Yttrium",
+          "name:8": "nomifactory.quest.db.144.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8056,7 +8057,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A piston is a specialized motor, which is needed to make certain machines.\n\nOne of the more intricate components, as it is made using a motor.",
+          "desc:8": "nomifactory.quest.db.145.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8067,7 +8068,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Pistons",
+          "name:8": "nomifactory.quest.db.145.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8108,7 +8109,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Another common component of any machine that uses fluids. Also usable as a cover for moving fluids between §bGregTech§r machines and adjacent tanks or machines.\n\nYou can use §6Paper Rings§r or §6Rubber Rings§r, but both will require a §aKnife§r to craft. A stick and a piece of flint will make a Knife with low durability, or check the recipe for metal ones.",
+          "desc:8": "nomifactory.quest.db.146.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8119,7 +8120,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Pumps",
+          "name:8": "nomifactory.quest.db.146.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8160,7 +8161,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts both LV and MV Polarizer.\n\nAlthough you could §emagnetize§r §6Iron Ingots§r by hand using §6Redstone§r, doing that consumes considerable amounts of dust and that\u0027s not an option for more advanced materials. This machine will let you magnetize §6Steel Rods§r, as well as even more advanced materials later.\n\n§2Polarizer recipes in GTCEu go up to HV.",
+          "desc:8": "nomifactory.quest.db.147.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8171,7 +8172,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Polarizer",
+          "name:8": "nomifactory.quest.db.147.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8212,7 +8213,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A perfect material for making chopsticks.\n\nAlso the tier material for Extreme Voltage (EV).",
+          "desc:8": "nomifactory.quest.db.148.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8223,7 +8224,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Titanium",
+          "name:8": "nomifactory.quest.db.148.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8265,7 +8266,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Combining §9Titanium Tetrachloride§r with §6Magnesium§r in an §3Electric Blast Furnace§r (approximating the Kroll process) will net you your first Titanium.\n\nUnfortunately, it is super hot. You\u0027ll need to cool it in a §3Vacuum Freezer§r for it to be usable.\n\nIf you are autocrafting on-demand, it\u0027s better to not have your ME network know about this intermediate state. Outputting the §6Hot Titanium Ingot§r directly into a Vacuum Freezer avoids extra computations and item types.\n\nIf you absolutely insist on putting hot ingots in your network, you\u0027ll have to manually encode the §aPattern§r with an ingot that §cdamages you while you hold it§r. Your call.\n\n",
+          "desc:8": "nomifactory.quest.db.149.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8276,7 +8277,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Hot Titanium",
+          "name:8": "nomifactory.quest.db.149.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8304,7 +8305,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Vacuum Freezers§r are primarily used to cool down hot ingots.\n\nThey\u0027re also capable of freezing air into a liquid, and making superconductors.\n\nAt minimum you will need an energy input hatch, an input bus, an output bus, and 22 §6Frost Proof Machine Casings§r for forming the multiblock for processing Hot Ingots.\n\nIf you want to deal with fluids as well, subtract two casings and use a fluid input and fluid output in their place.\n\nBesides the controller placement, as usual the hatches/buses can go anywhere. Use the building guide in §bJEI§r which can be pulled up from the controller block.",
+          "desc:8": "nomifactory.quest.db.150.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8315,7 +8316,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vacuum Freezer",
+          "name:8": "nomifactory.quest.db.150.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8357,7 +8358,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Rutile§r is a §6Titanium§r precursor found in §6Ilmenite Ore§r and §6Bauxite Ore§r, which spawn uncommonly in the Overworld.\n\n§6§rLarger quantities of Ilmenite and Bauxite may be found on the Moon and other planets.\n\n",
+          "desc:8": "nomifactory.quest.db.151.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8368,7 +8369,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Early Rutile",
+          "name:8": "nomifactory.quest.db.151.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -8410,7 +8411,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Rutile§r, §6Carbon§r, and §9Chlorine§r may be chemically reacted to form §9Titanium Tetrachloride§r.\n\nThis fluid is a precursor for metallic §6Titanium§r, as well as a titanium halide useful for catalyzing various polymer reactions (like plastics) for greater yields.",
+          "desc:8": "nomifactory.quest.db.152.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8425,7 +8426,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Titanium Tetrachloride",
+          "name:8": "nomifactory.quest.db.152.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8470,7 +8471,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need an §3HV Chemical Reactor§r for processing §6Titanium§r.",
+          "desc:8": "nomifactory.quest.db.153.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8481,7 +8482,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "HV Chemical Reactor",
+          "name:8": "nomifactory.quest.db.153.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8522,7 +8523,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "It\u0027s time to make a §3Distillation Tower§r, which is the gatekeeper for more advanced plastics like §6Epoxy§r and doing petrochemistry.\n\nThe Distillation Tower is a highly flexible multiblock structure, able to be anywhere from §62 blocks high to up to 13 high§r (12 fluid outputs). The way that it works is that each level of the tower after the first will output an additional fluid from the recipe. §cAny output fluids in excess of available buses are voided§r. \n\nWhat you need the Distillation Tower for initially is to break down §9Biomass§r into §9Ethanol§r and §9Water§r. This recipe only has two outputs, so a §ethree-block-high Distillation Tower§r is just fine (the quest materials are for such a tower; if you want to build it bigger, you will need §ean additional 7 casings and 1 fluid output per floor§r).\n\nAny recipe with more than two fluids (like §9Oil§r) will need a larger tower. Make sure to increase the height of your tower to accommodate all of the outputs you want to keep. Also check the voltage requirements of the recipes, as many Distillation Tower recipes need higher voltages than MV. §eYou can swap out your Energy Input for a higher tier one when that time comes§r.",
+          "desc:8": "nomifactory.quest.db.154.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8533,7 +8534,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Distillation Tower",
+          "name:8": "nomifactory.quest.db.154.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8607,7 +8608,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §6Crystal CPUs§r and the §3LuV Assembling Machine§r crafted, you can make the final type of Tier Five Circuit: the §6Crystal Circuit§r.\n\n§2This is the first Circuit which strictly requires Advanced SMD components. All of them will from now on.§r\n\nAs the best form of Tier Five circuit, these should be automated and stockpiled. The variant recipe requiring §6Crystal System-on-Chip§r won\u0027t be available until you can make a §3ZPM Assembling Machine§r.",
+          "desc:8": "nomifactory.quest.db.155.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8618,7 +8619,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Fourth and Final Tier Five Circuits",
+          "name:8": "nomifactory.quest.db.155.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8660,7 +8661,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Kanthal§r is an alloy of §6Iron§r, §6Aluminium§r, and §6Chrome§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r into a §6Hot Kanthal Ingot§r which will damage you if it is held. To prevent this damage and obtain the desired ingot, the Hot Ingot must be cooled in a §3Vacuum Freezer§r.\n\nIt is best to directly route this Hot Ingot from the §6Output Bus§r of your Blast Furnace to the §6Input Bus§r of your Vacuum Freezer via conduits or an §6Ore Dictionary Filter§r and then retrieve the cooled ingot.",
+          "desc:8": "nomifactory.quest.db.156.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8671,7 +8672,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Kanthal Ingots",
+          "name:8": "nomifactory.quest.db.156.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8712,7 +8713,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Kanthal§r is the second coil material available, increasing your EBF\u0027s operating temperature to 2700K so it can process more advanced materials.\n\n§2In CEu, using higher-tier coils provides some bonuses to their multiblocks.\n- Pyrolyse Oven: Cupronickel Coils are 25% slower, every coil above Kanthal grants +50% additive speed\n- Multi Smelter: Increases number of parallel operations and decreases energy usage\n- Cracking Unit: -5% energy usage per coil above Cupronickel\n- Electric Blast Furnace: The temperature of the EBF is the coil\u0027s temperature, plus 100K for each voltage tier above MV.\nFor every 900K above the recipe temperature, the energy usage is multiplied by 0.95x.\nFor every 1800K above, one overclock becomes 100% efficient - each overclock will 4x the speed instead of 2x.",
+          "desc:8": "nomifactory.quest.db.157.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8723,7 +8724,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Kanthal Coil Blocks",
+          "name:8": "nomifactory.quest.db.157.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8764,7 +8765,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Nichrome§r is an alloy of §6Nickel§r and §6Chrome§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.\n",
+          "desc:8": "nomifactory.quest.db.158.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8775,7 +8776,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nichrome Ingots",
+          "name:8": "nomifactory.quest.db.158.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8816,7 +8817,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Nichrome§r is the third coil material available, increasing your EBF\u0027s operating temperature to 3600K so it can process more advanced materials.\n\n§23600K is now also hot enough to grant a single 100% efficient overclock to 1800K and below recipes. In effect, you will get an additional 2x speed boost by overclocking once. You may wish to use this well to make up for the slower recipes.",
+          "desc:8": "nomifactory.quest.db.159.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8827,7 +8828,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Nichrome Coil Blocks",
+          "name:8": "nomifactory.quest.db.159.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8868,7 +8869,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "First, you need some §9Oil§r. Pick your favorite method: you should engineer a renewable automated source, as you will need large quantities.\n\nStart off by running the Oil through the §3Distillation Tower§r. This will result in §9Sulfuric Heavy Fuel§r, §9Sulfuric Light Fuel§r, §9Sulfuric Naphtha§r, and §9Sulfuric Gas§r.\n\nThese will all need to be hydrodesulfurized using §9Hydrogen§r in a §3Chemical Reactor§r, which produces the non-Sulfuric versions.\n\nAll of these products are useful, so figure out how you want to store the variety and large quantities of fluids.",
+          "desc:8": "nomifactory.quest.db.160.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8883,7 +8884,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Sulfuric Heavy, Light, Naphtha and Gas",
+          "name:8": "nomifactory.quest.db.160.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8933,7 +8934,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Like other petroleum products, §9Sulfuric Gas§r §2or Natural Gas§r is hydrodesulfurized into §9Refinery Gas§r using §9Hydrogen§r in a §3Chemical Reactor§r.\n\nRefinery Gas can be cracked and further distilled for its constituents, but it is also useful as fuel for §3Gas Turbines§r. While it can be burned directly, centrifuging Refinery Gas produces §9LPG§r (Liquefied Petroleum Gas), which is an ideal fuel for Gas Turbines, and §9Methane§r which is a potential suboptimal turbine fuel but is also useful for various chemical reactions.",
+          "desc:8": "nomifactory.quest.db.161.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8948,7 +8949,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Refinery Gas",
+          "name:8": "nomifactory.quest.db.161.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -8987,7 +8988,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Canola Press§r is a machine that uses RF power to extract §9Canola Oil§r from §6Canola§r.\n\nCanola Oil can be turned into §9Glycerol§r and §9Bio Diesel§r in a §3Chemical Reactor§r.\n\nRefining, Crystallizing, or Empowering the Canola Oil first allows you to make Glycerol and Bio Diesel more efficiently.",
+          "desc:8": "nomifactory.quest.db.162.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8998,7 +8999,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Canola Press",
+          "name:8": "nomifactory.quest.db.162.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9039,7 +9040,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A whole host of fluids can be used as the feedstock for your §9Bio Diesel§r, including §9Seed Oil§r, §9Fish Oil§r, and the various tiers of §9Canola Oils§r.\n\nFish Oil and Canola Oil are probably the easiest, but it\u0027s up to you to choose.\n\nFish are easiest to get from §aGuardian Models§r from §bDML§r.",
+          "desc:8": "nomifactory.quest.db.163.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9054,7 +9055,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Seed Oil, Fish Oil, Canola Oil",
+          "name:8": "nomifactory.quest.db.163.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -9082,7 +9083,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Heavy Fuel§r is mixed with §9Light Fuel§r to create §9Diesel§r.\n\nSince Diesel requires more Light than Heavy fuel, you should consider Steam-cracking and distilling the excess quantity of Heavy Fuel for its useful constituents.",
+          "desc:8": "nomifactory.quest.db.164.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9097,7 +9098,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Heavy Fuel",
+          "name:8": "nomifactory.quest.db.164.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9135,7 +9136,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Light Fuel\u0027s distillates are now more useful, and it is the only source of Octane for High-Octane Gasoline.\nBut if you choose to produce Diesel, a large proportion of the Light Fuel you produce still has to go into Diesel production.",
+          "desc:8": "nomifactory.quest.db.165.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9150,7 +9151,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Light Fuel",
+          "name:8": "nomifactory.quest.db.165.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9188,7 +9189,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Naphtha§r is best utilized for Steam-Cracking and distilling for its constituents.\n\nNotably it contains §9Light Fuel§r and §9Heavy Fuel§r for making more §9Diesel§r, as well as many other useful chemicals for a variety of purposes.",
+          "desc:8": "nomifactory.quest.db.166.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9203,7 +9204,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naphtha",
+          "name:8": "nomifactory.quest.db.166.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9241,7 +9242,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Hydrogen Sulfide§r is a byproduct of hydrodesulfurization. §2It also comes from distilling Liquid Nether Air.§r\n\nA simple chemical reaction with §9Water§r reprocesses it into the useful §9Sulfuric Acid§r, or it can be electrolyzed for recovering the §9Hydrogen§r.",
+          "desc:8": "nomifactory.quest.db.167.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9256,7 +9257,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Hydrogen Sulfide",
+          "name:8": "nomifactory.quest.db.167.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9295,7 +9296,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Diesel§r is a mixture of §9Light Fuel§r and §9Heavy Fuel§r. Each mB of Diesel generates §d480 EU§r in §3Combustion Generators§r.\n\nOnce you get HV machinery, you can upgrade this to §9Cetane-Boosted Diesel§r.\n\n§2§rIt\u0027s more power efficient to use §3singleblock Distilleries§r over a §3Distillation Tower§r for Oil, due to the overclocking mechanics being different. For Diesel, the correct ratio is §d3 Distilleries for Light Oil and 2 Distilleries for Heavy Oil§r.",
+          "desc:8": "nomifactory.quest.db.168.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9310,7 +9311,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Diesel",
+          "name:8": "nomifactory.quest.db.168.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9348,7 +9349,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§cKapton K§r is now required for preparing §6Wetware Lifesupport Circuit Boards§r.\n\nYou went through §9Polybenzimidazole§r, this should be easy by now.",
+          "desc:8": "nomifactory.quest.db.169.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9359,7 +9360,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Kapton K",
+          "name:8": "nomifactory.quest.db.169.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -9399,7 +9400,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Sodium Hydroxide§r is a strong base, and an ingredient in §9Bio Diesel§r, among other reactions.\n\n§2The only source§r is splitting §9Salt Water§r in an §3Electrolyzer§r - this is also a good source of §9Chlorine§r. You can get §9Salt Water§r from mixing §6Salt§r and §9Water§r (duh), §2dissolving Ghast Tears, or drilling it from Salt Water fluid veins, which only spawn over oceans.",
+          "desc:8": "nomifactory.quest.db.170.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9410,7 +9411,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Sodium Hydroxide",
+          "name:8": "nomifactory.quest.db.170.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -9452,7 +9453,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Air§r can be sent into the §3Vacuum Freezer§r to turn it into §9Liquid Air§r.\n\nLiquid Air can be sent into a §2normal Distillation Tower§r to break it down into its components.\n\n§2Liquid Nether Air and Liquid Ender Air give different useful components.\n",
+          "desc:8": "nomifactory.quest.db.171.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9463,7 +9464,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Cryogenic Air Distillation",
+          "name:8": "nomifactory.quest.db.171.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9502,7 +9503,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The reaction that produces §9Bio Diesel§r is also the only source of §9Glycerol§r, which is an easy way to make §9Epichlorohydrin§r, an important ingredient of §9Epoxy§r.\n\n§9Glycerol§r is also used in the production of §9§9Glyceryl Trinitrate§r, an important step in making §6Dynamite§r, which can be used later in the §9§r§3Implosion Compressor§r.\n\nEven if you\u0027re otherwise going all in on petrochemistry for Epoxy, you\u0027ll probably end up with some Bio Diesel as a result of making Glycerol.\n\nBio Diesel can be used for power, but is probably better to convert to §9Nitro Diesel§r§r.",
+          "desc:8": "nomifactory.quest.db.172.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9517,7 +9518,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Bio Diesel and Glycerol",
+          "name:8": "nomifactory.quest.db.172.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9556,7 +9557,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Nitrogen§r comprises 78% of the atmosphere. Because of this, after the first few processes of §9Liquid Air§r, you\u0027ll probably have more Nitrogen than you know what to do with.\n\nIf you got here centrifuging air, then it\u0027s gonna take you longer to get to that point.\n\nEven so, don\u0027t void it unless you have secured a very large stockpile. Storage is cheap and Nitrogen is used in sizeable quantities for several notable things, one of which you\u0027ll be needing very soon.",
+          "desc:8": "nomifactory.quest.db.173.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9571,7 +9572,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nitrogen",
+          "name:8": "nomifactory.quest.db.173.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -9609,7 +9610,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts LV/MV/HV/EV §3Gas Collectors§r.\n\nA §3Gas Collector§r will suck up air at a decent rate, provided the top side is unobstructed. The collected Air is automatically ejected into an adjacent tank via the output face.\n\n§2Gas Collectors in the Nether and End will collect Nether Air and Ender Air respectively, which yield different products.§r\n\nIV+ air collectors are not part of this quest, but for reference they exist and are called §3Atmosphere Collectors§r.\n\n",
+          "desc:8": "nomifactory.quest.db.174.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9620,7 +9621,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Basic Air Collection",
+          "name:8": "nomifactory.quest.db.174.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9661,7 +9662,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll be needing large quantities of the various Noble Gasses so you should get this automated and running continuously. \n\n§9Argon§r, for example, is important for production of advanced §6Silicon Boules§r.\n\n§2After liquefication, Overworld Air grants Helium and Argon; Nether Air grants Helium-3 and Neon; Ender Air grants Helium, Krypton, Xenon, and Radon.\n\n§2Certain Noble Gases can also boost the speed of EBF processes.",
+          "desc:8": "nomifactory.quest.db.175.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9676,7 +9677,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Noble Gasses",
+          "name:8": "nomifactory.quest.db.175.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9714,7 +9715,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A simple combination of §9Nitrogen§r and §9Oxygen§r, the two most common elements in the air, yet this substance is very toxic. Chemistry is weird.",
+          "desc:8": "nomifactory.quest.db.176.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9729,7 +9730,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nitrogen Dioxide",
+          "name:8": "nomifactory.quest.db.176.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9767,7 +9768,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Don\u0027t let the EPA catch you making this stuff.\n\n§9Nitrogen Dioxide§r, §9Oxygen§r, and §9Water§r will create §9Nitric Acid§r, the next step in your chemical journey.",
+          "desc:8": "nomifactory.quest.db.177.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9782,7 +9783,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Nitric Acid",
+          "name:8": "nomifactory.quest.db.177.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9821,7 +9822,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the additive that will bring our diesel fuel to the next level.\n\nMix §9Nitric Acid§r and §9Ethenone§r in a §3Chemical Reactor§r to make §9Tetranitromethane§r.\n\nIn a newly added route, you can also mix §9Nitric Acid§r and §9Methyl Acetate§r in a §3Chemical Reactor§r.",
+          "desc:8": "nomifactory.quest.db.178.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9836,7 +9837,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tetranitromethane",
+          "name:8": "nomifactory.quest.db.178.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9875,7 +9876,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mixing §9Diesel§r (or less efficiently, §9Bio Diesel§r) with §9Tetranitromethane§r in an §3HV Mixer§r produces §9Nitro Diesel§r, an extremely potent fuel. Burn it in the Large Combustion Engine and Extreme Combustion Engine, producing §2720 EU/mB of fuel.",
+          "desc:8": "nomifactory.quest.db.179.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9890,7 +9891,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2NITRO DIESEL!!",
+          "name:8": "nomifactory.quest.db.179.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9928,7 +9929,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Acetic Acid§r and §9Sulfuric Acid§r make §9Ethenone§r.\n\nOr you can heat §9Acetone§r, or a few other approaches. Check out §bJEI§r for the various options.",
+          "desc:8": "nomifactory.quest.db.180.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9943,7 +9944,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ethenone",
+          "name:8": "nomifactory.quest.db.180.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -9981,7 +9982,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "There are several paths to §9Acetic Acid§r... probably the simplest is combining §9Oxygen§r, §9Hydrogen§r, and §6Carbon§r, but one of the several other methods may appeal to you more, especially if you have a §3Distillation Tower§r.\n\nLook through §bJEI§r for the various options.",
+          "desc:8": "nomifactory.quest.db.181.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9996,7 +9997,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Acetic Acid",
+          "name:8": "nomifactory.quest.db.181.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10035,7 +10036,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A colorless liquid with a pungent, garlic-like odor. It\u0027s needed in the production of §9Epoxy§r.\n\n§2You can skip a step making this with the Large Chemical Reactor.",
+          "desc:8": "nomifactory.quest.db.182.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10050,7 +10051,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Epichlorohydrin",
+          "name:8": "nomifactory.quest.db.182.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -10088,7 +10089,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §6Fiber-Reinforced Epoxy Resin Sheet§r is made in a §3Chemical Bath§r, not a §3Chemical Reactor§r. The board itself is made in a Chemical Reactor though.\n\nOther than that, it\u0027s very similar to the other substrates you\u0027ve made so far. This board type unlocks §2Quantum Circuits, which span tiers four through seven.",
+          "desc:8": "nomifactory.quest.db.183.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10099,7 +10100,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Fiber Reinforced Epoxy Substrate",
+          "name:8": "nomifactory.quest.db.183.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10152,7 +10153,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Petrochemistry is the category of organic chemistry pertaining to petroleum, otherwise known as §9Oil§r.\n\n§bGregTech§r\u0027s petrochemistry may seem daunting at first, given the sheer number of chemicals and processing options, but it\u0027s actually easier to get into than you think.\n\nOil is the starting point, and can be found in several variants which you can pump from finite natural wells on the Overworld, as well as coming renewably from §6Oilsands Ore§r and §6Soul Sand§r, and directly in liquid form from a §3Fluid Rig§r.\n\nStart off by distilling the Oil. This will result in §9Sulfuric Heavy Fuel§r, §9Sulfuric Light Fuel§r, §9Sulfuric Naphtha§r, and/or §9Sulfuric Gas§r.\n\nThese will all need to be hydrodesulfurized using §9Hydrogen§r in a §3Chemical Reactor§r or §2Oil Cracking Unit§r, which produces the non-Sulfuric versions.\n\nAll of these products are useful, so figure out how you want to store the variety and large quantities of fluids.\n\nThe upcoming quests will guide you through the basics of petrochemistry. Once you\u0027ve mastered that, feel free to explore further.\n",
+          "desc:8": "nomifactory.quest.db.184.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10167,7 +10168,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Navigating Petrochem",
+          "name:8": "nomifactory.quest.db.184.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -10205,7 +10206,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Finally, §6Epoxy Resin Sheets§r.\n\nThese can be made into circuit boards as a substrate for advanced circuits.",
+          "desc:8": "nomifactory.quest.db.185.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10216,7 +10217,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Epoxy",
+          "name:8": "nomifactory.quest.db.185.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10257,7 +10258,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Carbon Fibers§r are useful for a variety of things.\n\n§2They are made with Carbon Dust and polymers. Higher tier polymers grant higher yields. It\u0027s also not a chanced output anymore.",
+          "desc:8": "nomifactory.quest.db.186.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10268,7 +10269,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Carbon Fibers",
+          "name:8": "nomifactory.quest.db.186.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10309,7 +10310,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Remember to keep the MV area separate from your LV area. §eHooking up an LV machine to MV current will result in the machine being destroyed! Also LV cables will burn up if you put MV current through them§r. That\u0027s why it\u0027s probably best to keep the areas separate until you\u0027re comfortable and confident with voltages. Eventually you can use transformers to switch voltages within a single setup, but don\u0027t feel forced to try that until you\u0027ve got a grasp on the basics.\n\nAll RF power is the same (it has no voltages), so you can use RF conduits to route power from wherever you\u0027re generating and converting to EU with §3Energy Converters§r for each voltage. You don\u0027t have to use this setup, but it\u0027s the most foolproof one for a beginner. And if you\u0027re an expert, well... you don\u0027t need my advice.\n\nFor your MV cables, you can use §6Copper§r to start with. §6Energetic Alloy cables§r are §cless lossy§r though, so consider them if you\u0027re able to mass produce those ingots.",
+          "desc:8": "nomifactory.quest.db.187.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10320,7 +10321,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Energy Converter",
+          "name:8": "nomifactory.quest.db.187.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10361,7 +10362,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Epoxy Circuit Boards§r are a more advanced substrate type that gives you access to §2Nanocircuits, which span tiers three through six.",
+          "desc:8": "nomifactory.quest.db.188.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10372,7 +10373,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Epoxy Substrate",
+          "name:8": "nomifactory.quest.db.188.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10451,7 +10452,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Nano CPUs§r are advanced §6Circuit Wafers§r made from infusing a §6CPU Wafer§r with §6Carbon Fibers§r and §9Energized Glowstone§r in a §3Chemical Reactor§r.\n\nThen, cut the resulting wafer into dies using a §3Cutting Machine§r.",
+          "desc:8": "nomifactory.quest.db.190.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10462,7 +10463,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nano CPUs",
+          "name:8": "nomifactory.quest.db.190.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10504,7 +10505,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Using your new §6Epoxy Circuit Boards§r and some familiar components, you can now make the final form of Tier Two Circuit: the §6Microcircuit§r.\n\nYou craft four of these at once, and they\u0027re pretty cheap. Consider that you used to have to make §6Primitive Processors§r for this tier, and realize how far you\u0027ve come.\n\nAs with the final form of any tier of circuits, be sure to set up automation to stockpile these. You won\u0027t get to the §6System-on-Chip§r variant recipe for a while yet.",
+          "desc:8": "nomifactory.quest.db.191.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10519,7 +10520,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Fourth And Final Tier Two Circuits",
+          "name:8": "nomifactory.quest.db.191.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10565,7 +10566,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The first Mainframe you\u0027ll have to contend with.\n\nThis is the first Tier Five circuit available, and consequently the most expensive to make. as always, invest in the next circuit theme to get to cheaper recipes as soon as possible.",
+          "desc:8": "nomifactory.quest.db.192.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10576,7 +10577,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Five Circuit",
+          "name:8": "nomifactory.quest.db.192.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10654,7 +10655,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A more advanced type of §6Silicon Boule§r, formed by doping the §6Silicon§r crystal lattice with §6Glowstone§r.\n\nThese are made in an §3EBF§r with §6Nichrome§r or better coils, and need §2Nitrogen§r for the process. It needs twice as much Silicon as the basic boules, but also results in twice as many doped Silicon Wafers when sliced.\n\nCircuit Wafers can be made far more efficiently with these doped Silicon Wafers, but they are also needed for some more advanced types of Circuit Wafers that can\u0027t be engraved onto the basic ones.",
+          "desc:8": "nomifactory.quest.db.194.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10665,7 +10666,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Glowstone Doped Silicon Boule",
+          "name:8": "nomifactory.quest.db.194.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10708,7 +10709,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "FUSION!\n\nThis baby can do any fusion recipe, notably giving you access to §6Neutronium§r.\n\nThe multiblock layout is the same as the Mark 1 and Mark 2, with the same hatch and casing substitutions permitted.\n\nObviously though, this one uses §6Fusion Machine Casing Mk §2III§r and only works with §aUV Energy Input Hatches§r.\n\nThe §3Mark 3 Fusion Reactor§r has an energy buffer of §e640M EU§r.",
+          "desc:8": "nomifactory.quest.db.195.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10719,7 +10720,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fusion Reactor MK3",
+          "name:8": "nomifactory.quest.db.195.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10766,7 +10767,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Doesn\u0027t look exactly like Europium anymore.§r\n\nTo make §9Tritanium§r, you first need to make §9Duranium§r. This is done by fusing molten §9Gallium§r and §9Radon§r in a §3Fusion Reactor Mark 1§r or better.\n\nOnce you have Duranium, you can fuse Tritanium in a §3Fusion Reactor Mark 2§r using the Duranium and molten §9Titanium§r.\n\nIf you\u0027re having trouble figuring out the right item and fluid ratios for batching up these processes, consider plugging the relevant recipes into the §aCrafting Calculator§r.",
+          "desc:8": "nomifactory.quest.db.196.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10777,7 +10778,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tritanium Ingot",
+          "name:8": "nomifactory.quest.db.196.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10818,7 +10819,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungstensteel§r is an alloy of §6Tungsten§r and §6Steel§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.\n",
+          "desc:8": "nomifactory.quest.db.197.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10829,7 +10830,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tungstensteel",
+          "name:8": "nomifactory.quest.db.197.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10871,7 +10872,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6Tungstensteel§r achieved, you can now make hulls for Insane Voltage (IV) §bGregTech§r machines.\n\n§2Starting at IV, 16A Energy and Dynamo hatches are available at each tier.",
+          "desc:8": "nomifactory.quest.db.198.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10882,7 +10883,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2IV Machine Hulls",
+          "name:8": "nomifactory.quest.db.198.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -10925,7 +10926,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Yttrium Barium Cuprate§r (more accurately, Yttrium Barium Copper Oxide, or YBCO) is, among other things, a high-temperature superconductor material.\n\nThis is used as plates in §bNuclearCraft§r, and will become an important cable material for later tiers of §bGregTech§r components.",
+          "desc:8": "nomifactory.quest.db.199.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10936,7 +10937,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Yttrium Barium Cuprate",
+          "name:8": "nomifactory.quest.db.199.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11014,7 +11015,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungsten§r is a material that requires an §3EV Electrolyzer §2and Chemical Bath§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r.\n\nIt is only found from §6Tungstate§r §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.\n\nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then electrolyzed§r to get to the Tungsten, which then needs to be cooked in the EBF for Tungsten ingots.",
+          "desc:8": "nomifactory.quest.db.201.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11025,7 +11026,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tungsten",
+          "name:8": "nomifactory.quest.db.201.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11067,7 +11068,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is one of the simpler rockets you can build. The specifics of the shape don\u0027t really matter, as long as the rocket engines are on the bottom and all the parts are added. It also needs to be inside the edges of the Launch Pad and not taller than the Structure Tower.\n\n§aIn order to progress this quest chain further, you\u0027ll first need to complete the Interdimensional Transport (either Dislocators or Telepad) questline and the Rocket Fuel questline, both of which are nearby on this quest tab.",
+          "desc:8": "nomifactory.quest.db.202.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11078,7 +11079,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Apollo Program",
+          "name:8": "nomifactory.quest.db.202.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11138,7 +11139,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Marginally cheaper to make than §2Advanced Integrated Circuits§r, and also the only way to make the §2Workstation§r, which is the first Tier Four circuit.",
+          "desc:8": "nomifactory.quest.db.203.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11149,7 +11150,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Three Circuits",
+          "name:8": "nomifactory.quest.db.203.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11190,7 +11191,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Making yourself a space suit is the most important step towards your space adventures.\n\nThis suit lets you breathe in space, which is kind of important.",
+          "desc:8": "nomifactory.quest.db.204.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11201,7 +11202,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Space Suit",
+          "name:8": "nomifactory.quest.db.204.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11261,7 +11262,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Suit Workstation is needed to install §6Low Pressure Tanks§r (or a larger tank if you like) onto your Space Suit Chest-Piece.\n\nOnce installed, you can stand on a §aGas Charging Pad§r to fill up the tanks with §9Oxygen§r. Of course, you\u0027ll need to fill the Gas Charging Pad with Oxygen first.",
+          "desc:8": "nomifactory.quest.db.205.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11272,7 +11273,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Suit Workstation",
+          "name:8": "nomifactory.quest.db.205.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11326,7 +11327,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A common component used by §bExtended Crafting§r.",
+          "desc:8": "nomifactory.quest.db.206.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11337,7 +11338,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Component",
+          "name:8": "nomifactory.quest.db.206.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11378,7 +11379,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Combine several components into a catalyst.",
+          "desc:8": "nomifactory.quest.db.207.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11389,7 +11390,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Catalyst",
+          "name:8": "nomifactory.quest.db.207.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11431,7 +11432,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "At some point you might consider venturing into space, like the Moon. While it\u0027s not at all required for the progression, you might find it valuable: to say the least, the Moon contains ore veins which are otherwise very rare to find in the Overworld. And for this, you\u0027ll need a rocket and a whole lot of preparations.\n\nBefore you can build the rocket itself, you\u0027ll need to create a launch pad. The §6Launch Pad§r blocks go in a 3x3 layout flat on the ground to form the platform.\n\nThe Structure Tower§r is formed from a column of §6Structure Tower§r blocks that holds your rocket upright. The first block goes adjacent to any side of the launch pad platform (on the same Y-level as the launch pad blocks).\n\nWith 6 Structure Tower blocks, you can only build a rocket 5 blocks high, since any higher would exceed the height of the tower. To build a taller rocket, you\u0027ll need to build a taller tower using more Structure Tower blocks.\n\nThe §3Rocket Assembling Machine§r needs to be placed next to the launch pad (not on it) 1 block higher than the platform, so that the bottom of the Rocket Assembler is flush with the top of the launch pad. It also needs to be supplied with RF power to function.\n\n",
+          "desc:8": "nomifactory.quest.db.208.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11442,7 +11443,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Launch Pad and Rocket Assembly Machine",
+          "name:8": "nomifactory.quest.db.208.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11495,7 +11496,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With the Extended Crafting Table, you can now craft 5x5 recipes.",
+          "desc:8": "nomifactory.quest.db.209.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11506,7 +11507,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced Extended Crafting Table",
+          "name:8": "nomifactory.quest.db.209.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11547,7 +11548,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Even simple rockets demand §6Heavy Plates§r for their construction. In this case, made out of §6Steel§r. ",
+          "desc:8": "nomifactory.quest.db.210.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11558,7 +11559,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Steel Heavy Plates",
+          "name:8": "nomifactory.quest.db.210.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11599,7 +11600,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need this to set the §aGuidance Computer\u0027s§r destination to the Moon (Luna).\n\nIn your assembled Rocket, press the Rocket GUI Hotkey (default is §eC§r but you may need to rebind it). Click the little square that says \"Guidance Computer\" to pull up the Guidance Computer inventory. Then, place the blank chip into the Guidance Computer. Back out of this menu (§eEsc§r or §eE§r) to get back to the main Rocket GUI.\n\nClick the §cSelect Dst§r button, choose Luna, and click the Select button to assign the destination to the chip.\n\n§eNote: if you want to return your rocket to Earth, you will need to change the destination in this manner again to Earth before launching.§r",
+          "desc:8": "nomifactory.quest.db.211.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11610,7 +11611,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Flightplan To The Moon",
+          "name:8": "nomifactory.quest.db.211.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11652,7 +11653,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Fueling Station§r is how rockets get fuel.\n\nFirst, put together your Rocket, then §aScan§r and §cBuild§r the Rocket in the §3Rocket Assembling Machine§r to assemble it (which turns it into an entity). Next, with the §aLinker§r in your hand, right-click the Fueling Station then the Rocket Assembling Machine to link the Fueling Station to the constructed Rocket. \n\nYou\u0027ll get a confirmation message when you do it right, and a little line will appear between the Fueling Station and the rocket.\n\nNow just get §9Rocket Fuel§r into the Fueling Station and it will transfer to the Rocket automatically.\n",
+          "desc:8": "nomifactory.quest.db.212.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11663,7 +11664,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fuel Loading",
+          "name:8": "nomifactory.quest.db.212.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11710,7 +11711,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Holding one of these reveals §aTravel Anchors§r and §aTelepads§r in range.\n\nShift + right-click after aiming to warp to one, or point it anywhere to teleport forward a short distance (works through walls).\n\nThese are powered with RF, and can be further enchanted through §bEnderIO§r\u0027s enchanting mechanics.\n\nThe §6Vibrant Crystal§r will require an §3Autoclave§r.",
+          "desc:8": "nomifactory.quest.db.213.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11727,7 +11728,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Staff of Traveling",
+          "name:8": "nomifactory.quest.db.213.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11774,7 +11775,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Moon is a barren, lifeless rock... So why did you want to come here?\n\nOne major draw is that §6Moon Turf§r, which makes up the surface of the Moon, is an efficient means of obtaining §9Deuterium§r. It will be useful for producing §9Microversium§r, §9Tritium§r, plasmas from fusion, and crystallizing §6Dilithium§r.\n\nThere are also several ores that are rare on the Overworld but exist in abundance on the Moon. Moreover, ores generate more densely on the Moon than in other realms.\n\nIn particular, the Moon contains large quantities of §6Titanium§r (in the form of §6Rutile Ore§r and §6Ilmenite Ore§r), §6Tungsten§r (in the form of §6Scheelite Ore§r and §6Tungstate Ore§r), §6Fluorine§r (in the form of §6Fluorite Ore§r), and §6Molybdenum§r (in the form of §6Wulfenite Ore§r and §6Molybdenite Ore§r).\n\n§2The Moon also contains fluid deposits of Deuterium and Helium-3, which you can harvest with a Fluid Rig. However, you will want to use the second Fluid Rig tier to extract it, as the amount of Deuterium and Helium-3 is too low to be anything appreciable from a first tier Fluid Rig.\n",
+          "desc:8": "nomifactory.quest.db.214.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11785,7 +11786,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Deuterium",
+          "name:8": "nomifactory.quest.db.214.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11826,7 +11827,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Pumps are now available in GT. Useful for gathering Oil or perhaps Lava from the Nether.",
+          "desc:8": "nomifactory.quest.db.215.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11837,7 +11838,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Pumps",
+          "name:8": "nomifactory.quest.db.215.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11881,7 +11882,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is your first §3Microverse Projector§r.\n\nThese structures are used to project §6Micro Miners§r into a §eMicroverse§r to obtain valuable loot such as §6ores§r, §6gems§r, and otherwise unobtainable items§r like §6Radium Salt§r and §6Naquadah Dust§r. §cKeep in mind that Micro Miners are single-use!§r\n\nMicroverse Projectors are §bGregTech§r multiblocks, which means that they\u0027re just as flexible as other machines in terms of the I/O block placement: §epositions of Buses and Hatches can be swapped with any Microverse Projector Casing§r.\n\nA single §6HV Energy Input§r supports missions up to 1024 EU/t. To process the rest, you\u0027ll need to upgrade the multiblock to at least §eEV power§r, which is either §6two HV Energy Inputs§r or §6one EV Energy Input§r. Missions will also overclock, increasing in speed each time the projector\u0027s energy tier increases and available power reaches the next multiple of four times the base mission power.\n\nHover your mouse over the Small Microverse Projector and press §bU§r to see all available missions.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.216.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11892,7 +11893,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Small Microverse Projector",
+          "name:8": "nomifactory.quest.db.216.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -11995,7 +11996,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is your first Micro Miner ever.\nYes, not the last: these things aren\u0027t reusable.\n\nThis one can get you:\n§6* Cassiterite Ore\n* Dense Iron Ore\n* Uraninite Ore\n* Redstone Ore\n* Nickel Ore\n§2* Bauxite Ore\n§6* Galena Ore\n* Moon Turf\n* Dilithium\n* Salt Ore§r\n§2* Molybdenum Ore§r\n\nWhen equipped with a Gemstone Sensor (which may currently not be available to you yet):\n§2* Perfect Diamond\n§6* Apatite Ore\n* Tricalcium Phosphate Ore\n* Quartzite Ore§r\n\nCan also be used to bring §bStellar Creation Data§r, but less efficiently than the Tier Two.\n\n",
+          "desc:8": "nomifactory.quest.db.217.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12006,7 +12007,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2First Foray Into The Microverse",
+          "name:8": "nomifactory.quest.db.217.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12084,7 +12085,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Scatter a few around your base, and you can warp to anywhere you please!",
+          "desc:8": "nomifactory.quest.db.219.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12095,7 +12096,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Travel Anchors",
+          "name:8": "nomifactory.quest.db.219.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12136,7 +12137,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mix §9Oxygen§r and §91,1-Dimethylhydrazine§r together to make §9Rocket Fuel§r.\n\nAwesome!\n\nWhen you have stable sourcing for Nitrogen and Oxygen, you can make and use §9Dinitrogen Tetroxide§r in the recipe instead of Oxygen. It doubles the efficiency of your §9UDMH§r when making Rocket Fuel.\n\nLater, when you have access to (non-methylated) §9Hydrazine§r, using that in place of §9N₂O₄ §rcan further increase your Rocket Fuel yield.",
+          "desc:8": "nomifactory.quest.db.220.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12151,7 +12152,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Rocket Fuel",
+          "name:8": "nomifactory.quest.db.220.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12190,7 +12191,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Dimethylamine§r and §9Chloramine§r combine together into §91,1-Dimethylhydrazine§r.",
+          "desc:8": "nomifactory.quest.db.221.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12205,7 +12206,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "1,1-Dimethylhydrazine",
+          "name:8": "nomifactory.quest.db.221.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12244,7 +12245,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Methanol§r and §9Ammonia§r combine together to make §9Dimethylamine§r.\n\nI know you\u0027re expecting a Breaking Bad joke here, but I don\u0027t walt to go for such low hanging fruit.",
+          "desc:8": "nomifactory.quest.db.222.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12259,7 +12260,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dimethylamine",
+          "name:8": "nomifactory.quest.db.222.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12298,7 +12299,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Hypochlorous Acid§r and §9Ammonia§r combine together to make §9Chloramine§r.",
+          "desc:8": "nomifactory.quest.db.223.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12313,7 +12314,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chloramine",
+          "name:8": "nomifactory.quest.db.223.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12351,7 +12352,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Hydrogen§r and §9Nitrogen§r combine together to make §9Ammonia§r.\n\nAn easy way to get Nitrogen is to centrifuge §9Air§r, which will require you to build an §3Air Collector§r. You could also electrolyze §6Saltpeter§r, distill §9Fermented Biomass§r in a §3Distillation Tower§r, or get huge amounts from a §3Cryogenic Air Distillation§r Tower§r.",
+          "desc:8": "nomifactory.quest.db.224.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12366,7 +12367,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ammonia",
+          "name:8": "nomifactory.quest.db.224.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12404,7 +12405,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Oxygen§r, §9Hydrogen§r, and §6Carbon§r combine together in a §3Chemical Reactor§r to make §9Methanol§r.\n\nYou can also use a §3Distillation Tower§r to get Methanol from §9Wood Vinegar§r and §9Fermented Biomass§r.",
+          "desc:8": "nomifactory.quest.db.225.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12419,7 +12420,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Methanol",
+          "name:8": "nomifactory.quest.db.225.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12457,7 +12458,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Water§r and §9Chlorine§r can be combined to make §9Hypochlorous Acid§r. If you add §9Mercury§r to catalyze the reaction, the yield is much better.\n\n§ePlease note that Hypochlorous Acid and Hydrochloric Acid are different things.§r\n\nYou\u0027re already familiar with Chlorine production from your forays into Plastics, but a great source of Mercury is §2centrifuging§4 §6Redstone§r.",
+          "desc:8": "nomifactory.quest.db.226.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12472,7 +12473,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Hypochlorous Acid",
+          "name:8": "nomifactory.quest.db.226.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12510,7 +12511,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Here comes the chemistry.\n\nIt might seem crazy right now, but you\u0027ll want a dedicated §3Chemical Reactor§r for pretty much every chemical you want to process. You probably want to hold off on doing that until you\u0027ve got a solid base of autocrafting though... it stings a lot less when you can just request crafts of Chemical Reactors from your AE2 system.\n",
+          "desc:8": "nomifactory.quest.db.227.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12521,7 +12522,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Chemical Reactor",
+          "name:8": "nomifactory.quest.db.227.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12562,7 +12563,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Yes, Snad.\n\nThis pack has §aSnad§r, which is simply a sand-like block that instantly grows sugar cane/cactus on top of it when it receives either a block update or a redstone update.\n\nThe sugar cane it produces can be used as a fuel for your dynamos, and later you can even brew it for §9Biomass§r.\n\nThis quest calls for a §aRedstone Timer§r, but there are other ways to make snad grow sugar cane even faster (like a vanilla observer clock pointing into the Snad). Make sure to set the timer to pulse as fast as possible.\n\nTo collect the sugar cane, you can use a piston and an observer. Later you can make an §6Auto-Breaker§r from §bActually Additions§r, which works even better and doesn\u0027t spill sugar cane everywhere.\n\nFor now, a §3Vacuum Chest§r should help keep the floor clean, and causes less lag than Hoppers. A §aVoid Upgrade§r in a §6Storage Drawer§r will automatically delete any items that overflow the drawer\u0027s capacity, so it\u0027s a good way to ensure you don\u0027t crash your server from accumulating a massive sugar cane pile before safer block breakers are available to you.",
+          "desc:8": "nomifactory.quest.db.228.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12573,7 +12574,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Snad",
+          "name:8": "nomifactory.quest.db.228.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12632,7 +12633,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "There\u0027s a great deal of interesting content within §bExtra Utilities 2§r, and although most of it is not required for progression, you should still look through what it offers and build what interests you.\n\nIn particular, the §aAngel Ring§r bauble offers creative flight, and although some of the RF generators are not particularly good, others are quite competitive with the Dynamos. And of course, you can aim for the all powerful §aRainbow Generator§r as you work towards endgame. All that and much more await, so explore away!",
+          "desc:8": "nomifactory.quest.db.229.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12643,7 +12644,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Explore Extra Utilities 2",
+          "name:8": "nomifactory.quest.db.229.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12671,7 +12672,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "If you\u0027ve tried to insert or remove a lot of items quickly, you might notice your ME network\n§eflickers offline§r briefly. This is because digitizing and re-materializing items requires energy!\n\nYour network doesn\u0027t naturally store very much energy and the §6Energy Acceptor§r only intermittently refills the network\u0027s power. To keep things stable, you will need to add some energy storage in your network using §6Energy Cells§r.\n\nJust place one anywhere in your network and it will fill up with AE energy received from the Energy Acceptor. Now, you should have enough energy in your network to prevent these power losses. Feel free to add more energy cells, or upgrade to §6Dense Energy Cells§r, if you continue to experience problems.\n\nIf you\u0027ve opted to enable channels in your AE2 configs, you will innately have some energy storage from the §3ME Controller§r, but we assume you know what you\u0027re doing at that point. §eAE2 Channels mechanics are outside the scope of the quest book, and this is the only time it will be mentioned.",
+          "desc:8": "nomifactory.quest.db.230.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12683,7 +12684,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Oops... A Blackout!",
+          "name:8": "nomifactory.quest.db.230.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12725,7 +12726,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Endervoirs are multiblocks formed by at least three Endervoir blocks. You can right-click a block with a wrench to make it output into adjacent machines.\n\nThe maximum transfer rate of an Endervoir is one bucket per second.",
+          "desc:8": "nomifactory.quest.db.231.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12736,7 +12737,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infiniter Water",
+          "name:8": "nomifactory.quest.db.231.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12780,7 +12781,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your Rocket built, fuel loaded, and destination set, it\u0027s time for the prelaunch checklist.\n\n- §eMake sure you\u0027re wearing your Space Suit§r (all four pieces) and that it has a full tank of Oxygen. If you plan to stay on the Moon a while, maybe bring a gas charging pad and Ender Tank (being filled with Oxygen) with you.\n\nTeleportation:\n\n- If you decided to go with §aDislocators§r, make sure you take two with you: one bound to the Overworld, the other ready to bind to the Moon. Also bring along a Pedestal to put the Overworld one on the Moon surface.\n\n- If you decided to go with §aTelepads§r, make sure you\u0027ve constructed a Telepad in the Overworld and that you\u0027re carrying coordinates that lead to it. Make sure to bring your Coordinate Selector, blank Paper, and materials for the second Telepad setup. Bring Dew of the Void and RF power (like a §6Solar Panel§r and a §6Capacitor Bank§r).\n\nIn either case, as soon as you land you will need to prepare the other half of the teleportation route, and chunkload it.\n\nWhen you\u0027re sure you\u0027re prepared, sit in your rocket and press §eSpace§r.\n\nLiftoff!",
+          "desc:8": "nomifactory.quest.db.232.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12791,7 +12792,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fly To The Moon",
+          "name:8": "nomifactory.quest.db.232.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12832,7 +12833,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "There\u0027s a great deal of interesting content within §bActually Additions§r, and although most of it is not strictly required for progression, you should still look through what it offers and build what interests you.\n\nIn particular, the §aDrill§r with all the upgrades is a fantastically powerful mining tool, and the §3Vertical Digger§r is a machine which can be placed to automate mining an entire vein for you.\n\n§3Phantomfaces§r, §3Auto Placers/Breakers§r, §3Lava Factories§r, and much more can be utilized at your discretion to supplement and refine your automation techniques.",
+          "desc:8": "nomifactory.quest.db.233.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12843,7 +12844,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Explore Actually Additions",
+          "name:8": "nomifactory.quest.db.233.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12871,7 +12872,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Barium§r is an element found in §6Barite§r, which may be found as §6Barite Ore§r, inside §6Quartz§r veins.\n\nBarite can also be extracted from other Quartz ores via ore processing.",
+          "desc:8": "nomifactory.quest.db.234.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12882,7 +12883,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Barium",
+          "name:8": "nomifactory.quest.db.234.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12923,7 +12924,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Melting §6Mana Dust§r in a §3Fluid Extractor§r produces §9Primal Mana§r, which is needed for smelting various alloys from §bThermal Expansion§r.",
+          "desc:8": "nomifactory.quest.db.235.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12938,7 +12939,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Primal Mana",
+          "name:8": "nomifactory.quest.db.235.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -12977,7 +12978,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Transistors§r are semiconductors that can amplify or switch electrical signals and power. They\u0027re probably one of the most important inventions of the 20th century.\n\nYou\u0027re going to use them as a component for better circuits. This one is a bit pricey, requiring §2PE, Silicon Plates and Fine Tin Wire.",
+          "desc:8": "nomifactory.quest.db.236.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12988,7 +12989,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Transistor",
+          "name:8": "nomifactory.quest.db.236.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13029,7 +13030,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bApplied Energistics§r uses §aPresses§r found in chests at the heart of meteors as templates for §3Inscribers§r to make §6inscribed circuits§r.\n\nThis compass will lead you to the nearest meteor impact. Use your favorite mining tools to smash through the §6Skystone§r shell and get to the juicy center where the §6Skystone Chest§r with the plate is found.\n\nPlease note that while they\u0027re often in a big crater, the meteors might be buried underground; when the compass is spinning wildly, you\u0027re right on top of one.",
+          "desc:8": "nomifactory.quest.db.237.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13040,7 +13041,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Meteorite Hunter",
+          "name:8": "nomifactory.quest.db.237.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13083,7 +13084,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Eighth Micro Miner.\n\nThe main source of §6Chaos Shards§r.\n\nThe other mission gives negligible amounts of §6Neutronium§r and some other moderately useful things, but you\u0027re better off making Neutronium in the §3Fusion Reactor Mark 3§r§r and the other items are otherwise craftable.",
+          "desc:8": "nomifactory.quest.db.238.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13094,7 +13095,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tier Eight Micro Miner",
+          "name:8": "nomifactory.quest.db.238.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13136,7 +13137,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Chaos Shards§r are an endgame component for §bDraconic Evolution§r.\n\nThey are the base material for Chaotic Tier materials and come exclusively from Tier Eight Micro Miners.",
+          "desc:8": "nomifactory.quest.db.239.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13147,7 +13148,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chaos Shards",
+          "name:8": "nomifactory.quest.db.239.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13191,7 +13192,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Ninth Micro Miner.\n\nCombines §bStellar Creation Data§r into the §dUniverse Creation Data§r, which is a crucial component for the Tier Ten Micro Miner mission.\n\nThe alternate mission brings a decent quantity of §6Neutronium§r, but you have to bootstrap it with some Neutronium from the §3Fusion Reactor Mark 3§r anyway. It might be easier to just make all your Neutronium in the reactor, but it\u0027s up to you.",
+          "desc:8": "nomifactory.quest.db.240.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13202,7 +13203,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tier Nine Micro Miner",
+          "name:8": "nomifactory.quest.db.240.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13244,7 +13245,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy plating used exclusively for the Tier Eight Micro Miner. ",
+          "desc:8": "nomifactory.quest.db.241.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13255,7 +13256,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Crystal Matrix Heavy Plating",
+          "name:8": "nomifactory.quest.db.241.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13299,7 +13300,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The most advanced substrate available, prepared for bleeding-edge bioengineering technology.\n\n§6Wetware Circuit Boards§r are the basis of §6Wetware§r circuits, the final theme that spans tiers six through nine.",
+          "desc:8": "nomifactory.quest.db.242.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13310,7 +13311,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Wetware Substrate",
+          "name:8": "nomifactory.quest.db.242.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13355,7 +13356,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "",
+          "desc:8": "nomifactory.quest.db.243.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13366,7 +13367,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Superconducting Coil Block",
+          "name:8": "nomifactory.quest.db.243.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13409,7 +13410,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Awakened Draconium§r, §6Chaos Shards§r, and §6Stabilized Einsteinium§r can be used in a Draconic Tier fusion crafting setup to create a §6Draconic Reactor Core§r.\n\nThis is an important component in the Tier Nine and Tier Ten Micro Miners, as well as some Endgame items.",
+          "desc:8": "nomifactory.quest.db.244.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13420,7 +13421,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconic Reactor Core",
+          "name:8": "nomifactory.quest.db.244.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13461,7 +13462,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy: avoid dropping it on your foot.\n\nThis special plating is used for two things-- §6Tier Two Micro Miners§r and the §3Space Station Assembler§r.",
+          "desc:8": "nomifactory.quest.db.245.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13472,7 +13473,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Titanium Heavy Plating",
+          "name:8": "nomifactory.quest.db.245.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13513,7 +13514,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy Plating for Micro Miners made from §6Tungsten Carbide§r.\n\nYou §2no longer need high tier Compressors to make these.",
+          "desc:8": "nomifactory.quest.db.246.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13524,7 +13525,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tungsten Carbide Heavy Plating",
+          "name:8": "nomifactory.quest.db.246.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13602,7 +13603,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This quest, and the ones that follow it, are §cNOT REQUIRED§r for progression.\n\nOnly do them if you want to be able to explore the various planets offered by Advanced Rocketry and potentially build bases there, or in space.\n\nRefer to the various high quality tutorials on AR available on YouTube for specifics.",
+          "desc:8": "nomifactory.quest.db.248.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13613,7 +13614,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Space Station Assembler",
+          "name:8": "nomifactory.quest.db.248.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13667,7 +13668,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Warp Core§r is a multiblock structure that you can build on the space station. Use the Holo-Projector for a building guide.\n\nWhile it\u0027s not required for the progression, you can spend some resources to travel to distant planets, either to explore them or just to change the background of your space station.\n\nThe Input Hatch must be filled with §6Dilithium§r.",
+          "desc:8": "nomifactory.quest.db.249.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13678,7 +13679,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Warp Core",
+          "name:8": "nomifactory.quest.db.249.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13756,7 +13757,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Dilithium Crystals§r are used to power Warp Cores, and are also a key component in several Micro Miner missions.\n\nThey are made by crystallizing §6Dilithium Dust§r with §9Deuterium§r in an §3Autoclave§r.",
+          "desc:8": "nomifactory.quest.db.250.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13767,7 +13768,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dilithium",
+          "name:8": "nomifactory.quest.db.250.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -13811,7 +13812,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Fourth Micro Miner.\n\nAll of the Tier Four missions require §68 Quantum Flux§r and a stack of §6Petrotheum Dust§r.\n\nThis miner brings §cPlatinum Group Sludge-bearing ores, sources of §6Osmium§r and §6Iridium§r, via a mission requiring §6Wither Realm Data§r.\n\nA §6Composition Sensor§r instead directs the miner to obtain §6Dense Oilsands Ore§r, equivalent to §264§r stacks of §6Oilsands Ore§r.\n\nWhen equipped with a §6Gemstone Sensor§r:\n§6* Dense Redstone Ore\n* Dense Emerald Ore\n* Dense Diamond Ore\n* Dense Lapis Ore\n* Dense Coal Ore§r",
+          "desc:8": "nomifactory.quest.db.251.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13822,7 +13823,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Four Micro Miner",
+          "name:8": "nomifactory.quest.db.251.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13863,7 +13864,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Fifth Micro Miner.\n\nThe only source of §6Naquadah§r, in the form of §cSnowchestite Ore§r. Along with it, § §2Kaemanite Ore§r (for §6Trinium§r).\n\nWhen provided with §6Stabilized Uranium§r, brings:\n§6§2* Uraninite Ore§6\n* Molybdenite Ore\n* Bastnasite Ore\n* Sphalerite Ore\n* Palladium Ore\n* Beryllium Ore\n* Monazite Ore\n§2* Osmiridium 80/20 Ore\n* Realgar Ore§6§r\n§6* Enderpearl Blocks\n* Boron Dust§r",
+          "desc:8": "nomifactory.quest.db.252.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13874,7 +13875,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Five Micro Miner",
+          "name:8": "nomifactory.quest.db.252.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -13916,7 +13917,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Iridium§r is an advanced material used for Micro Miner plating, §6§rand for alloying with §6Osmium§r into §6Osmiridium§r.\n\n§6Iridium Ore§r is available renewably from the Tier Four and Tier Six micro miners.",
+          "desc:8": "nomifactory.quest.db.253.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13927,7 +13928,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Iridium",
+          "name:8": "nomifactory.quest.db.253.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -13968,7 +13969,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Sixth Micro Miner.\n\nThe first decent source of §6Dragon Eggs§r and §6Stabilized Einsteinium§r.\n\nIs also useful for:\n§6§2* Uraninite Ore\n§c* Sheldonite Ore\n* Iridosmine 80/20 Ore",
+          "desc:8": "nomifactory.quest.db.254.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -13979,7 +13980,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Six Micro Miner",
+          "name:8": "nomifactory.quest.db.254.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14020,7 +14021,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An alloy of equal parts §6Tungsten§r and §6Carbon Dust§r.\n\n§6Tungsten Carbide§r is a very dense, sturdy, and heat-resistant material useful for a variety of applications.",
+          "desc:8": "nomifactory.quest.db.255.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14031,7 +14032,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tungsten Carbide",
+          "name:8": "nomifactory.quest.db.255.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14074,7 +14075,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Seventh Micro Miner.\n\nThe source of §6Dragon Hearts§r and the valuable §6Lair of The Chaos Guardian Data§r.\n\nAs a bonus, brings §6Dragon Eggs, Dragon\u0027s Breath, Ender Dragon Scales§r, §2Americium Blocks§r and a plenty of different precious metals and gems.",
+          "desc:8": "nomifactory.quest.db.256.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14085,7 +14086,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Tier Seven Micro Miner",
+          "name:8": "nomifactory.quest.db.256.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14126,7 +14127,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy plating used exclusively for the Tier Seven Micro Miner. ",
+          "desc:8": "nomifactory.quest.db.257.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14137,7 +14138,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Draconium Heavy Plating",
+          "name:8": "nomifactory.quest.db.257.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14178,7 +14179,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Awakened Draconium§r is a powerful material used for crafting high-grade components, items, and machines from §bDraconic Evolution§r.\n\nFive §6§6Draconium Blocks§r can be processed in a Wyvern Tier fusion crafting setup to create an equal output of five §6Awakened Draconium Blocks§r. At §e24 Billion RF per craft§r, you better have a handle on your power infrastructure.",
+          "desc:8": "nomifactory.quest.db.258.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14189,7 +14190,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Awakened Draconium",
+          "name:8": "nomifactory.quest.db.258.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14230,7 +14231,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your first MV hull is as good of a place as any to consider yourself graduated from LV.\n\nYou might notice that these hulls can be made more cheaply in an §3Assembling Machine§r, but you don\u0027t have that weird fluid. Don\u0027t worry, you\u0027ll be able to make that soon.\n\n§2Overclocking mechanics have changed in CEu. All overclocks now multiply the speed by 2.0x (instead of the 2.0/2.8 split in CE). This means that to save energy, you should build more low-tier machines over overclocking a high-tier machine, especially for passive processes.\nAdditionally, ULV recipes will not overclock to LV. A ≤8 EU/t recipe won\u0027t overclock at all in an LV machine, will only overclock once in an MV machine, etc.",
+          "desc:8": "nomifactory.quest.db.259.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14241,7 +14242,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2MV Machine Hulls",
+          "name:8": "nomifactory.quest.db.259.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14282,7 +14283,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Electrolyzers§r use electricity to separate items into their more basic components.\n\nFor example, you can break down Water into §9Hydrogen Gas§r and §9Oxygen Gas§r, or break down §6Clay Dust§r into §6Sodium Dust§r, §6Silicon Dust§r, §6Lithium Dust§r, and §6Aluminium Dust§r.",
+          "desc:8": "nomifactory.quest.db.260.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14293,7 +14294,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Electrolyzer",
+          "name:8": "nomifactory.quest.db.260.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14336,7 +14337,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Having unlocked §6Signalum§r and §6Lumium§r, at long last you can now make §aSignalum Upgrade Kits§r!\n\nProvides more augment slots to machines and dynamos.\n\nDynamos operate at §a500% of base power and fuel burn rate§r.\n\nPortable Tanks hold §a800 buckets§r.\n\nMachines operate at §a400% of base speed§r.",
+          "desc:8": "nomifactory.quest.db.261.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14347,7 +14348,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Signalum Upgrade Kit",
+          "name:8": "nomifactory.quest.db.261.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14389,7 +14390,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An advanced ingredient used for the §aUltimate Extended Crafting Table§r and other late-game recipes. ",
+          "desc:8": "nomifactory.quest.db.262.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14400,7 +14401,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Conflux Catalyst",
+          "name:8": "nomifactory.quest.db.262.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14441,7 +14442,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Indium§r is a rare material requiring specialized bulk ore processing to acquire. It is useful for making §6Indium Gallium Phosphide§r (InGaP).\n\nYou will need to purify (with a §3Washer§r or §3Chemical Bath§r) §6Galena§r and §6Sphalerite§r to get §6Crushed Purified§r dusts. These need to be placed together in a §3Chemical Reactor§r along with §9Sulfuric Acid§r, which will result in §9Indium Concentrate§r.\n\nThis in turn needs to be reacted with §6Aluminium§r in another Chemical Reactor, to create §2Small Piles of Indium Dust, Aluminium Sulfite and §9Lead-Zinc Solution§r. The latter two can be centrifuged into various useful materials, and the Indium piles can be combined into full dusts.\n\n§2Indium can also be obtained from the Naquadah processing chain in LuV.\n",
+          "desc:8": "nomifactory.quest.db.263.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14452,7 +14453,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Indium",
+          "name:8": "nomifactory.quest.db.263.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14495,7 +14496,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your new §6§6§ §6Epoxy Circuit Boards§r, §6QBit CPUs§r, and some standard components, you can make the final type of Tier Four Circuit: the §6Quantum Circuit§r.\n\nAs the best form of Tier Four circuit, these should be automated and stockpiled. The variant recipe requiring §6Advanced System-on-Chip§r won\u0027t be available until ZPM.",
+          "desc:8": "nomifactory.quest.db.264.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14506,7 +14507,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third And Final Tier Four Circuits",
+          "name:8": "nomifactory.quest.db.264.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14548,7 +14549,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6QBit CPUs§r are an advanced Circuit Wafer crucial for §6Quantum Circuits§r.\n\nThere are two methods of creating them:\n\nThe simpler recipe uses two §6Quantum Eyes§r and two ingots worth of molten §9Gallium Arsenide§r to enhance a §6NanoCPU Wafer§r. This recipe is slow and requires substantially more §9Radon§r per craft.\n\nThe other route instead uses §6Indium Gallium Phosphide§r and a tiny amount of Radon. This skips the slow-crafting Quantum Eyes, using far less Radon in the process, but requires the infrastructure in place for obtaining §6Indium§r.\n\nThe second route is overall better, and you will need Indium processing to complete the pack so might as well do it.",
+          "desc:8": "nomifactory.quest.db.265.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14559,7 +14560,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "QBit Processing Unit",
+          "name:8": "nomifactory.quest.db.265.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -14600,7 +14601,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Item Pipes are back in GTCEu! They will transport items instantly through them.\n\nTheir advantage over EnderIO Item Conduits is their far higher throughput. An unupgraded EIO Item Conduit transports 8 items per second, and up to 128 when upgraded. In comparison, small low-tier Item Pipes can transfer 64 items per second, and those made from later materials can transfer multiple stacks per second.\n\nThey don\u0027t auto-extract by themselves, so you have to use Conveyor covers etc. with them.\n\nThe priority mechanics are more complicated, so skip ahead if you are not interested:\nA Destination will have a Routing Value calculated, which is the sum of all Routing Values of the individual Pipes to that Destination. Whichever Destination has the lowest Routing Value will be the one selected for Insertion.\nRestrictive Pipes typically have the lowest Priority for insertion due to their higher Routing Value.",
+          "desc:8": "nomifactory.quest.db.266.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14611,7 +14612,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2GT Item Pipes",
+          "name:8": "nomifactory.quest.db.266.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -14651,7 +14652,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Radon§r will be needed in large quantities.\n\nFor now, you\u0027ll need to obtain it from Tier Two Micro Miner missions, in the form of §6Radium Salt§r. Electrolyze it for Radon and §6Rock Salt§r. §2You can also get it from distilling liquid Ender Air.§r\n\nLater it will be possible to make Radon using a §bGregTech§r §3Fusion Reactor§r.",
+          "desc:8": "nomifactory.quest.db.267.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14666,7 +14667,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Radon",
+          "name:8": "nomifactory.quest.db.267.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14704,7 +14705,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Nothing new here, just use more standard circuit stuff and you can upgrade several §6Quantum Circuits§r into a §6Quantum Processor§r.",
+          "desc:8": "nomifactory.quest.db.268.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14715,7 +14716,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Third Tier Five Circuit",
+          "name:8": "nomifactory.quest.db.268.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14756,7 +14757,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Nothing special about this tier either.",
+          "desc:8": "nomifactory.quest.db.269.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14767,7 +14768,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Six Circuits",
+          "name:8": "nomifactory.quest.db.269.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14808,7 +14809,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Macerators§r are useful for grinding things down, replacing the §aMortars§r you\u0027ve needed until now. This is an important machine you will be using for many things in the future.\n\nOne useful application for a Macerator in the near future is grinding down §6Clay§r or §6Terracotta§r into §6Clay Dust§f.\n\nBesides not having limited durability, a key advantage of Macerators over Mortars is the chance to get additional materials when grinding things down. These are called §ebyproducts§r, and HV or better Macerators have three slots instead of one so byproducts can appear.\n\nWhen reading Macerator recipes in §bJEI§r, you can tell which outputs are byproducts by seeing if §ethe tooltip tells you it has a chance to appear§r: guaranteed outputs do not list a chance. §2The chance increases by a certain amount for each tier of machine you have above the tier of recipe. This chance is also listed in the tooltip.§r\n\n§2Macerators can now also recycle your old Machines for some extra materials.§r\n\nFinally, a Macerator will only start processing if there is room for all possible outputs. Make sure you empty them so they can keep working.",
+          "desc:8": "nomifactory.quest.db.270.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14819,7 +14820,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Macerator",
+          "name:8": "nomifactory.quest.db.270.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14861,7 +14862,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Reactor Stabilizer§r is a component needed for the Tier Nine and Tier Ten Micro Miners, as well as a component in a few Endgame recipes.\n\nThey are made in a Chaotic Tier fusion crafting setup, requiring a whopping §e56 Billion total RF each§r. You\u0027re gonna need some serious power generation and crafting infrastructure to make everything for these.",
+          "desc:8": "nomifactory.quest.db.271.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14872,7 +14873,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reactor Stabilizer",
+          "name:8": "nomifactory.quest.db.271.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14913,7 +14914,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The first tier of §6capacitors§r. These (or stronger versions) are required to make §bEnderIO§r machines run. They\u0027re also used as components in a variety of recipes.\n\nHigher tier capacitors will significantly increase the speed at which these machines operate, among other machine-specific properties.",
+          "desc:8": "nomifactory.quest.db.272.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14924,7 +14925,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basic Capacitors",
+          "name:8": "nomifactory.quest.db.272.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -14965,7 +14966,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mixes two dusts to make a third.\n\nFor now, you\u0027ll be using it to make §6Glowstone Dust§r.\n\nGlowstone Dust is made from §6Tricalcium Phosphate Dust§r and §6Gold Dust§r, or you could eventually gather it from the Nether.",
+          "desc:8": "nomifactory.quest.db.273.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14976,7 +14977,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Mixer",
+          "name:8": "nomifactory.quest.db.273.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15017,7 +15018,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Dragon Hearts§r are needed for both §6Awakened Draconium§r and §6The Ultimate Material§r.",
+          "desc:8": "nomifactory.quest.db.274.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15028,7 +15029,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dragon Hearts",
+          "name:8": "nomifactory.quest.db.274.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15070,7 +15071,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Luminessence§r is used in a number of things, but right now, it will be a component in your §aExtended Crafting Tables§r.",
+          "desc:8": "nomifactory.quest.db.275.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15081,7 +15082,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Luminessence",
+          "name:8": "nomifactory.quest.db.275.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15123,7 +15124,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Phosphoric Acid§r is a key component of §6Luminessence§r, which will be used extensively for such things as §6Nether Stars§r, §6Lumium Blend§r, and §bExtended Crafting§r components.\n\nIt can be made using several equally viable recipes:\n\n§6Phosphorus§r, §9Oxygen§r, and §9Water§r can be chemically reacted to produce §9Phosphoric Acid§r.\n\nAlternatively, you can combine §6Phosphorus Pentoxide§r and Water for a much faster reaction.\n\nOtherwise, you can react §6Apatite Dust§r, §9Sulfuric Acid§r, and Water to get Phosphoric Acid, §9Hydrochloric Acid§r, and a whole bunch of §6Gypsum Dust§r.",
+          "desc:8": "nomifactory.quest.db.276.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15138,7 +15139,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phosphoric Acid",
+          "name:8": "nomifactory.quest.db.276.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -15211,7 +15212,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You can combine various items with a §6Blank Data Model§r for a completed §6Data Model§r that you can run inside the §3Simulation Chamber§r.",
+          "desc:8": "nomifactory.quest.db.278.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15222,7 +15223,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Simulated Mobs",
+          "name:8": "nomifactory.quest.db.278.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15263,7 +15264,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "\"§6Dragon Eggs§r?\" You might ask. Yep.\n\nThe final circuit theme, Wetware, will require a lot of them.\n\nTier Six Micro Miners can get some eggs (enough for this quest, as it happens), but Tier Seven miners are a better long-term solution for building up your supply, as they also give §6Dragon Hearts§r.\n\nLater, you\u0027ll also get substantial quantities from Tier Eight Micro Miners, while you are accumulating §6Chaos Shards§r.\n\n",
+          "desc:8": "nomifactory.quest.db.279.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15274,7 +15275,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Breaking Some Eggs",
+          "name:8": "nomifactory.quest.db.279.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15390,7 +15391,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Man, that\u0027s a LOT of quests linked to this one.\n\n§dOmnium§r, as the name suggests, is an incredible material composed of all elements and alloys you\u0027ve encountered so far.\n\nYou\u0027ve got all this automated, right?",
+          "desc:8": "nomifactory.quest.db.280.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15401,7 +15402,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mote of Omnium",
+          "name:8": "nomifactory.quest.db.280.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15479,7 +15480,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Fluix is initially made via in-world crafting, by dropping §6Redstone Dust§r, §6Nether Quartz§r, and a §6Charged Certus Quartz Crystal§r in the same block of §9Water§r. You\u0027ll see some sparks then the items will merge into a §6Fluix Crystal§r. Be sure to turn off any nearby item magnets/collectors or they might interrupt this crafting process.\n\nThe §3Energy Acceptor§r converts RF power into AE power that Applied Energistics uses, in a 2 RF to 1 AE ratio. This power will be transmitted through adjacent full-block ME Network devices, as well as along all connected §6ME Cables§r, §6ME Conduits§r, and §6Quartz Fiber§r. \n\nQuartz Fiber are §emicroparts§r you can put between an ME Cable and any ME Network block or another ME Cable. This will allow transmission of AE power but not data, which is useful for having data-isolated ME Networks all sharing the same power source.",
+          "desc:8": "nomifactory.quest.db.282.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15490,7 +15491,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Energy Acceptor",
+          "name:8": "nomifactory.quest.db.282.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -15540,7 +15541,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §6§2Rhodium Plated Lumium-Palladium§r-based machine hulls, Assembling Machine built, and §6Quantum Processor Mainframes§r squared away, you can finally get on the path to making a Ludicrous Voltage §3Circuit Assembling Machine§r.\n\nThis tier of Assembling Machine unlocks §6Crystal Circuits§r, as well as handling crafting recipes up to 32768 EU/t. It can also optionally overclock recipes that consume up to 8192 EU/t for improved speed at the cost of relatively more power.",
+          "desc:8": "nomifactory.quest.db.283.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15551,7 +15552,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LuV Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.283.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15629,7 +15630,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Vanadium-Gallium§r is an alloy made in the §3Electric Blast Furnace§r. It is a Ludicrous Voltage (LuV) cable material needed for certain recipes.\n\n§6",
+          "desc:8": "nomifactory.quest.db.285.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15640,7 +15641,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vanadium Gallium",
+          "name:8": "nomifactory.quest.db.285.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15682,7 +15683,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Assembly Line§r is a large multiblock structure that crafts complex materials, similar to an §3Assembling Machine§r. These will be crucial going forward for making a variety of components and machinery.\n\nMake sure your power generation and circuit production are up to the challenge. §2None of the Assembly Line recipes require programmed circuits anymore.§r\n\nNotice that all numbers of required items are §emultiples of 11.§r This is to make an Assembly Line that\u0027s 11 units long, allowing for 10 inputs and one output. This is a large enough Assembly Line to make a §aFusion Reactor Controller Mk1§r, but you\u0027ll need to expand to more inputs for later projects.\n\n§2You will also need a Maintenance Hatch.\n\n§aFluid Input Hatches§r can replace any of the §6Steel Casings§r along the bottom outside except for the Casings touching the §aOutput Bus§r. For the most part, ULV ones work fine, but a few recipes will need an LV one.\n\nThe §aEnergy Input Hatches§r along the top can be replaced by Steel Casings: you only need the one Energy Input Hatch (although you can add more if you want).\n\nThe §aInput Buses§r along the bottom §emust be ULV tier§r, nothing else. Make sure to spin them all so the hole is on the bottom.",
+          "desc:8": "nomifactory.quest.db.286.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15693,7 +15694,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Assembly Line",
+          "name:8": "nomifactory.quest.db.286.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15783,7 +15784,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Time to get fusing!\n\nThe §3Fusion Reactor§r is a multiblock that uses enormous amounts of energy to fuse fluids into new elements. This one is less flexible than the previous GregTech multiblocks, as you can only put hatches where the preview shows. §6Sneak-right click§r the controller to enable the in-world preview.\n\nThe §bJEI§r preview shows §e§eall valid hatch locations§r, but you don\u0027t actually need that many fluid hatches. You can replace any of the hatch positions in the structure with §2Fusion Glass or Fusion Machine Casings§r as long as you have at least §atwo Fluid Input Hatches§r and §aone Fluid Output Hatch§r. It\u0027s possible to use input/output hatches in every valid location, if you prefer.\n\nBecause of this, the quest only asks for §248 Fusion Machine Casings, 31 Fusion Glass§r. If you want to use the minimum number of fluid hatches, you\u0027ll need to craft an additional §231 Fusion Machine Casings§r.\n\nEach §aEnergy Input Hatch§r increases the reactor\u0027s power buffer. §aAll 16 Energy Input Hatches§r are required to be able to process all Mark 1 recipes and give a power buffer of §e160M EU§r.\n\nIn addition to the recipe power drain, Fusion Reactors have a §eheat§r mechanic related to the recipe\u0027s §e\"Eu to Start\"§r. This amount of power is drained from the reactor\u0027s buffer before starting the recipe to heat up the reactor to the necessary temperature, and is independent of the recipe\u0027s EU/t cost. As such, this determines the minimum tier of reactor you need for a recipe.\n\nIf the reactor stops processing, it will §erapidly lose heat§r, even if you pause it with a soft hammer. On the other hand, if the reactor is already at the required temperature for a recipe, §eno additional power§r is required to heat up the reactor! This is true even if you switch between different recipes. This mechanic incentivizes continuous use of the reactor.\n\nIf you switch to a recipe that requires more heat, §eonly the difference§r in heat values is consumed as EU to reach the target heat (up to a maximum heat equal to the reactor\u0027s current buffer).\n\nFusion Reactors §2now overclock§r, but they gate the next tier of materials, so you will eventually want to make more than one.",
+          "desc:8": "nomifactory.quest.db.287.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15794,7 +15795,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fusion Reactor MK1",
+          "name:8": "nomifactory.quest.db.287.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15873,7 +15874,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need at least §6Naquadah Coil Blocks§r in your blast furnace to smelt §6Draconium§r, as well as a healthy supply of §cHigh-Octane Gasoline§r to reach the immense heat it takes to liquefy.\n\nDraconium gets so hot that it requires the potent coolant §9Gelid Cryotheum§r to aid your §3Vacuum Freezer§r in turning it into usable ingots.\n\nThere are several ways to make Draconium: dust can be smelted into ingots, but you can also turn §6Ender Dragon Scales§r, which contain Draconium, directly into ingots. It uses a lot of§2 combustion fuel§r, but is the most efficient way to craft Draconium.\n\nYou\u0027ve been stockpiling fuel, right?",
+          "desc:8": "nomifactory.quest.db.288.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15884,7 +15885,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Draconium Ingots",
+          "name:8": "nomifactory.quest.db.288.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -15925,7 +15926,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "By baking a §2Raw Crystal Chip §rand §6Emerald Plates§r with §9Helium§r in an §3Electric Blast Furnace§r, you can create an §6Engraved Crystal Chip§r.\n\nThis is a material needed for §6Crystal Circuits§r.",
+          "desc:8": "nomifactory.quest.db.289.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15936,7 +15937,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Engraved Crystal Chip",
+          "name:8": "nomifactory.quest.db.289.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16014,7 +16015,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Crystal CPUs§r are the cores of §6Crystal Circuits§r.\n\nYou\u0027ll need an §2LuV Precision Laser Engraver§r to craft this.",
+          "desc:8": "nomifactory.quest.db.291.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16025,7 +16026,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Crystal Processing Unit",
+          "name:8": "nomifactory.quest.db.291.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16066,7 +16067,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With some now-standard components you can upgrade a few §6Crystal Circuits§r into a §6Crystal Processor§r.",
+          "desc:8": "nomifactory.quest.db.292.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16077,7 +16078,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third Tier Six Circuits",
+          "name:8": "nomifactory.quest.db.292.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16119,7 +16120,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The culmination of so much effort.\n\n§6Chaotic Cores§r are the ultimate tier of §bDraconic Evolution§r core, used for the most powerful and advanced items.",
+          "desc:8": "nomifactory.quest.db.293.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16130,7 +16131,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chaotic Cores",
+          "name:8": "nomifactory.quest.db.293.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16171,7 +16172,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Restonia Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.294.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16182,7 +16183,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Restonia Gear",
+          "name:8": "nomifactory.quest.db.294.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16225,7 +16226,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bDraconic Evolution§r features §eFusion Crafting§r, which requires a §6Fusion Crafting Core§r and up to ten injectors of the appropriate tier.\n\nYou\u0027ll need eight §6Basic Fusion Crafting Injectors§r to upgrade any additional injectors you make to Wyvern Tier.\n\nYes, that means you should plan to make more than eight. If you really want to plan ahead, make thirty-four of these.",
+          "desc:8": "nomifactory.quest.db.295.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16236,7 +16237,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basic Fusion Injectors",
+          "name:8": "nomifactory.quest.db.295.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16283,7 +16284,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Obtaining §6Grains of Infinity§r will require you to mine all the way down to Bedrock level.\n\nUse Flint and Steel to light a fire (or many fires) and then wait for it to go out. There\u0027s a 50% chance of Grains Of Infinity to appear for every fire that burns out on its own.\n\nBut who wants to do that forever? There will be better ways before too long, don\u0027t worry.",
+          "desc:8": "nomifactory.quest.db.296.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16294,7 +16295,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Grains Of Infinity",
+          "name:8": "nomifactory.quest.db.296.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16342,7 +16343,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mixing §6Titanium§r with §6Mana Dust§r creates §6Mana Infused Metal Dust§r. This can be smelted into ingots in an §3Electric Blast Furnace§r equipped with §6Kanthal Coils§r or better.\n\nMana Infused Metal is the basis of §bThermal Expansion§r device casings, and is used for many advanced §aAugments§r.",
+          "desc:8": "nomifactory.quest.db.297.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16353,7 +16354,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mana Infused Ingot",
+          "name:8": "nomifactory.quest.db.297.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16403,7 +16404,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "ASSEMBLE!\n\n§6Mana Dust§r is an important material. It is needed for a variety of materials related to §bThermal Expansion§r.",
+          "desc:8": "nomifactory.quest.db.298.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16414,7 +16415,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mana Dust",
+          "name:8": "nomifactory.quest.db.298.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16455,7 +16456,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This casing is the structure for §bThermal Expansion§r\u0027s devices, which are simpler machines.\n\n",
+          "desc:8": "nomifactory.quest.db.299.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16466,7 +16467,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Thermal Device Casing",
+          "name:8": "nomifactory.quest.db.299.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16507,7 +16508,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Thermal Device Casings§r are upgradable to a §6Machine Frame§r with some §6Stainless Steel Plates§r.\n\nThese frames form the basis of §bThermal Expansion§r\u0027s more advanced machinery.",
+          "desc:8": "nomifactory.quest.db.300.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16518,7 +16519,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Thermal Machine Frame",
+          "name:8": "nomifactory.quest.db.300.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16559,7 +16560,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Redstone§r, a §6Snowball§r, and §6Blizz Powder§r creates §6Cryotheum Dust§r, a mixture imbued with potent elemental frost.",
+          "desc:8": "nomifactory.quest.db.301.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16570,7 +16571,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Cryotheum",
+          "name:8": "nomifactory.quest.db.301.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16611,7 +16612,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Redstone§r, §6Saltpeter§r, and §6Blitz Powder§r creates §6Aerotheum Dust§r, a mixture imbued with potent elemental air.",
+          "desc:8": "nomifactory.quest.db.302.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16622,7 +16623,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Aerotheum",
+          "name:8": "nomifactory.quest.db.302.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16663,7 +16664,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Redstone§r, §6Obsidian Dust§r, and §6Basalz Powder§r creates §6Petrotheum Dust§r, a mixture imbued with potent elemental earth.",
+          "desc:8": "nomifactory.quest.db.303.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16674,7 +16675,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Petrotheum",
+          "name:8": "nomifactory.quest.db.303.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16715,7 +16716,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Redstone§r, §6Sulfur§r, and §6Blaze Powder§r creates §6Pyrotheum Dust§r, a mixture imbued with potent elemental flame.",
+          "desc:8": "nomifactory.quest.db.304.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16726,7 +16727,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pyrotheum",
+          "name:8": "nomifactory.quest.db.304.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -16767,7 +16768,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Bits of a §6Blaze Rod§r. Using a §3Macerator§r doubles your yield.",
+          "desc:8": "nomifactory.quest.db.305.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16778,7 +16779,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Blaze Powder",
+          "name:8": "nomifactory.quest.db.305.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -16819,7 +16820,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Bits of a §6Basalz Rod§r. Using a §3Macerator§r doubles your yield.",
+          "desc:8": "nomifactory.quest.db.306.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16830,7 +16831,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basalz Powder",
+          "name:8": "nomifactory.quest.db.306.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -16871,7 +16872,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Bits of a §6Blitz Rod§r. Using a §3Macerator§r doubles your yield.",
+          "desc:8": "nomifactory.quest.db.307.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16882,7 +16883,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Blitz Powder",
+          "name:8": "nomifactory.quest.db.307.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -16923,7 +16924,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Bits of a §6Blizz Rod§r. Using a §3Macerator§r doubles your yield.",
+          "desc:8": "nomifactory.quest.db.308.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16934,7 +16935,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Blizz Powder",
+          "name:8": "nomifactory.quest.db.308.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -16976,7 +16977,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Once you gain access to §9Fluoroantimonic Acid§r, you can make this more efficiently with respect to §9Fluorine§r.",
+          "desc:8": "nomifactory.quest.db.309.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16991,7 +16992,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Elemental Reduction Fluid",
+          "name:8": "nomifactory.quest.db.309.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17029,7 +17030,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Praise the sun. \\[T]/\n\nThis machine uses various tiers of §6Phyto-Gro§r and §9Water§r to grow plants.\n\nIt can be customized with various §aAugments§r.",
+          "desc:8": "nomifactory.quest.db.310.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17054,7 +17055,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phytogenic Insolator",
+          "name:8": "nomifactory.quest.db.310.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17109,7 +17110,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Tungstensteel§r is the fourth coil material available, increasing your EBF\u0027s operating temperature to 4500K so it can process more advanced materials.",
+          "desc:8": "nomifactory.quest.db.311.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17120,7 +17121,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tungstensteel Coil Blocks",
+          "name:8": "nomifactory.quest.db.311.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17161,7 +17162,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6HSS-G§r is an alloy of §6Tungstensteel§r, §6Chrome§r, §6Molybdenum§r, and §6Vanadium§r.\n\nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.\n",
+          "desc:8": "nomifactory.quest.db.312.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17172,7 +17173,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "High Speed Steel Type G",
+          "name:8": "nomifactory.quest.db.312.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17214,7 +17215,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6HSS-G§r is the fifth coil material available, increasing your EBF\u0027s operating temperature to 5400K so it can process more advanced materials, such as §6Naquadah§r.",
+          "desc:8": "nomifactory.quest.db.313.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17225,7 +17226,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "HSS-G Coil Block",
+          "name:8": "nomifactory.quest.db.313.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17266,7 +17267,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy plating made from §6Iridium§r for Tier Five and Tier Eight Micro Miners.",
+          "desc:8": "nomifactory.quest.db.314.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17277,7 +17278,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Iridium Heavy Plating",
+          "name:8": "nomifactory.quest.db.314.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -17319,7 +17320,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A heavy plating material required for the next two tiers of Micro Miners.",
+          "desc:8": "nomifactory.quest.db.315.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17330,7 +17331,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Signalum Heavy Plating",
+          "name:8": "nomifactory.quest.db.315.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17371,7 +17372,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Heavy plating made from §6Enderium§r used for the Tier Six Micro Miner.",
+          "desc:8": "nomifactory.quest.db.316.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17382,7 +17383,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Enderium Heavy Plating",
+          "name:8": "nomifactory.quest.db.316.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17424,7 +17425,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A complex plating material used exclusively for the Tier Nine Micro Miner.",
+          "desc:8": "nomifactory.quest.db.317.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17435,7 +17436,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Quantum Fluxed Eternium Heavy Plating",
+          "name:8": "nomifactory.quest.db.317.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17476,7 +17477,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Naphtha route for Epoxy has been removed. You can only make Epoxy using the BPA route.\n\n§rBPA can be produced using petrochemistry distillation products, or via distilling §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r into useful components. Alternatively, you can get §9Phenol§r from §6Coal§r pyrolysis. §9Fermented Biomass§r is also useful to distill as it provides many useful products.\n\n§2Using the Large Chemical Reactor, you can skip two steps in the Epoxy production line.",
+          "desc:8": "nomifactory.quest.db.318.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17491,7 +17492,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Epoxy Production",
+          "name:8": "nomifactory.quest.db.318.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17519,7 +17520,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need large quantities of §6Canola§f (for §6Canola Oil§f in a §bCanola Press§f) and §6Sugarcane§f (for §6Ethanol§f).\n\nOf course, other crops can work as well, if you want to mix things up.",
+          "desc:8": "nomifactory.quest.db.319.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17530,7 +17531,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Farming",
+          "name:8": "nomifactory.quest.db.319.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17577,7 +17578,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Void Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.320.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17588,7 +17589,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Void Gear",
+          "name:8": "nomifactory.quest.db.320.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17629,7 +17630,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Palis Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.321.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17640,7 +17641,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Palis Gear",
+          "name:8": "nomifactory.quest.db.321.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17681,7 +17682,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Emeradic Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.322.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17692,7 +17693,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Emeradic Gear",
+          "name:8": "nomifactory.quest.db.322.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17734,7 +17735,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An otherworldly material exclusive to Microverses, §6Naquadah§r is an important material in the late game.\n\nFor its processing, you will need §9Aerotheum§r and §9Petrotheum§r to separate the §6Naquadah Oxide§r, and §9Neocryolite§r as the electrolyte to get the §6Naquadah§r out.\n\nIt can be alloyed and enriched to various forms, and is the eventual source of §6Neutronium§r in a §3Mark Three Fusion Reactor§r.",
+          "desc:8": "nomifactory.quest.db.323.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17745,7 +17746,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Ingots",
+          "name:8": "nomifactory.quest.db.323.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17786,7 +17787,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Naquadah§r is the sixth coil material available, increasing your EBF\u0027s operating temperature to 7200K so it can process more advanced materials.\n\n§2You cannot skip a coil material anymore.",
+          "desc:8": "nomifactory.quest.db.324.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17797,7 +17798,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Coil Blocks",
+          "name:8": "nomifactory.quest.db.324.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17838,7 +17839,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With a §3Fusion Reactor§r, you can make Europium!\n\nThis element is needed for making things in §bDraconic Evolution§r§r, as well as the §6Fusion Reactor Computer Mark 2§r, §2Crystal Chip growing§r, and §6Wetware Supercomputers§r§r.\n\nYou make it by fusing molten §9§9Neodymium§r§r and §9Hydrogen§r.",
+          "desc:8": "nomifactory.quest.db.325.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17849,7 +17850,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Europium Ingot",
+          "name:8": "nomifactory.quest.db.325.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17928,7 +17929,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Just ignore the protesters outside your base.\n\nEach craft in an §3LuV Chemical Reactor§r takes five minutes, so it\u0027s probably a good idea to have more than one machine running this recipe. At least you get §2128 from a single craft.\n",
+          "desc:8": "nomifactory.quest.db.327.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17939,7 +17940,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Stem Cells",
+          "name:8": "nomifactory.quest.db.327.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -17980,7 +17981,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Boron§r is currently obtainable by doing ore processing on §6Lepidolite Ore§r and §6Salt Ore§r (via §6Borax§r).",
+          "desc:8": "nomifactory.quest.db.328.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -17991,7 +17992,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Boron",
+          "name:8": "nomifactory.quest.db.328.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18032,7 +18033,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Basic Fusion Crafting Injectors§r can be upgraded to Wyvern Tier via fusion crafting.\n\nTechnically you only need six of these to start making the next tier of injectors, but some recipes will need more than that. Plan on making at least twenty-six of these.",
+          "desc:8": "nomifactory.quest.db.329.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18043,7 +18044,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Wyvern Fusion Injectors",
+          "name:8": "nomifactory.quest.db.329.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18084,7 +18085,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Draconic Fusion Crafting Injectors§r are the penultimate tier of injectors for fusion crafting.\n\nYou\u0027ll need a fusion crafting setup with ten of these for the next tier of injector, and the next tier you\u0027ll also need ten injectors, so consider making 20 of these.",
+          "desc:8": "nomifactory.quest.db.330.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18095,7 +18096,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconic Fusion Injectors",
+          "name:8": "nomifactory.quest.db.330.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18137,7 +18138,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The highest tier of fusion crafting injectors. You will need at least ten of these to reach the §dCreative Portable Tank§r.\n\nEach injector requires four ingots of §6Neutronium§r and four §6Chaos Shards§r, as well as two §6Crystal Matrix§r blocks.\n\nHope you\u0027ve got those Tier Eight Micro Miners automated.",
+          "desc:8": "nomifactory.quest.db.331.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18148,7 +18149,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Chaotic Fusion Injectors",
+          "name:8": "nomifactory.quest.db.331.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18191,7 +18192,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The final form of Tier Six circuits, and the final circuit theme.\n\nUsing your §2Neuro Processing Units§r, you can craft (grow?) these circuits in a ZPM or better §3Assembling Machine§r.\n\nThese are fairly slow to craft and you\u0027re going to need considerable quantities, so make sure you have a good parallelized infrastructure for keeping these stocked.",
+          "desc:8": "nomifactory.quest.db.332.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18202,7 +18203,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Fourth And Final Tier Six Circuits",
+          "name:8": "nomifactory.quest.db.332.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18244,7 +18245,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Wetware Processors§r are made in §2the ZPM+ Circuit Assembler still.",
+          "desc:8": "nomifactory.quest.db.333.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18255,7 +18256,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third and Final Tier Seven Circuits",
+          "name:8": "nomifactory.quest.db.333.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18296,7 +18297,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Wetware Supercomputers§r are made in an §3Assembly Line§r at ZPM or better power.\n\nYou\u0027ll need §6Europium§r from the §3Fusion Reactor§r to craft these.",
+          "desc:8": "nomifactory.quest.db.334.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18307,7 +18308,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second And Final Tier Eight Circuits",
+          "name:8": "nomifactory.quest.db.334.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18349,7 +18350,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The final circuit!\n\nThe only novel ingredient is §6Tritanium Frames§r.\n\n§6Wetware Processor Mainframes§r are unique in that there are no subsquent circuit themes, and thus no other kinds of Tier Nine circuits. Unlike past mainframes, you will need to craft more than just a few of them. They\u0027re mostly used in the Endgame though, so you don\u0027t have to worry too much yet.\n\nDefinitely consider parallelizing your §3Assembly Lines§r if you haven\u0027t already. Even just having two or three lines will vastly improve your production speeds and help avoid bottlenecks as you push towards the Endgame.\n",
+          "desc:8": "nomifactory.quest.db.335.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18360,7 +18361,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First And Only Tier Nine Circuit",
+          "name:8": "nomifactory.quest.db.335.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18402,7 +18403,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Draconium is a complex material needed in vast quantities.\n\nYou\u0027ll likely have come by some dust while mining in the End, but you can also create it with §6Dragon\u0027s Breath§r and §6Manyullyn§r.",
+          "desc:8": "nomifactory.quest.db.336.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18413,7 +18414,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconium Dust",
+          "name:8": "nomifactory.quest.db.336.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -18455,7 +18456,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Draconic Cores§r are the first crafting step into §bDraconic Evolution§r.\n\nThese serve as the basis for crafting many items and can be upgraded into different tiers of cores via §eFusion Crafting§r.",
+          "desc:8": "nomifactory.quest.db.337.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18466,7 +18467,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconic Cores",
+          "name:8": "nomifactory.quest.db.337.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18507,7 +18508,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2You can make HV Batteries like LV and MV ones, but there is a better option.\n\nEnergium Crystals can store 6,400,000 EU, at the cost of some crafting complexity. They need an HV Autoclave.",
+          "desc:8": "nomifactory.quest.db.338.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18521,7 +18522,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2HV Power Storage",
+          "name:8": "nomifactory.quest.db.338.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18562,7 +18563,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6Titanium§r smelting automated, you can now build Machine Hulls for Extreme Voltage machines.\n\n§2Starting at EV, 4A Energy and Dynamo hatches are available at each tier.",
+          "desc:8": "nomifactory.quest.db.339.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18573,7 +18574,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2EV Machine Hulls",
+          "name:8": "nomifactory.quest.db.339.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18614,7 +18615,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An Extreme Voltage tier §bGregTech§r battery.\n\n§3§2Higher tier GT Batteries have been buffed to be quite strong - this one holds 25 MEU, or 100 MRF. You may want to consider using them over RF storage.",
+          "desc:8": "nomifactory.quest.db.340.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18628,7 +18629,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2EV Power Storage",
+          "name:8": "nomifactory.quest.db.340.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18669,7 +18670,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An Insane Voltage tier §bGregTech§r battery. §2Equivalent to 40 Vibrant Capacitor Banks!",
+          "desc:8": "nomifactory.quest.db.341.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18680,7 +18681,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2IV Power Storage",
+          "name:8": "nomifactory.quest.db.341.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18722,7 +18723,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A Ludicrous Voltage tier §bGregTech§r battery.",
+          "desc:8": "nomifactory.quest.db.342.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18733,7 +18734,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LuV Power Storage",
+          "name:8": "nomifactory.quest.db.342.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18811,7 +18812,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3The Empowerer§r is a machine from §bActually Additions§r used to convert its special crystalline materials into empowered variants.\n\nThe Empowerer is placed in the center of a flat 7x7 region. The four §aDisplay Stands§r are placed with a two-block gap from the Empowerer, one in each cardinal direction.\n\nRecipes require specific items to be placed on the Display Stands and the main item on the Empowerer itself. The items on the Display Stands are consumed and the central item is Empowered.\n\nRF power needs to be fed into the Display Stands to infuse the center item with power. The Display Stands have a low per-side power transfer rate so it takes a while. Consider putting energy conduits on multiple sides of each display stand to speed it up a bit.\n\nThis thing\u0027s a bit of a pain. It\u0027s slow, takes up a large space, and it\u0027s cumbersome to automate. Don\u0027t worry, you\u0027ll get access to the §3Crafting Core§r after you get §6Draconium§r, which is vastly faster, more compact, and easier to automate. Even better, that\u0027s pretty much immediately craftable into the §3Combination Package Crafter§r, which can do the Empowerer recipes directly through §bPackagedAuto§r and §bAE2§r.",
+          "desc:8": "nomifactory.quest.db.344.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18822,7 +18823,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowerer",
+          "name:8": "nomifactory.quest.db.344.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18869,7 +18870,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Wyvern Cores§r are the second tier of cores, used for intermediate crafting recipes.\n\nEach Wyvern Core is made via fusion crafting and the setup needs eight §6Basic Fusion Crafting Injectors§r.",
+          "desc:8": "nomifactory.quest.db.345.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18880,7 +18881,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Wyvern Core",
+          "name:8": "nomifactory.quest.db.345.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -18960,7 +18961,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Steel Heavy Plating§r can be augmented with §6Tungsten Plates§r and §6Tough Alloy§r to make §6Basic Reactor Plating§r.\n\nThat\u0027s right-- it\u0027s time to get into §bNuclearCraft§r.\n\nEnhancing basic plating with §6YBCO§r and §6Hard Carbon alloy§r results in a better plating material for more advanced §bNuclearCraft§r blocks.",
+          "desc:8": "nomifactory.quest.db.347.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -18971,7 +18972,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "NuclearCraft Platings",
+          "name:8": "nomifactory.quest.db.347.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19086,7 +19087,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The full complexity of §bNuclearCraft§r is far too much for the scope of this quest guide, so §eyou\u0027re encouraged to watch a tutorial or read a guide online§r. For the purposes of this particular quest, you\u0027ll be building a cheap breeder reactor to make §6Plutonium§r. This is a very basic reactor and can be changed to run faster and safer. Alternatively, reactors can be designed to produce a decent amount of power for the mid game of the pack.\n\nFirst, set up your 54 §6Reactor Casings§r to encase a 3x3 cube shape of empty air. The Casings should only cover the faces of the interior cube, not the edges or corners. You should have exactly the right number of Casings to encase a 3x3 space.\n\nNext, create a hole so you can get inside the cube. Place the §6Reactor Cells§r in all 8 corners. Then the §6Lapis Coolers§r will go between them: 4 on the top layer and 4 on the bottom layer. At this point, the top and bottom layers should have eight blocks each with an empty middle, and the middle layer is fully empty. In the middle layer, place the 4 §6Graphite Blocks§r on the corners, and the 4 §6Glowstone Coolers§r on the sides (so they touch both Lapis Coolers). Now the cube should be full, except for an empty column in the middle. The reactor will now be complete when you reseal it up with the Casings you removed to access the interior.\n\nFinally, place the §3Fission Reactor Controller§r along any edge or corner of the reactor. Opening the Reactor Controller GUI should let you know that the structure was properly formed; if not, go back and check what you did wrong.\n\nThe lever is placed on the reactor, as a redstone signal is required for it to start working. §cReactors can overheat and melt if the temperature exceeds its ability to cool.§r You can make a safety loop on the controller (instead of the lever) to automatically shut off the reactor when it starts getting hot using a §aRedstone Conduit§r, a §aRedstone Sensor Filter§r (on the input channel), and a §aRedstone NOT Filter§r (on the output channel). Make sure input and output are on the same channel color.",
+          "desc:8": "nomifactory.quest.db.350.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19097,7 +19098,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fission Reactor",
+          "name:8": "nomifactory.quest.db.350.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19174,7 +19175,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You don\u0027t need it just yet, but you can make it now.\n\nThis is a critical material for the Endgame.",
+          "desc:8": "nomifactory.quest.db.351.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19185,7 +19186,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Ultimate Material",
+          "name:8": "nomifactory.quest.db.351.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19227,7 +19228,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "If you don\u0027t want to mine Obsidian by hand, consider using a Fluid Solidifier to turn §cLava§r into §6Obsidian Blocks§r for you. The process is slow and energy intensive, though.\n\n§3Fluid Solidifiers§r are useful for lots of other things too, of course. Look through the various molds to see what you can make with one.",
+          "desc:8": "nomifactory.quest.db.352.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19238,7 +19239,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Fluid Solidifier",
+          "name:8": "nomifactory.quest.db.352.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19279,7 +19280,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aHang Glider§f is a great way to cross long distances, if you\u0027re so inclined.\n\nIf you don\u0027t want to go exploring for Cows, just buy a pair of \"§6Spawn Cow§f\" eggs and breed them. Seriously, spend your §dcoins§f!",
+          "desc:8": "nomifactory.quest.db.353.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19290,7 +19291,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Glider",
+          "name:8": "nomifactory.quest.db.353.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19331,7 +19332,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Enori Crystal§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.354.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19342,7 +19343,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Enori Gear",
+          "name:8": "nomifactory.quest.db.354.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19391,7 +19392,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A catalyst forged from §dOmnium§r, §6Empowered Gears§r, various enhanced §6Nether Stars§r, and a core made of §6The Ultimate Material§r.",
+          "desc:8": "nomifactory.quest.db.355.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19402,7 +19403,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Eternal Catalyst",
+          "name:8": "nomifactory.quest.db.355.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19445,7 +19446,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Are you ready to go infinite?\n\nReinforcing §6Heart of a Universe§r with §6Chaotic Cores§r, many §6Piles of Neutrons§r, and a bunch of §6Eternal Catalysts§r produces an §cInfinity Catalyst§r.\n\nThis material is the core of most creative-tier crafting recipes.",
+          "desc:8": "nomifactory.quest.db.356.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19456,7 +19457,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Catalyst",
+          "name:8": "nomifactory.quest.db.356.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19497,7 +19498,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This ingot is the most advanced basic material.\n\nWith all the automation you hopefully set up for your first §c§cInfinity Catalyst§r, these ingots should be easy.\n\nWell, not easy. But... Reasonable.\n\nFrom here, you are going to be crafting a multitude of Creative-Tier items from various mods. In addition to being useful for their regular functionality, they are needed for the final goal: the §dCreative Vending Upgrade§r.\n\n§bJEI§r is your friend: beyond noting a few more items, I will not be holding your hand anymore. I\u0027ve taught you everything you need to know to beat the pack.\n\nYou can do it!",
+          "desc:8": "nomifactory.quest.db.357.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19508,7 +19509,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Ingot",
+          "name:8": "nomifactory.quest.db.357.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19550,7 +19551,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A helmet to surpass the ultimate, forged with the hearts of stars and the raw fury of the universe.",
+          "desc:8": "nomifactory.quest.db.358.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19561,7 +19562,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Helmet",
+          "name:8": "nomifactory.quest.db.358.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19603,7 +19604,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A chestplate to surpass the ultimate, forged with the hearts of stars and the raw fury of the universe.",
+          "desc:8": "nomifactory.quest.db.359.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19614,7 +19615,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Chestplate",
+          "name:8": "nomifactory.quest.db.359.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19656,7 +19657,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Leggings to surpass the ultimate, forged with the hearts of stars and the raw fury of the universe.",
+          "desc:8": "nomifactory.quest.db.360.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19667,7 +19668,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Leggings",
+          "name:8": "nomifactory.quest.db.360.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19709,7 +19710,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Boots to surpass the ultimate, forged with the hearts of stars and the raw fury of the universe.",
+          "desc:8": "nomifactory.quest.db.361.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19720,7 +19721,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity Boots",
+          "name:8": "nomifactory.quest.db.361.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19761,7 +19762,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An ultimate helmet, forged from all manner of materials across dimensions and microverses.",
+          "desc:8": "nomifactory.quest.db.362.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19772,7 +19773,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Helmet",
+          "name:8": "nomifactory.quest.db.362.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19813,7 +19814,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An ultimate chestplate, forged from all manner of materials across dimensions and microverses.",
+          "desc:8": "nomifactory.quest.db.363.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19824,7 +19825,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Chestplate",
+          "name:8": "nomifactory.quest.db.363.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19865,7 +19866,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An ultimate pair of boots, forged from all manner of materials across dimensions and microverses.",
+          "desc:8": "nomifactory.quest.db.364.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19876,7 +19877,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Boots",
+          "name:8": "nomifactory.quest.db.364.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19917,7 +19918,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An ultimate pair of leggings, forged from all manner of materials across dimensions and microverses.",
+          "desc:8": "nomifactory.quest.db.365.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19928,7 +19929,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Leggings",
+          "name:8": "nomifactory.quest.db.365.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -19972,7 +19973,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You win.\n\nCongratulations.\n\nI hope you enjoyed playing §5Nomifactory§r.",
+          "desc:8": "nomifactory.quest.db.366.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -19983,7 +19984,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Creative Vending Upgrade",
+          "name:8": "nomifactory.quest.db.366.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20024,7 +20025,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§dStabilized Micro Miners§r are the end game way of generating infinite resources.\n\n\"Stabilization\" is a process of injecting §6Micro Miners§r with a §6Heart of a Universe§r, which makes them reusable at a reasonable cost.\n\nMuch like regular Micro Miners, the stabilized versions must be inserted into appropriate §3Microverse Projectors§r. However, running stabilized missions doesn\u0027t require any catalysts.\n\nStabilized missions don\u0027t bring loot, but rather §dPristine Microverse Matter§r that can be exchanged for loot using an §3Actualization Chamber§r.\n\nIt\u0027s a good idea to invest into multiple chambers to be able to round-robin Pristine Matter between them, since you can\u0027t take integrated circuits out.\n\nThe §6Stabilized Tier Eight Micro Miner§r might be the best investment, but the final decision is down to you.",
+          "desc:8": "nomifactory.quest.db.367.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20035,7 +20036,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Stabilized Micro Miners",
+          "name:8": "nomifactory.quest.db.367.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20076,7 +20077,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §aGrappling Hook§f is very useful in an urban environment.\n\nThere are lots of ways to upgrade and improve your Grappling Hook, so play around with it.\n\nOpen your inventory and look for the Baubles button, click it to reveal the additional bauble slots and put the Hook there.\n\nThe default key is §6C§r, however since quite a lot of mods occupy this hotkey you\u0027ll need to visit the controls menu to resolve the button conflicts.",
+          "desc:8": "nomifactory.quest.db.368.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20087,7 +20088,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Grappling Hook",
+          "name:8": "nomifactory.quest.db.368.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20165,7 +20166,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2For making Charcoal for smelting, and Creosote, which can be used as furnace fuel, boiler fuel, and for Treated Planks.\n\nUse up to 5 Coke Oven Hatches for automation.",
+          "desc:8": "nomifactory.quest.db.370.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20176,7 +20177,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Coke Oven",
+          "name:8": "nomifactory.quest.db.370.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -20235,7 +20236,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §aSoft Hammer§f can be used to temporarily stop a machine from functioning. This is useful when you have two machines running and both are unable to keep going because of a lack of power... let one finish then turn the other one back on with a second hit from the hammer.",
+          "desc:8": "nomifactory.quest.db.371.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20255,7 +20256,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Soft Hammer",
+          "name:8": "nomifactory.quest.db.371.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20750,7 +20751,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A component used for more advanced items related to §bExtended Crafting§r.",
+          "desc:8": "nomifactory.quest.db.384.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20761,7 +20762,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Elite Component",
+          "name:8": "nomifactory.quest.db.384.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20802,7 +20803,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Again, combining a few Components will make a Catalyst.",
+          "desc:8": "nomifactory.quest.db.385.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20813,7 +20814,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Elite Catalyst",
+          "name:8": "nomifactory.quest.db.385.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20855,7 +20856,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This table allows you to craft 7x7 Extended Crafting Table recipes.",
+          "desc:8": "nomifactory.quest.db.386.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20866,7 +20867,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Elite Extended Crafting Table",
+          "name:8": "nomifactory.quest.db.386.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20907,7 +20908,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Combine several components into a catalyst.",
+          "desc:8": "nomifactory.quest.db.387.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20918,7 +20919,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Catalyst",
+          "name:8": "nomifactory.quest.db.387.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -20960,7 +20961,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Used for Ultimate tier §bExtended Crafting§r.\n\nDon\u0027t worry if you can\u0027t make these for a while. You\u0027ll probably get to them around IV power.",
+          "desc:8": "nomifactory.quest.db.388.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -20971,7 +20972,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Component",
+          "name:8": "nomifactory.quest.db.388.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21014,7 +21015,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the largest Extended Crafting Table, capable of handling 9x9 recipes.",
+          "desc:8": "nomifactory.quest.db.389.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21025,7 +21026,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ultimate Extended Crafting Table",
+          "name:8": "nomifactory.quest.db.389.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21066,7 +21067,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Infuses things with Redstone Flux.\n\nThis is useful for charging RF-powered devices, but it also can also charge §6Rich Phyto-Gro§r into §6Fluxed Phyto-Gro§r, and charge §6Activated Certus Quartz Crystals§r into §6Charged Certus Quartz Crystals§r.",
+          "desc:8": "nomifactory.quest.db.390.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21091,7 +21092,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Energetic Infuser",
+          "name:8": "nomifactory.quest.db.390.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21150,7 +21151,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "ASSEMBLE... TOO!\n\nYeah you get to craft §6Nether Stars§r. Cool huh?\n\nOver the course of the pack, Nether Stars are going to be needed in quantities that far exceed a reasonable player\u0027s ability to farm Withers. §eCraft them, don\u0027t bother trying to farm them.§r\n\nOnce you gain access to §6Tier 4.5 Micro Miners§r, they will become your best§6 Nether Star§r source.",
+          "desc:8": "nomifactory.quest.db.391.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21161,7 +21162,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Craftable Nether Stars",
+          "name:8": "nomifactory.quest.db.391.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21232,7 +21233,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Congratulations! You\u0027ve reached the end of the circuit progression.\n\nThe only UHV circuit is the §6Wetware Mainframe§r, which is used for crafting high-tier micro miners among some endgame stuff.",
+          "desc:8": "nomifactory.quest.db.392.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21243,7 +21244,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "UHV Circuit...s?",
+          "name:8": "nomifactory.quest.db.392.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21266,7 +21267,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You might be wondering what chunkloading options there are in the pack.\n\nOpen your inventory and look at the top-left corner of the screen. Click the map-looking icon called §eClaimed Chunks§r.\n\n§6Click a chunk§r to claim it as yours. This will prevent unwanted creeper explosions and other players from interacting with your base.\n\n§6Shift-left click a claimed chunk§r to load it. This will ensure that the chunk is loaded at all times, even when you\u0027re not there. Alternatively, there are §achunk-loading wards§f from §bExtra Utilities§f.\n\n§eIf you\u0027re playing on a server with custom settings, ask the server owner what methods are available§f.\n\nTo invite players to your §bFTB Utils§f party, look for a corresponding button in the same corner. Parties share claimed chunks with each other. You can configure permissions for your party\u0027s claimed chunks in the party settings menu.",
+          "desc:8": "nomifactory.quest.db.393.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21277,7 +21278,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Claim Your Chunks and Invite Teammates!",
+          "name:8": "nomifactory.quest.db.393.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21305,7 +21306,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Basic §aFlux Capacitors§r hold a whopping lot of energy - §a1 million RF§r - and are useful for keeping your §aRF-powered§r equipment and tools charged.\n\nPut one into your newly crafted §3Battery Buffer§r to charge it. You can then put it in your inventory to charge your items with §aRF§r. \n§cRF batteries such as Flux Capacitors cannot be drained by Battery Buffers!§r\n\nFlux Capacitor is a §bBauble§r, open your inventory and look for the Baubles button, click it to reveal the additional bauble slots menu and put it into any slot you wish.\n\nFinally you can charge up all those depleted §6Dark Boots§r and §6The Ender§r swords you\u0027ve looted.",
+          "desc:8": "nomifactory.quest.db.394.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21319,7 +21320,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Flux Capacitors",
+          "name:8": "nomifactory.quest.db.394.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21370,7 +21371,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Very fluxy.\n\nA reagent used in the majority of §6Micro Miner§r missions.\n\nThere are several ways to produce §6Quantum Flux§r. All are viable, so figure out which one works best for you.",
+          "desc:8": "nomifactory.quest.db.395.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21381,7 +21382,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Quantum Flux",
+          "name:8": "nomifactory.quest.db.395.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -21459,7 +21460,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A single-block solution to all your power needs.\n\nThis baby pushes out 2.14 GRF/t per side.",
+          "desc:8": "nomifactory.quest.db.397.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21470,7 +21471,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Creative RF Source",
+          "name:8": "nomifactory.quest.db.397.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21512,7 +21513,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Multi Smelter§r is an absolute smelting unit, and is most likely the best furnace added by a mod.\n\nIt\u0027s a 3x3x3 multiblock machine capable of §esmelting huge amounts of items per second§r. By upgrading its coils and power tier, it can become capable of smelting up to literal thousands of items per second.\n\nHover over different coil blocks: the higher the §elevel§r, the more items a Multi Smelter can smelt per operation: §e32 items per level§r. The most basic Multi Smelter essentially does 32 items in the same time as a furnace does one. With a set of level 4 coil blocks, that jumps to 128 items per operation.\n\nThis quest doesn\u0027t ask for coils, hatches or buses: feel free to choose whatever combination you want. You\u0027ll need §a8 coil blocks§r, §a1 input bus§r, §a1 output bus§r and at least §a1 energy hatch§r of any tier.\n\n",
+          "desc:8": "nomifactory.quest.db.398.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21523,7 +21524,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Multi Smelter",
+          "name:8": "nomifactory.quest.db.398.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21570,7 +21571,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Large Plasma Turbines§r are a powerful late game method of generating power. One Large Plasma Turbine produces §2a base of 16384 EU/t when using an IV Rotor Holder§r.",
+          "desc:8": "nomifactory.quest.db.399.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21581,7 +21582,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Plasma Turbine",
+          "name:8": "nomifactory.quest.db.399.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -21634,7 +21635,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Space exploration isn\u0027t mandatory in this pack, so if you don\u0027t feel like exploring space with §bAdvanced Rocketry§r, then you can centrifuge §9Hydrogen§r for §eDeuterium§r instead.\n\nJust keep in mind that it\u0027s much less rewarding to skip this and you\u0027ll need lots of Hydrogen to compensate, although you won\u0027t need too much for the first §3Microverse Projector§r.\n\n§2In HV Age and more effectively in IV Age, you can get this from processing Ender Air.",
+          "desc:8": "nomifactory.quest.db.400.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21649,7 +21650,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2I Don\u0027t Like Space",
+          "name:8": "nomifactory.quest.db.400.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21687,7 +21688,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Anvils§f can be used to repair almost all §bGregTech tools§f!\n\nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§f spawn abundantly in §bLost Cities§f buildings, so go and snatch one!\n\nPut a damaged tool inside and put some material it\u0027s made of. For example, you\u0027ll need to put §6Wrought Iron Ingots§f to repair tools made of §6Wrought Iron§f. The only tools unable to be repaired are the mortar and the plunger.",
+          "desc:8": "nomifactory.quest.db.401.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21698,7 +21699,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Proper Tool Care",
+          "name:8": "nomifactory.quest.db.401.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21739,7 +21740,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bGregTech§r adds a very versatile way of augmenting machines with §aMachine Covers§r. Covers are \"upgrades\" that you can put on any GregTech machine, chest, or drum to expand its functionality. To work with covers, you\u0027ll need to make yourself a §aScrewdriver§r to configure covers, and a §aCrowbar§r to remove covers without having to break the machine.\n\nHere\u0027s a list of some covers there are in the game, and what they do:\n\n- §a§lConveyor§r: transfers items continuously to or from an adjacent inventory.\n\n- §a§lPump§r: is much like a §aConveyor§f, but for fluids.\n\n- §a§lRobotic Arm§r: is much like §aConveyor§r, but has two additional modes:\n    * §eKeep Exact§r: moves items to keep a stock of at most the specified number of items\n    * §eSupply Exact§r: transfers precisely the specified number of items per operation.\nThis cover is very useful for crafting automation.\n\n- §a§lFluid Regulator§r: is like a §aRobotic Arm§r, but works with fluids instead of items.\n\n- §a§lShutter§r: prevents automation from interacting with a specific side of a machine.\n\n- §2§lDetector§r: Available in Item, Fluid, Energy, Activity, and Advanced Activity flavours. Emits a Redstone signal depending on the status of whatever it\u0027s detecting.\n\n- §2§lDigital Interface§r: A graphical display for the machine\u0027s current status. Can display things like contained fluids, energy levels, etc.\n\nCovers that move items or fluids can have a §aFilter§r placed inside them. These modify the functionality of covers in ways explained in their own quests.\n",
+          "desc:8": "nomifactory.quest.db.402.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21750,7 +21751,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Machine Covers",
+          "name:8": "nomifactory.quest.db.402.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21807,7 +21808,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "All GregTech machines have one dedicated output side, which can be set by right-clicking a side with a §aGregTech Wrench§f. This is used for ejecting items into an adjacent inventory.\n\nTo enable auto-output, open the machine GUI and click one of the buttons in the bottom-left corner: §6orange§r is items and §9blue§r is fluids.\n\nIf you want to also be able to insert items into the output side, you\u0027ll have to right-click the output side with a §aGregTech Screwdriver§r.\n\nThis can be done by directly right clicking on the output side with a screwdriver, or §6shift right-clicking§r with a screwdriver from the machine grid.\n\nThese features can be used to chain machines together to make processing pipelines and facilitate crafting automation with §bApplied Energistics 2§f.",
+          "desc:8": "nomifactory.quest.db.403.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21823,7 +21824,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Screwdrive Output Sides!",
+          "name:8": "nomifactory.quest.db.403.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21852,7 +21853,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You can easily automate most §bGregTech§r machines with §aME Interfaces§r and processing §aPatterns§r early on by using the machines\u0027 auto-output feature.\n\nUse a §aGregTech Wrench§r to relocate the output side of a machine where you want it to be, right-click it with a §aGregTech Screwdriver§r to permit input on the output face, then put an ME Interface on that side of the machine.\n\nYou can also permit input from the output side by shift-right-clicking with a screwdriver on the output side via the machine grid.\n\nRight-click the machine and enable item auto-output (§6orange box§r in the bottom-left corner of the GUI).\n\nNow, stuff the ME Interface with processing patterns. The next time you order an item, the ME Interface will push ingredients into the machine, and the machine will push outputs back into the Interface once they\u0027re ready, completing the craft. No need to use conduits or import buses!",
+          "desc:8": "nomifactory.quest.db.404.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21863,7 +21864,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Simple GregTech Automation",
+          "name:8": "nomifactory.quest.db.404.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21891,7 +21892,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This modpack has §aCrafting Calculators§r. It has a steep learning curve, but once you manage to learn how to use it, it\u0027s going to be your trusty companion in calculating recipe costs.\n\nCraft yourself one and hit the book button in the top-left corner for a quick overview of how it works.\n\n§2The GTCEu Terminal also has an in-built equivalent to the Crafting Calculator, which you may use instead if you prefer.",
+          "desc:8": "nomifactory.quest.db.405.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21902,7 +21903,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crafting Calculator",
+          "name:8": "nomifactory.quest.db.405.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -21946,7 +21947,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have §6Osmium§r and §6Iridium§r from the §6Tier Four Micro Miner§r, you can begin automating §bExtended Crafting§r recipes. While it is possible to use §6Automation Interfaces§r for this task, you have access to something §nvastly§r better§r: §bPackagedExCrafting§r.\n\nTo begin, you\u0027ll need to craft one of each extended §3Package Crafter§r listed on the right. Put an §3Unpackager§r on top of each one, and then a §3Packager§r on top of each Unpackager. These are all AE2 devices, so you\u0027ll need to connect them to an ME Network.\n\nNext, right-click the §3Package Recipe Encoder§r, and you should see a button saying \"Processing\": this button cycles through recipe types, including the various Extended Crafting tables. You\u0027ll have to choose the appropriate table for the recipe you want to encode.\n\n§6Holders§r must be encoded in pairs: one for the Packager, and one for the Unpackager. Select the appropriate table for the recipe, look up the recipe you want to encode, and press §6[+]§r in §bJEI§r to fill it in. Put two Holders in the top-left slot and press Save to encode the recipe to both of them. Finally, put each Holder into the respective machines.\n\nIf you\u0027ve done everything correctly, you should see the item appear as craftable in a Terminal.\n\nWhile it might seem that the crafting process is slow, §ePackagedAuto is excellent at parallelizing§r. You can surround an Unpackager with Crafters and it will use all of them. It\u0027s also possible to add more Unpackagers with Crafters to keep up with the Packager, as long as the Holders are all the same.\n\n",
+          "desc:8": "nomifactory.quest.db.406.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21957,7 +21958,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Automating Extended Crafting",
+          "name:8": "nomifactory.quest.db.406.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22029,7 +22030,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Medium Microverse Projector§r is a more powerful projector required for sending §6Tier Four§r through §6Tier Six Micro Miners§r into microverses.\n\nInitial missions can operate on §eIV power§r, while §eLuV power§r is required for later missions. As with the prior projector, this structure supports overclocking and the position of buses and hatches can be swapped with any §6Microverse Projector Casing§r.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.407.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22040,7 +22041,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Medium Microverse Projector",
+          "name:8": "nomifactory.quest.db.407.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22119,7 +22120,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bPackagedAuto§r is an addon for §bApplied Energistics 2§r. Its main purpose in §5Nomifactory§r is to allow you to automate extended crafting recipes.\n\nApplied Energistics 2 stores recipes in §aPatterns§r, but they are limited to at most 9 stacks of items (a standard 3x3 crafting grid). PackagedAuto stores recipes in §aPackage Recipe Holders§r, which don\u0027t have this limitation. Additionally, each Holder can store up to §e20 different recipes§r. Holders must be encoded in the §3Package Recipe Encoder§r.\n\nIn the vast majority of situations you\u0027ll need two identically-encoded Holders, as the following machines work together.\n\nThe §3Packager§r is a machine that compresses ingredients for a specific recipe into a set of §6Recipe Packages§r. Each package in a set can hold up to 9 stacks of ingredient items. A simple recipe might consist of one package, but a complex recipe can have up to 9 packages in its set (for 81 total item stacks).\n\nThe §3Unpackager§r is a machine that extracts ingredient items from complete sets of Recipe Packages made in a Packager, ejecting the items into an adjacent inventory. It will only extract the items if §eall packages in a set are present§r.\n\nWhen both a Packager and Unpackager are connected to an ME Network and have the same recipe, the resulting item will appear as craftable in your §aTerminal§r.\n\nUp to 8 §3Packager Extensions§r can optionally be added to the Packager to speed up package creation. Place the Packager Extensions in a plane surrounding the Packager, creating a 3 by 3 structure with the Packager in the center when all 8 Packager Extensions are placed.",
+          "desc:8": "nomifactory.quest.db.408.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22130,7 +22131,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "PackagedAuto",
+          "name:8": "nomifactory.quest.db.408.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22189,7 +22190,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Unlike §aRF power§r, which is safe to transport in any §6conduit§r, §aEU power §r§erequires caution§r. The key is to always §amatch or exceed§r the §eVoltage §rand §eAmperage§r of your power source with your §6cables§r and machines.\n\n§o§4§cNEVER §rhook up your Energy Converter§r to a cable that has fewer §eAmps§r than your Energy Converter or Battery Buffer§r generates. For example, you must use §64x cable§r for a 4A Converter§r, and §616x cable§r for a filled 16-slot Battery Buffer§r. Cables with insufficient amperage rating will §cburn and be destroyed§r. §2Both the multiple-amp-source and multiple-face-input bugs from CE have been fixed - the Energy network now works as intended.§r\n\nSimilarly, your cable must match or exceed the §eVoltage§r of your machines, or they will §cburn and be destroyed§r.\n\n§cNEVER§r connect a machine to excessive §eVoltage§r or it will §cvaporize§r. Touching a §6wire§r with connected §aEU power§r will §cinjure or kill you§r, so for your safety, §euse §6cables§e instead§r!\n\n§2Superconductor-type wires do not damage you in CEu. The 0-loss cables in CE (Conductive Iron, Energetic Alloy, etc.) are considered Superconductors.",
+          "desc:8": "nomifactory.quest.db.409.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22200,7 +22201,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2A Primer on Power",
+          "name:8": "nomifactory.quest.db.409.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22266,7 +22267,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Large Microverse Projector§r is a more powerful projector required for sending §6Tier Seven§r through §6Tier Ten Micro Miners§r into microverses.\n\nTier Seven missions will operate on §eLuV power§r, but higher energy tiers will be required for later missions. As with the prior projector, this structure supports overclocking and the position of buses and hatches can be swapped with any §6Microverse Projector Casing§r.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.411.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22277,7 +22278,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Large Microverse Projector",
+          "name:8": "nomifactory.quest.db.411.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22356,7 +22357,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Lunar Mining Station§r is a large multiblock structure used for mining gases from the moon. It is an excellent (though not the only) source of §9Deuterium§r or §9Helium-3§r, depending on what kind of §6Rover§r you use. \n\nRovers only have a 10% chance to break while mining, so a stack of them will last quite a while.\n\nWhile both available recipes require §eMV power§r, you can overclock it with higher tiers of power. The positions of hatches and buses can be swapped with any §6LuV Machine Casing§r.\n\n§6Sneak-right click§r the controller to enable the in-world preview.\n\nBecause this structure must be placed on the Moon, it is a good idea to use mechanisms like §aEnder Tanks§r or a §6Quantum Link Chamber§r for teleporting the fluids back to your base.\n\nMake sure to keep it chunk-loaded!\n",
+          "desc:8": "nomifactory.quest.db.412.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22367,7 +22368,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Lunar Mining Station",
+          "name:8": "nomifactory.quest.db.412.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22457,7 +22458,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The functions of the Extractor and Fluid Extractor have been combined into a single machine!\n\n§3Extractors§r are useful for melting things into liquids. For example, you can melt down ingots into molten metals, or §6Rubber Sheets§r into liquid §9Rubber§r.\n\nWhen you have access to §6Steel§r, you can make molds and use §3Fluid Solidifiers§r to form various components more efficiently from fluids, like §6Gears§r.",
+          "desc:8": "nomifactory.quest.db.413.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22468,7 +22469,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Extractor",
+          "name:8": "nomifactory.quest.db.413.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22546,7 +22547,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have a §aFlux Capacitor§r to keep things charged, you might consider making yourself a §aFluxomagnet§r.\n\nThis relatively inexpensive bauble will suck nearby items into your inventory.",
+          "desc:8": "nomifactory.quest.db.415.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22560,7 +22561,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluxomagnet",
+          "name:8": "nomifactory.quest.db.415.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22605,7 +22606,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Fish Oil, surprisingly, comes from fish.",
+          "desc:8": "nomifactory.quest.db.416.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22616,7 +22617,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fish Oil",
+          "name:8": "nomifactory.quest.db.416.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -22668,7 +22669,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A much more efficient version of the §3Empowerer§r.\n\nThis is a digital upgrade to the §3Crafting Core§r, allowing you to craft Empowerer recipes directly through §bPackagedAuto§r.\n\nThe §aMarked Pedestals§r can be placed freely within three blocks distance of the Crafting block, as long as they are on the same Y-level.\n\nAs usual with PackagedAuto crafters, you need to encode the recipe in the correct mode and place a copy in two places: a §3Packager§r somewhere on your network, and an §3Unpackager§r adjacent to the §3Combination Package Crafter§r.\n\nThese recipes require large amounts of RF and it §ewill not use power from your §aME Network§r, so you must also connect the package crafter directly to energy conduits.",
+          "desc:8": "nomifactory.quest.db.417.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -22679,7 +22680,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Combination Package Crafter",
+          "name:8": "nomifactory.quest.db.417.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25316,7 +25317,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Useful to carry more stuff.\n\nWhat more explanation are you expecting?",
+          "desc:8": "nomifactory.quest.db.488.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25330,7 +25331,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Basic Satchel",
+          "name:8": "nomifactory.quest.db.488.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25374,7 +25375,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Most plates are made in the Bending Machine instead of here. (Technically this was the case in CE, but this modpack transferred its recipes to the Compressor.)\n\nHowever, this machine will still see use for compressing Nuggets into Ingots, Ingots into Blocks, and gem Dusts into Plates (such as Certus).",
+          "desc:8": "nomifactory.quest.db.489.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25385,7 +25386,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2LV Compressor",
+          "name:8": "nomifactory.quest.db.489.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25426,7 +25427,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An §3Autoclave§r is a machine that uses liquids (usually water) to polish stones, carve gems into lenses, infuse gems with special liquids, and crystallize various dusts.\n\nYou\u0027ll need an Autoclave for many recipes, but right now you want it to make §6Activated Certus Quartz Crystals§r for §bApplied Energistics§r out of the §bGregTech§r §6Certus Quartz§r and its dust you get from mining and ore processing.",
+          "desc:8": "nomifactory.quest.db.490.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25437,7 +25438,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Autoclave",
+          "name:8": "nomifactory.quest.db.490.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25478,7 +25479,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "No need for Lumberaxes anymore, §dGregTech Axes§r will cut down entire trees for you. They won\u0027t destroy your Storage Drawer networks, too.",
+          "desc:8": "nomifactory.quest.db.491.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25494,7 +25495,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Veinmining Trees?",
+          "name:8": "nomifactory.quest.db.491.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25540,7 +25541,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Is it expensive? Yes. Is it worth it? Hell yes.\n\nIt doesn\u0027t start to shine until you get the good upgrades for it though, so maybe hold off for a while.",
+          "desc:8": "nomifactory.quest.db.492.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25554,7 +25555,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Drill Baby Drill",
+          "name:8": "nomifactory.quest.db.492.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25635,7 +25636,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This terminal allows you to interact with fluid storage on your ME Network, like §aFluid Storage Disks§r.\n\nPut fluids in or remove fluids via this terminal with any GUI-compatible container, by clicking on a fluid to fill it, or an empty space to drain into the network.\n\nIt\u0027s a micropart, so you need to place it on §6ME Cable§r (not a conduit).",
+          "desc:8": "nomifactory.quest.db.494.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25646,7 +25647,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluid Terminal",
+          "name:8": "nomifactory.quest.db.494.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25687,7 +25688,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aStorage Drawer Controllers§r are the central hub of any good storage system. They can pull from any drawers they are connected to (via other drawers, or drawer trims) within a 12 block cubic radius. This leads to a potential 25x25x25 area to connect drawers, centered on the controller.\n\nThe appearance can be customized by crafting the controller into §aFramed Controller§r and putting it into a §aFraming Table§r.\n\n§aController Slaves§r do not extend the range, but rather act as another access point to that controller - allowing you to push/pull from any of the drawers within range of the local Drawer Controller.\n\nConnecting an §6ME Storage Bus§f to a controller exposes all of the drawers to §bApplied Energistics§f. Particularly large networks can be laggy though, so keep your drawer networks a manageable size.\n",
+          "desc:8": "nomifactory.quest.db.495.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25698,7 +25699,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Storage Drawer Controller",
+          "name:8": "nomifactory.quest.db.495.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25739,7 +25740,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bStorage Drawers§f provide a huge amount of storage for a single item type. Use them for things you have a lot of, such as stone, dirt and ores.\n\nIf the default appearances aren\u0027t your style, the §3Framing Table§f is useful for making custom drawers out of §6Framed Drawers§f and up to three additional items which define how the resulting drawer will look.\n\nIn addition, the §aHand Framing Tool§r has been implemented, allowing you to reframe your drawers in world, and convert default drawers into Framed Drawers§r in-world. See the §eJEI Information Page§r of the Hand Framing Tool§r for more information.",
+          "desc:8": "nomifactory.quest.db.496.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25750,7 +25751,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Drawers",
+          "name:8": "nomifactory.quest.db.496.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25797,7 +25798,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Great for automatically converting between Nuggets, Ingots, and Blocks of metals, or simply storing massive amounts of things.\n\nThe appearance can be customized by crafting the drawer into §aFramed Compacting Drawer§r and putting it into a §aFraming Table§r.",
+          "desc:8": "nomifactory.quest.db.497.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25808,7 +25809,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Compacting Drawers",
+          "name:8": "nomifactory.quest.db.497.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25849,7 +25850,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "When making circuits, you\u0027ll need either molten §9Tin§r, or molten §9Soldering Alloy§r§r§r. §2Soldering Alloy is made in the Mixer with 6 parts Tin Dust, 3 parts Lead Dust and 1 part Antimony Dust.§r You then process it in an §3Extractor §rfor the usual 144mB of fluid per unit.\n\nThe §2Circuit Assembler§r will only consume half as much Soldering Alloy as it would have consumed molten Tin per craft (72mB vs 144mB), so it\u0027s very efficient to use this stuff.\n\n§2Antimony can be directly smelted from Stibnite Ore, allowing you to skip ore processing for this.",
+          "desc:8": "nomifactory.quest.db.498.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25864,7 +25865,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Soldering Alloy",
+          "name:8": "nomifactory.quest.db.498.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -25959,7 +25960,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your new§2 Epoxy Circuit Boards§r, §6Nano CPUs§r, and some standard components, you can make the final type of Tier Three Circuit: the §6Nanocircuit§r.\n\nAs the best form of Tier Three circuit, these should be automated and stockpiled. As with the Final Tier Two circuits, the §6Advanced System-on-Chip§r variant recipes won\u0027t be available for a while.",
+          "desc:8": "nomifactory.quest.db.500.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25970,7 +25971,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Third And Final Tier Three Circuits",
+          "name:8": "nomifactory.quest.db.500.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26035,7 +26036,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A small appetizer, before the §dOmnium§r main course.\n\nAs the name suggests, this catalyst is formed from exotic non-elemental materials and alloys.",
+          "desc:8": "nomifactory.quest.db.501.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26046,7 +26047,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Exotic Materials Catalyst",
+          "name:8": "nomifactory.quest.db.501.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26088,7 +26089,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Capacitors§r are devices that store electrical energy, which is useful for circuits.\n\nNot to be confused with §bEnderIO§r\u0027s capacitors§r, which store redstone flux.",
+          "desc:8": "nomifactory.quest.db.502.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26099,7 +26100,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Capacitors",
+          "name:8": "nomifactory.quest.db.502.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26140,7 +26141,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.503.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26151,7 +26152,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dark Soularium Ingots",
+          "name:8": "nomifactory.quest.db.503.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26192,7 +26193,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts both LV and MV Brewery.\n\nYou can turn §6Plant Balls§r and other various §6sugary crops§r into §9Biomass§r with a §3Brewery§r. Biomass is the first step towards making Plastic in the form of §9Polyethylene§r.\n\nThe Brewery is a very very slow machine, but it requires almost no power. Building §2many Breweries§r is necessary to brew enough Biomass for plastics.",
+          "desc:8": "nomifactory.quest.db.504.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26203,7 +26204,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Brewery",
+          "name:8": "nomifactory.quest.db.504.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26245,7 +26246,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Ethanol§r is alcohol, which you can first produce from distilling §9Biomass§r.\n\nBoiling §6Sugar Cane§r in a §3Brewery§r is a great way to get Biomass, but you can also get it from other crops and saplings if you want.\n\nOnce you have a hefty starting stock of Ethanol, consider making and distilling §9Fermented Biomass§r in a §3Distillation Tower§r for extra chemicals.",
+          "desc:8": "nomifactory.quest.db.505.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26260,7 +26261,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ethanol",
+          "name:8": "nomifactory.quest.db.505.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26335,7 +26336,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need §9Chlorine§r at this point. It is an important ingredient in many chemical processes, and you can currently get it from electrolyzing either §6Salt§r or §6Rock Salt§r.\n\n§2Later, you can use Fluid Rigs or break down Ghast Tears to obtain Salt Water, and electrolyze it to Chlorine.",
+          "desc:8": "nomifactory.quest.db.507.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26350,7 +26351,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Chlorine",
+          "name:8": "nomifactory.quest.db.507.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26388,7 +26389,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.508.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26399,7 +26400,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Ruridit Ingots",
+          "name:8": "nomifactory.quest.db.508.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26440,7 +26441,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bEnderIO§r and §bThermal§r alloys are a bit more expensive than the normal wires, but they come with the huge advantage of being §e§2superconductors§r. Lossy cables like §6Tin§r and §6Copper§r will bleed out energy for every block they travel, but §2superconductors§r do not.\n\nThe §2cheap superconductors§r for each tier are:\n\nLV - Conductive Iron\nMV - Energetic Alloy\nHV - Vibrant Alloy\nEV - End Steel\nIV - Lumium \nLuV   - Signalum \nZPM - Enderium \nUV     - Draconium \nMAX - §2Draconic Superconductor§r, Omnium\n\n§2There are an additional set of superconductors, one for each tier, which are the CEu default superconductors. Their advantage is their higher amperage rating, reaching the hundreds of amps for higher tier 16x wires. They are also used in crafting Field Generators.§,§r\n\nMV and higher cables are made in an §3Assembling Machine§r. They\u0027re made with liquid §9Rubber§r and §6Wires§r, plus a reusable §6Programmed Circuit§r that tells it what thickness of wire to make.\n\nYou can use Wires, and for these materials they\u0027ll conduct just as well as if they were covered. §2Superconductor wires also won\u0027t kill you when touched now. In fact, you have to use Wires for Superconductors, because they don\u0027t even have cables!",
+          "desc:8": "nomifactory.quest.db.509.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26451,7 +26452,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Lossless Cables",
+          "name:8": "nomifactory.quest.db.509.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26492,7 +26493,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Mix together these two crushed gems along with §9Resonant Ender§r to make §9Dew of the Void§r, the fluid that will power §bEnderIO§r interdimensional teleportation.\n\nPlease note that Dew of the Void goes great with Doritos.",
+          "desc:8": "nomifactory.quest.db.510.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26507,7 +26508,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dew Of The Void",
+          "name:8": "nomifactory.quest.db.510.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26565,7 +26566,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bEnderIO§r\u0027s equivalent of a §3Chemical Reactor§r, roughly speaking.\n\nThe only way to make several important liquids from EnderIO.",
+          "desc:8": "nomifactory.quest.db.511.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26576,7 +26577,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Vat",
+          "name:8": "nomifactory.quest.db.511.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26619,7 +26620,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Slice\u0027N\u0027Splice§r is a machine from §bEnderIO§r.\n\nIt is used for making monster-head-related items that are components for various things.\n\nIt needs to be supplied with an Axe and Shears, which are slowly damaged over time as items are crafted.",
+          "desc:8": "nomifactory.quest.db.512.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26630,7 +26631,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Slice\u0027N\u0027Splice",
+          "name:8": "nomifactory.quest.db.512.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26671,7 +26672,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.513.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26682,7 +26683,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Red Steel Ingots",
+          "name:8": "nomifactory.quest.db.513.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26797,7 +26798,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Not as common a component, but used in a number of critical machines.\n\nAlso useful as a machine cover for continuously moving items.",
+          "desc:8": "nomifactory.quest.db.516.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26808,7 +26809,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Conveyor",
+          "name:8": "nomifactory.quest.db.516.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26850,7 +26851,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Robot Arms§r are components of several powerful machines, and are also useful as a machine cover for precise item movement.\n\nOne of the most expensive components, as it requires motors, pistons, and a circuit.",
+          "desc:8": "nomifactory.quest.db.517.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26861,7 +26862,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Robot Arm",
+          "name:8": "nomifactory.quest.db.517.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -26939,7 +26940,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Naquadah Reactor Mk1§r is a structure used to generate considerable amounts of EU power from decaying §6Enriched Naquadah§r or §6Naquadria§r into §6Lead§r.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.519.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26950,7 +26951,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Reactor Mk1",
+          "name:8": "nomifactory.quest.db.519.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27022,7 +27023,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Four §6Microprocessors§r combined with §6Titanium Plates§r and a few other standard components will make a §6MicroSupercomputer§r.",
+          "desc:8": "nomifactory.quest.db.520.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27037,7 +27038,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Second Tier Four Circuits",
+          "name:8": "nomifactory.quest.db.520.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27084,7 +27085,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Provides more augment slots to machines and dynamos.\n\nDynamos operate at §a1000% of base power and fuel burn rate§r.\n\nPortable Tanks hold §a1250 buckets§r.\n\nMachines operate at §a600% of base speed§r.",
+          "desc:8": "nomifactory.quest.db.521.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27095,7 +27096,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Resonant Upgrade Kit",
+          "name:8": "nomifactory.quest.db.521.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27137,7 +27138,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This compressor is needed for making §6Iridium Heavy Plating§r and §6Enderium Heavy Plating§r.",
+          "desc:8": "nomifactory.quest.db.522.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27148,7 +27149,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LuV Compressor",
+          "name:8": "nomifactory.quest.db.522.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27189,7 +27190,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Upgrading to the §6Nano Supercomputer§r requires some standard circuit components, but also some §6Lumium Wire§r and §2Fine Tungstensteel Wire.",
+          "desc:8": "nomifactory.quest.db.523.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27200,7 +27201,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Five Circuits",
+          "name:8": "nomifactory.quest.db.523.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27241,7 +27242,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The first and most expensive Tier Six Circuit, needed for crafting the §3IV Assembling Machine§r.\n\nRequires a bunch of standard circuit components.",
+          "desc:8": "nomifactory.quest.db.524.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27252,7 +27253,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Six Circuits",
+          "name:8": "nomifactory.quest.db.524.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27293,7 +27294,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Nothing you haven\u0027t seen here: just combine some standard circuit components and §6Nanocircuits§r to make a §6Nanoprocessor§r.",
+          "desc:8": "nomifactory.quest.db.525.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27304,7 +27305,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Four Circuits",
+          "name:8": "nomifactory.quest.db.525.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27347,7 +27348,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §6Titanium§r-based machine hulls and §6Mainframes§r squared away, you can finally get on the path to making an Extreme Voltage §3Circuit Assembling Machine§r.\n\nThis tier of Assembling Machine unlocks §6Nanocircuits§r, as well as handling crafting recipes up to 2048 EU/t. It can also optionally overclock recipes that consume up to 512 EU/t for improved speed at the cost of relatively more power.",
+          "desc:8": "nomifactory.quest.db.526.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27358,7 +27359,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2EV Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.526.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27399,7 +27400,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Glowing! §2But all the GTCEu machines glow already, so...§r\n\nThis one takes a significant amount of time to cook, so make sure to have it going constantly.\n\nWires made from §6Lumium§r transmit IV power losslessly, and it forms part of the basis for §6LuV Machine Hulls§r.",
+          "desc:8": "nomifactory.quest.db.527.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27410,7 +27411,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Lumium",
+          "name:8": "nomifactory.quest.db.527.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27451,7 +27452,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "What?!\n§6STEAM DYNAMO§r is evolving!\n\nUpgrade kits can be applied to Thermal Expansion Dynamos, machines, and even Portable Tanks. Machines and dynamos get additional augment slots.\n\nWhen applied to a dynamo, it increases the §apower generation and fuel burn rate to 150%§r.\n\nIncreases the base capacity of Portable Tanks to §a200 buckets§r.\n\nAllows machines operate at §a150% of base power per tick§r. The more power a machine can use, the faster it works.\n",
+          "desc:8": "nomifactory.quest.db.528.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27462,7 +27463,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Hardened Upgrade Kit",
+          "name:8": "nomifactory.quest.db.528.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27504,7 +27505,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §6Tungstensteel§r-based machine hulls and §6Nanoprocessor Mainframes§r squared away, you can finally get on the path to making an Insane Voltage §3Circuit Assembling Machine§r.\n\nThis tier of Assembling Machine unlocks §6Quantum Circuits§r, as well as handling crafting recipes up to 8192 EU/t. It can also optionally overclock recipes that consume up to 2048 EU/t for improved speed at the cost of relatively more power.",
+          "desc:8": "nomifactory.quest.db.529.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27515,7 +27516,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2IV Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.529.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27557,7 +27558,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With all of the components made, it\u0027s time to craft an §2Electronic Circuit§r.\n\nThis is where your §3Crafting Station§f setups will really shine! With the patterns encoded into a Crafting Stations (well, really over §omany§r Crafting Stations), you\u0027ll be able to §ebatch craft circuits quickly§f.\n\nYou\u0027ll be making a LOT§r of circuits, so take advantage of the improved crafting efficiency.",
+          "desc:8": "nomifactory.quest.db.530.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27568,7 +27569,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Your First Circuit",
+          "name:8": "nomifactory.quest.db.530.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27615,7 +27616,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now you can craft the §6Quantum Processor Mainframe§r, the first Tier Seven circuit.\n\nThese are required for crafting the Ludicrous Voltage (LuV) §3Assembling Machine§r.",
+          "desc:8": "nomifactory.quest.db.531.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27626,7 +27627,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Seven Circuits",
+          "name:8": "nomifactory.quest.db.531.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27667,7 +27668,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3HV Circuit Assembling Machine§r unlocks §2the Mainframe§r, as well as handling crafting recipes that consume up to 512 EU/t.\n\nIt can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
+          "desc:8": "nomifactory.quest.db.532.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27678,7 +27679,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2HV Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.532.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27720,7 +27721,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your §2Naquadah Alloy§r-based machine hulls and §6Crystal Processor Mainframes§r squared away, you can finally get on the path to making a ZPM §3Circuit Assembling Machine§r.\n\nThis tier of Assembling Machine unlocks §6Wetware Circuits§r, as well as handling crafting recipes up to 131072 EU/t. It can also optionally overclock recipes that consume up to 32768 EU/t for improved speed at the cost of relatively more power.",
+          "desc:8": "nomifactory.quest.db.533.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27731,7 +27732,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2ZPM Circuit Assembling Machine",
+          "name:8": "nomifactory.quest.db.533.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27773,7 +27774,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6Enderium§r, you can assemble a §6Crystal Supercomputer§r.",
+          "desc:8": "nomifactory.quest.db.534.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27784,7 +27785,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The Second Tier Seven Circuits",
+          "name:8": "nomifactory.quest.db.534.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27825,7 +27826,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Crystal Processor Mainframe§r is the first Tier Eight circuit.\n\nAlong with things you already know how to make, this needs §6HSS-E Frames§r.\n\nThese are required for crafting the §3ZPM Assembling Machine§r. As usual, these are extremely expensive: invest in the next theme of circuits instead of trying to mass-produce these.\n",
+          "desc:8": "nomifactory.quest.db.535.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27836,7 +27837,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2The First Tier Eight Circuits",
+          "name:8": "nomifactory.quest.db.535.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27877,7 +27878,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6ZPM Machine Hulls§r are made with §2Naquadah Alloy Plates,§r but you\u0027ll notice they also need §2Polybenzimidazole§r.\n\nZPM stands for Zero Point Module.\n\nThis is the last tier of machine that\u0027s sensible to produce before you reach the §dCreative Tank§r. Multiblock hatches are a different matter: feel free to upgrade your §3EBF§rs to Ultimate Voltage, if you can handle the power drain.\n",
+          "desc:8": "nomifactory.quest.db.536.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27888,7 +27889,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2ZPM Machine Hulls",
+          "name:8": "nomifactory.quest.db.536.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -27929,7 +27930,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Sterilized Growth Medium§r is needed for §6Wetware Circuits§r.\n\nYou\u0027ll need to mix §6Mincemeat§r, §2Calcium, Salt, Agar, and Mutagen§r with water in a mixer to make §9Raw Growth Medium§r, then use a §3Fluid Heater§r to sterilize it. §2This is a significantly more involved process than before.§r\n\nMincemeat comes from pulverizing any kind of animal meat. A §aPowered Spawner§r might be useful for this endeavor. §2Agar is produced from Mincemeat through multiple steps.",
+          "desc:8": "nomifactory.quest.db.537.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27944,7 +27945,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Sterilized Growth Medium",
+          "name:8": "nomifactory.quest.db.537.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28019,7 +28020,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Phosphorus§r can be obtained by processing §6Tricalcium Phosphate§r or §6Apatite§r with §6Sand§r and §6Coke§r in the §3Blast Furnace§r.",
+          "desc:8": "nomifactory.quest.db.539.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28030,7 +28031,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phosphorus",
+          "name:8": "nomifactory.quest.db.539.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28073,7 +28074,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Extruder§r is an alternative way to form shapes from metal. §aExtruder Shapes§r are used for telling an Extruder which shape to make.\n\nExtruders are §2no longer strictly needed for Large Pipes.§r Extruders use ingots, but are as efficient for making §6Gears§r as melting and solidifying. They are also the most efficient way to make §6Bolts§r, §6Small Gears§r, and §6Rings§r.\n\nYou can also use Extruders to make things from other machines like plates and wires, but they are less efficient than using the dedicated machines for these purposes.",
+          "desc:8": "nomifactory.quest.db.540.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28084,7 +28085,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2MV Extruder",
+          "name:8": "nomifactory.quest.db.540.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28125,7 +28126,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Overclocking aside, as you continue to progress in §5Nomifactory§f, materials made in the §3Electric Blast Furnace§f will take longer to complete. §eMore advanced coils do not give speed bonuses§f §2directly§r; they mainly allow for the furnace to §eget hot enough to process more advanced materials§f, §2and they also granting energy efficiency bonuses and speed bonuses to overclocking.§r\n\nConsequently, you\u0027ll need to continually expand your smelting and power generation infrastructure.\n\nYou don\u0027t have to get all four of these Electric Blast Furnaces completed and running just yet, but be prepared to make many of them over the course of the pack.\n\n§2As a reminder, all blocks and hatches can be shared across EBFs, except Maintenance!",
+          "desc:8": "nomifactory.quest.db.541.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28136,7 +28137,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2More Blast Furnaces",
+          "name:8": "nomifactory.quest.db.541.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28178,7 +28179,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Soul Binder§r is an §bEnderIO§r machine which uses §aSoul Vials§r and Experience to enhance specific items.\n\nIt may be prudent to store §9Liquid XP§r in an adjacent §3Obelisk§r, which the Soul Binder can draw from directly, or you can insert it using other standard means of fluid routing.",
+          "desc:8": "nomifactory.quest.db.542.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28189,7 +28190,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Soul Binder",
+          "name:8": "nomifactory.quest.db.542.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28230,7 +28231,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.543.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28241,7 +28242,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Blue Steel Ingots",
+          "name:8": "nomifactory.quest.db.543.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28283,7 +28284,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Carry even more stuff.",
+          "desc:8": "nomifactory.quest.db.544.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28297,7 +28298,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Hardened Satchel",
+          "name:8": "nomifactory.quest.db.544.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28354,7 +28355,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Carry §oeven more§r stuff.",
+          "desc:8": "nomifactory.quest.db.545.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28368,7 +28369,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reinforced Satchel",
+          "name:8": "nomifactory.quest.db.545.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28424,7 +28425,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts both LV and MV Distillery. §2If you are distilling Ethanol, you now need an MV Distillery.\n\n§rThe §3Distillery§r is a single-block machine which only outputs one distillate out of several and §cdiscards§r the rest. You can use this now to get §9Ethanol§r from §9Biomass§r, or to selectively distill §9Oil§r in multiple steps to §9Ethylene§r. Its advantage over the full Tower, apart from cost, is its §denergy efficiency§r.§r \n\nHowever, the Distillation Tower is mandatory for advanced chemistry, as most things have more than one important output: §9Fermented Biomass§r, §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r, and the entire line of petrochemicals from §9Oil§r, to name a few.\n\nCan\u0027t avoid it forever!\n\n",
+          "desc:8": "nomifactory.quest.db.546.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28435,7 +28436,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Distillery",
+          "name:8": "nomifactory.quest.db.546.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28476,7 +28477,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "",
+          "desc:8": "nomifactory.quest.db.547.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28491,7 +28492,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Scanner Module: Block",
+          "name:8": "nomifactory.quest.db.547.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28536,7 +28537,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aMolds§r are used in a §3Fluid Solidifier§r or §3Alloy Smelter§r to form materials into specific shapes. These are not consumed or damaged during crafting, so you can leave them in a machine to dedicate it to that shape.\n\nThe Fluid Solidifier tends to be the more efficient option: for example, you can use §e8 ingots§r to make one §6Gear§r in an Alloy Smelter, but with an Extractor and Solidifier you can accomplish the same result with §e4 ingots§r.\n\nBe careful not to accidentally make §aExtruder Shapes§r. Those are for a machine you will get access to later. The three molds in this quest are ones you will find useful right away.",
+          "desc:8": "nomifactory.quest.db.548.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28547,7 +28548,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Molds",
+          "name:8": "nomifactory.quest.db.548.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28607,7 +28608,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Fluid Rigs will harvest fluids from underground fluid veins. Note that the fluid veins are simply simulated and don\u0027t exist in the world. §r\n\nUse your §3Prospector\u0027s Scanner§r to see the type and amount of fluid underground and to check the depletion state of the vein. The first number represents the base amount of fluid extracted per second. \n\nIn the §eOverworld§r, it can harvest: §9Oil, Light Oil, Heavy Oil, Raw Oil, Natural Gas, Salt Water§r\n\nIn the §eNether§r: §eLava, Natural Gas§r\n\nOn the §eMoon§r: §9Deuterium, Helium-3§r\n\nThe first tier of Fluid Rig is good for §d100,000 operations§r. Higher tier Fluid Rigs harvest fluids far faster and deplete veins slower.",
+          "desc:8": "nomifactory.quest.db.549.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28622,7 +28623,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fluid Rig",
+          "name:8": "nomifactory.quest.db.549.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28677,7 +28678,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Place the §3Vertical Digger§r over an ore vein, feed it RF, and it will mine up the entire vein for you.\n\nFor drills, you will need a §6GregTech Drill§r (any LV drill will work), a §6Fluxbore§r (Reinforced tier is required) and an §6Actually Additions Drill§r (any color is fine, but take out any augments you wish to keep).\n\nThe GregTech Drill will not be consumed, but everything else will be.",
+          "desc:8": "nomifactory.quest.db.550.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28688,7 +28689,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vertical Digger",
+          "name:8": "nomifactory.quest.db.550.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28729,7 +28730,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "These are useful for extending the range of other \"Phantom\" machines and devices from §bActually Additions§r.",
+          "desc:8": "nomifactory.quest.db.551.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28740,7 +28741,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Phantom Booster",
+          "name:8": "nomifactory.quest.db.551.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28781,7 +28782,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Being able to fly is pretty sick. It\u0027s also pretty expensive.\n\nIt\u0027s probably a bit premature to consider a §6jetpack§r at this point, but if you really want to craft this bad boy, I won\u0027t stop you.\n\nThere\u0027s also a quest chain for §bEnderIO§r Jetpacks (starting with the §6Conductive Iron Jetpack§r). Eventually you\u0027ll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really really like flying.\n\nIf the §6Jetpack§r overview and information from §bThe One Probe§r conflict, they can be adjusted through the §bSimply Jetpacks 2§r §eConfiguration file§r or the command §6/topcfg§r respectively.",
+          "desc:8": "nomifactory.quest.db.552.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28796,7 +28797,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Leadstone Jetpack",
+          "name:8": "nomifactory.quest.db.552.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28843,7 +28844,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Better flying.",
+          "desc:8": "nomifactory.quest.db.553.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28858,7 +28859,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Hardened Jetpack",
+          "name:8": "nomifactory.quest.db.553.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28903,7 +28904,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Even better flying.\n\nYou\u0027re not getting up to Resonant for a long time, just FYI.",
+          "desc:8": "nomifactory.quest.db.554.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28918,7 +28919,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reinforced Jetpack",
+          "name:8": "nomifactory.quest.db.554.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -28963,7 +28964,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Rich Phyto-Gro§r can be further enhanced by infusing it with Redstone Flux in the §3Energetic Infuser§r.",
+          "desc:8": "nomifactory.quest.db.555.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28974,7 +28975,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluxed Phyto-Gro",
+          "name:8": "nomifactory.quest.db.555.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -29015,7 +29016,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The 4.5th Micro Miner.\n\nAll of the Tier Four missions require §68 Quantum Flux§r and a stack of §6Aerotheum Dust§r.\n\nThis miner will be your primary source of mob drops all the way until the end\n\nWhen equipped with a §6Sapling§r:\n§6* Creeper, Skeleton and Zombie skulls\n* Bone\n* Rotten Flesh\n* Gunpowder\n* Slime Block\n* Guardian Scale§r\n\nWhen equipped with a §6Block of Netherrack:\n* Wither Skeleton Skull and Bones\n* Blaze Rod\n* Ghast Tear\n* Magma Cream§r\n\nWhen equipped with a §6Block of Endstone:\n* Enderman Skull\n* Enderpearl Block\n* Shulker Shell§r\n\nWhen equipped with §6Ender Eyes:\n* Dragon Lair Data\n* Ender Dragon Head§r\n\nWhen equipped with §6Wither Bones§r:\n§6* Wither Realm Data\n* Nether Star Block\n",
+          "desc:8": "nomifactory.quest.db.556.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29026,7 +29027,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Tier 4.5 Micro Miner",
+          "name:8": "nomifactory.quest.db.556.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -29103,7 +29104,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is an augment that will work in all §3dynamos§f. It increases the efficiency of the fuel being used inside the dynamo, increasing the power it generates. However, the rate of power generation remains the same, the fuel simply lasts longer. So, while §6Fuel Catalyzers§f decrease the amount you\u0027ll need to go mining for §6Coal§f, they won\u0027t boost your production of RF per second.\n\nEach Fuel Catalyzer increases fuel efficiency by §a15%§f, additively (so two will make fuel last §a30% longer§f, three is §a45% longer§f, etc.).",
+          "desc:8": "nomifactory.quest.db.558.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29114,7 +29115,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fuel Catalyzers",
+          "name:8": "nomifactory.quest.db.558.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -29156,7 +29157,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aAuxiliary Transmission Coil §ris an augment that will work in all types of dynamos. It will consume fuel faster to produce a correspondingly higher RF per tick.\n\nEach augment increases both base power production and fuel consumption by 100%, additively (so the second is 200%, third is 300%, etc.).\n\nConsider the tradeoffs however, as you could just make another dynamo, and you miss out on §aFuel Catalyzer§r augments that make fuels burn longer for more total RF generated. The Auxiliary Transmission Coil will put additional stress your fuel production infrastructure.\n\nIf that\u0027s an acceptable tradeoff, then Auxiliary Transmission Coils are a cheap and effective way to boost your power production.",
+          "desc:8": "nomifactory.quest.db.559.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 2,
@@ -29167,7 +29168,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Auxiliary Transmission Coils",
+          "name:8": "nomifactory.quest.db.559.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -29356,7 +29357,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "How much do you think these solar panels weigh? \n\nThese are quite expensive and two of them are required for each Tier Ten Micro Miner.\n\n§6Neutronium Solar Panels§r generate an enormous amount of RF power in sunlight, so once you get your tank it\u0027s also a good choice for compact power generation.\n\nProtip: it\u0027s always daytime in space.",
+          "desc:8": "nomifactory.quest.db.564.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29367,7 +29368,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Neutronium Solar Panel",
+          "name:8": "nomifactory.quest.db.564.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -29963,7 +29964,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "As you continue to progress, crafting times for more advanced §3Electric Blast Furnace§r recipes will continue to increase. More advanced coils do not give speed bonuses, they just increase the operating temperature so you can smelt more advanced materials, §2and they also grant energy efficiency bonuses and speed bonuses to overclocking.§r\n\nTo compensate, you\u0027ll need to get your infrastructure for smelting, as well as for power generation, up to snuff.\n\nYou don\u0027t need to get all eight of these completed and running just yet, but plan to at some point in the future. Instead of upgrading existing EBFs, have them passively automating a stock of materials and build new EBFs with higher specifications for new materials.\n\n",
+          "desc:8": "nomifactory.quest.db.580.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -29974,7 +29975,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Blast Furnaces Galore",
+          "name:8": "nomifactory.quest.db.580.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30052,7 +30053,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.582.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30063,7 +30064,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluxed Electrum Ingots",
+          "name:8": "nomifactory.quest.db.582.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30104,7 +30105,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.583.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30115,7 +30116,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Signalum Ingots",
+          "name:8": "nomifactory.quest.db.583.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30156,7 +30157,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.584.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30167,7 +30168,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Enderium Ingots",
+          "name:8": "nomifactory.quest.db.584.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30208,7 +30209,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.585.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30219,7 +30220,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pulsating Iron Ingots",
+          "name:8": "nomifactory.quest.db.585.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30261,7 +30262,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.586.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30272,7 +30273,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "High Speed Steel Type E Ingot",
+          "name:8": "nomifactory.quest.db.586.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -30313,7 +30314,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.587.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30324,7 +30325,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "High Speed Steel Type G Ingots",
+          "name:8": "nomifactory.quest.db.587.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30366,7 +30367,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.588.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30377,7 +30378,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "High Speed Steel Type S Ingots",
+          "name:8": "nomifactory.quest.db.588.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -30418,7 +30419,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.589.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30429,7 +30430,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Crystal Matrix Ingots",
+          "name:8": "nomifactory.quest.db.589.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30507,7 +30508,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.591.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30518,7 +30519,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vanadium Steel Ingots",
+          "name:8": "nomifactory.quest.db.591.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30559,7 +30560,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.592.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30570,7 +30571,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Electrical Steel Ingots",
+          "name:8": "nomifactory.quest.db.592.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30611,7 +30612,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.593.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30622,7 +30623,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "End Steel Ingots",
+          "name:8": "nomifactory.quest.db.593.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30664,7 +30665,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.594.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30675,7 +30676,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Microversium Ingots",
+          "name:8": "nomifactory.quest.db.594.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -30716,7 +30717,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.595.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30727,7 +30728,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Mana Infused Ingots",
+          "name:8": "nomifactory.quest.db.595.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30768,7 +30769,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.596.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30779,7 +30780,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dark Steel Ingots",
+          "name:8": "nomifactory.quest.db.596.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30820,7 +30821,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.597.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30831,7 +30832,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vibrant Alloy Ingots",
+          "name:8": "nomifactory.quest.db.597.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30872,7 +30873,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.598.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30883,7 +30884,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Energetic Alloy Ingots",
+          "name:8": "nomifactory.quest.db.598.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30924,7 +30925,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.599.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30935,7 +30936,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Soularium Ingots",
+          "name:8": "nomifactory.quest.db.599.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -30977,7 +30978,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.600.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30988,7 +30989,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Manyullyn Ingots",
+          "name:8": "nomifactory.quest.db.600.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31029,7 +31030,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.601.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31040,7 +31041,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Magnalium Ingots",
+          "name:8": "nomifactory.quest.db.601.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31081,7 +31082,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.602.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 64,
@@ -31092,7 +31093,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Kanthal Ingots",
+          "name:8": "nomifactory.quest.db.602.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31133,7 +31134,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": " nomifactory.quest.db.603.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31144,7 +31145,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Nichrome Ingots",
+          "name:8": "nomifactory.quest.db.603.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31185,7 +31186,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "No hypothetical aliens were harmed in the harvesting of this item.\n\nProbably.",
+          "desc:8": "nomifactory.quest.db.604.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31196,7 +31197,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Heart Of A Universe",
+          "name:8": "nomifactory.quest.db.604.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31239,7 +31240,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You are become Death, destroyer of Universes.\n\nMight probably be obvious, but this miner gathers §6Heart of a Universe§r.",
+          "desc:8": "nomifactory.quest.db.605.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31250,7 +31251,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tier Ten Micro Miner",
+          "name:8": "nomifactory.quest.db.605.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31291,7 +31292,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Kind of redundant, really.\n\nThis plating is used exclusively for the Tier Ten Micro Miner. You need some serious protection from forces when harvesting a whole microverse.",
+          "desc:8": "nomifactory.quest.db.606.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31302,7 +31303,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Neutronium Heavy Plating",
+          "name:8": "nomifactory.quest.db.606.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31344,7 +31345,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Neutronium§r is a hyper-dense material normally found in the hearts of neutron stars: the collapsed cores of stars between ten and thirty times the size of the sun.\n\nFun fact: a single neutronium block is approximately 2884 million metric tons and somewhere around 600000K, yet you\u0027re somehow capable of holding one with your bare hands. Don\u0027t think about it too much.\n\nNeutronium is made from fusing molten §9Naquadria§r, a super-enriched form of §6Naquadah§r, with molten §9Americium§r. \n\nAfter getting §6Chaotic Fusion Injectors§r, you might consider using Tier Nine Micro Miners to supplement the fusion, as it is net-positive for Neutronium. These miners are expensive though, so it\u0027s up to you.\n",
+          "desc:8": "nomifactory.quest.db.607.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31355,7 +31356,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Neutronium Ingot",
+          "name:8": "nomifactory.quest.db.607.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -31396,7 +31397,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Coating §6Draconium Wire§r with §9Molten Nether Star§r and freezing it solid results in a superconductive material capable of transmitting enormous amounts of energy.\n\nThese wires losslessly transmit \"MAX\" tier, which is effectively infinite transfer rate. This means they will work for any tier of power. 1x wires handle 4 amps, meaning 4x wires can handle 16 amps.\n\nThese can also be made into RF conduits that can transmit a whopping 134 Million RF/t.",
+          "desc:8": "nomifactory.quest.db.608.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31407,7 +31408,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Superconductor Wire",
+          "name:8": "nomifactory.quest.db.608.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31449,7 +31450,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Provides more augment slots to machines and dynamos.\n\nDynamos operate at §a250% of base power and fuel burn rate§r.\n\nTanks hold §a450 buckets§r.\n\nMachines operate at §a250% of base speed.",
+          "desc:8": "nomifactory.quest.db.609.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31460,7 +31461,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Reinforced Upgrade Kit",
+          "name:8": "nomifactory.quest.db.609.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31501,7 +31502,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An alloy of §6Steel§r and §6Boron§r. Pretty simple.",
+          "desc:8": "nomifactory.quest.db.610.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31512,7 +31513,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Ferroboron",
+          "name:8": "nomifactory.quest.db.610.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31553,7 +31554,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Alloying some §6Lithium§r into your §6Ferroboron§r results in §6Tough Alloy§r, a common component in §bNuclearCraft§r blocks.",
+          "desc:8": "nomifactory.quest.db.611.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31564,7 +31565,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Tough Alloy",
+          "name:8": "nomifactory.quest.db.611.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31605,7 +31606,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The ZPM tier §3Compressor§r is needed for the most advanced heavy plating types: §6Draconium§r and §6Crystal Matrix§r.",
+          "desc:8": "nomifactory.quest.db.612.title",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31616,7 +31617,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ZPM Compressor",
+          "name:8": "nomifactory.quest.db.612.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31658,7 +31659,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.613.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31669,7 +31670,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 001: Hydrogen",
+          "name:8": "nomifactory.quest.db.613.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31710,7 +31711,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": " nomifactory.quest.db.614.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31721,7 +31722,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 002: Helium",
+          "name:8": "nomifactory.quest.db.614.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31762,7 +31763,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.615.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31773,7 +31774,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 003: Lithium",
+          "name:8": "nomifactory.quest.db.615.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31814,7 +31815,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.616.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31825,7 +31826,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 004: Beryllium",
+          "name:8": "nomifactory.quest.db.616.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31866,7 +31867,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.617.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31877,7 +31878,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 005: Boron",
+          "name:8": "nomifactory.quest.db.617.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31918,7 +31919,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.618.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31929,7 +31930,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 006: Carbon",
+          "name:8": "nomifactory.quest.db.618.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -31971,7 +31972,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.619.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31982,7 +31983,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 007: Nitrogen",
+          "name:8": "nomifactory.quest.db.619.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32024,7 +32025,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.620.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32035,7 +32036,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 008: Oxygen",
+          "name:8": "nomifactory.quest.db.620.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32076,7 +32077,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.621.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32087,7 +32088,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 009: Fluorine",
+          "name:8": "nomifactory.quest.db.621.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32128,7 +32129,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.622.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32139,7 +32140,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 010: Neon",
+          "name:8": "nomifactory.quest.db.622.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32180,7 +32181,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.623.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32191,7 +32192,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 011: Sodium",
+          "name:8": "nomifactory.quest.db.623.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32232,7 +32233,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.624.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32243,7 +32244,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 012: Magnesium",
+          "name:8": "nomifactory.quest.db.624.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32284,7 +32285,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.625.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32295,7 +32296,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 013: Aluminium",
+          "name:8": "nomifactory.quest.db.625.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32336,7 +32337,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.626.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32347,7 +32348,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 014: Silicon",
+          "name:8": "nomifactory.quest.db.626.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32388,7 +32389,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.627.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32399,7 +32400,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 015: Phosphorus",
+          "name:8": "nomifactory.quest.db.627.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32440,7 +32441,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.628.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32451,7 +32452,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 016: Sulfur",
+          "name:8": "nomifactory.quest.db.628.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32492,7 +32493,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.629.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32503,7 +32504,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 017: Chlorine",
+          "name:8": "nomifactory.quest.db.629.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32544,7 +32545,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.630.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32555,7 +32556,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 018: Argon",
+          "name:8": "nomifactory.quest.db.630.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32596,7 +32597,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.631.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32607,7 +32608,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 019: Potassium",
+          "name:8": "nomifactory.quest.db.631.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32648,7 +32649,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.632.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32659,7 +32660,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 020: Calcium",
+          "name:8": "nomifactory.quest.db.632.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32700,7 +32701,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.633.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32711,7 +32712,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 057: Lanthanum",
+          "name:8": "nomifactory.quest.db.633.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32752,7 +32753,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.634.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32763,7 +32764,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 022: Titanium",
+          "name:8": "nomifactory.quest.db.634.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32804,7 +32805,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.635.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32815,7 +32816,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 023: Vanadium",
+          "name:8": "nomifactory.quest.db.635.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32856,7 +32857,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.636.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32867,7 +32868,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 024: Chromium",
+          "name:8": "nomifactory.quest.db.636.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32908,7 +32909,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.637.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32919,7 +32920,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 025: Manganese",
+          "name:8": "nomifactory.quest.db.637.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -32960,7 +32961,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.638.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -32971,7 +32972,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 026: Iron",
+          "name:8": "nomifactory.quest.db.638.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33012,7 +33013,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.639.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33023,7 +33024,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 027: Cobalt",
+          "name:8": "nomifactory.quest.db.639.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33064,7 +33065,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.640.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33075,7 +33076,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 028: Nickel",
+          "name:8": "nomifactory.quest.db.640.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33116,7 +33117,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.641.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33127,7 +33128,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 029: Copper",
+          "name:8": "nomifactory.quest.db.641.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33168,7 +33169,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.642.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33179,7 +33180,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 030: Zinc",
+          "name:8": "nomifactory.quest.db.642.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33220,7 +33221,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.643.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33231,7 +33232,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 031: Gallium",
+          "name:8": "nomifactory.quest.db.643.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33272,7 +33273,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.644.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33283,7 +33284,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 033: Arsenic",
+          "name:8": "nomifactory.quest.db.644.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33324,7 +33325,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.645.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33335,7 +33336,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 036: Krypton",
+          "name:8": "nomifactory.quest.db.645.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33376,7 +33377,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.646.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33387,7 +33388,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 039: Yttrium",
+          "name:8": "nomifactory.quest.db.646.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33428,7 +33429,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.647.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33439,7 +33440,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 046: Palladium",
+          "name:8": "nomifactory.quest.db.647.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33480,7 +33481,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.648.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33491,7 +33492,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 047: Silver",
+          "name:8": "nomifactory.quest.db.648.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33532,7 +33533,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": " nomifactory.quest.db.649.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 64,
@@ -33543,7 +33544,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 049: Indium",
+          "name:8": "nomifactory.quest.db.649.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33584,7 +33585,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.650.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33595,7 +33596,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 050: Tin",
+          "name:8": "nomifactory.quest.db.650.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33637,7 +33638,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.651.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33648,7 +33649,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 051: Antimony",
+          "name:8": "nomifactory.quest.db.651.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -33689,7 +33690,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.652.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33700,7 +33701,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 054: Xenon",
+          "name:8": "nomifactory.quest.db.652.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33741,7 +33742,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.653.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33752,7 +33753,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 074: Tungsten",
+          "name:8": "nomifactory.quest.db.653.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33793,7 +33794,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.654.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33804,7 +33805,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 076: Osmium",
+          "name:8": "nomifactory.quest.db.654.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33845,7 +33846,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.655.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33856,7 +33857,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 077: Iridium",
+          "name:8": "nomifactory.quest.db.655.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33897,7 +33898,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.656.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33908,7 +33909,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 078: Platinum",
+          "name:8": "nomifactory.quest.db.656.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -33949,7 +33950,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.657.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33960,7 +33961,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 079: Gold",
+          "name:8": "nomifactory.quest.db.657.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34001,7 +34002,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.658.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34012,7 +34013,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 080: Mercury",
+          "name:8": "nomifactory.quest.db.658.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34053,7 +34054,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.659.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34064,7 +34065,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 086: Radon",
+          "name:8": "nomifactory.quest.db.659.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34105,7 +34106,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.660.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34116,7 +34117,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 090: Thorium",
+          "name:8": "nomifactory.quest.db.660.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34157,7 +34158,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.661.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34168,7 +34169,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 092: Uranium",
+          "name:8": "nomifactory.quest.db.661.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34209,7 +34210,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.662.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34220,7 +34221,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 093: Neptunium",
+          "name:8": "nomifactory.quest.db.662.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34261,7 +34262,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.663.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34272,7 +34273,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 094: Plutonium",
+          "name:8": "nomifactory.quest.db.663.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34313,7 +34314,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.664.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34324,7 +34325,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Element 095: Americium",
+          "name:8": "nomifactory.quest.db.664.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34365,7 +34366,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.665.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34376,7 +34377,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 096: Curium",
+          "name:8": "nomifactory.quest.db.665.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34417,7 +34418,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.666.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34428,7 +34429,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 097: Berkelium",
+          "name:8": "nomifactory.quest.db.666.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34469,7 +34470,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.667.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34480,7 +34481,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 098: Californium",
+          "name:8": "nomifactory.quest.db.667.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34522,7 +34523,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": " ",
+          "desc:8": "nomifactory.quest.db.668.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34533,7 +34534,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Element 099: Einsteinium",
+          "name:8": "nomifactory.quest.db.668.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -34574,7 +34575,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "When you have enough materials, you can craft Uranium isotope clumps into Low-Enriched Uranium 235 Fuel (or §6LEU-235§r, for short). This fuel uses an 8:1 ratio of U238 to U235.\n\nThis fuel is processed in your §3Fission Reactor§r by placing it in the controller. When a redstone signal is applied it will burn the fuel, generating some power from the reactor and after a while you\u0027ll get a §6Depleted LEU-235 Fuel§r§r.\n\nThe depleted fuel is separated in a regular §3Centrifuge§r, resulting in many tiny clumps of fissile materials: Uranium 238, §6Neptunium 237§r, §6§6Plutonium 239§r, and §6Plutonium 241§r.",
+          "desc:8": "nomifactory.quest.db.669.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34585,7 +34586,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Uranium Fission",
+          "name:8": "nomifactory.quest.db.669.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34632,7 +34633,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Steam Machines can run recipes listed as up to §d32 EU/t§r. They need to have their vent side unobstructed. Use a Wrench to change the venting side.\n\n- §3Forge Hammer§r: Allows you to make §62 plates§r from §63 ingots§r.\n\n- §3Macerator§r: Allows you to grind §6Clay§r into §6Clay Dust§r.\n\n- §3Compressor§r: Allows you to make §6Compressed Fireclay§r and §6Rubber Sheets§r.\n\n- §3Alloy Smelter§r: Allows you to make §6Bronze§r more efficiently, as well as other useful alloys like §6Invar§r. Also allows you to cast §6Glass§r, and make components like §eGears§r more easily with Molds.\n\nYou can upgrade them to HP version with Steel, which doubles their speed.",
+          "desc:8": "nomifactory.quest.db.670.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34643,7 +34644,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Steam Machines",
+          "name:8": "nomifactory.quest.db.670.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -34701,7 +34702,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Thorium is another basic fissile material that can be used to get into the fissile chain. Thorium comes from §6Pitchblende Ore§r, §6Thorium Ore§r, and even §2Black Granite§r (with a few processing steps).\n\nThorium-Bred Uranium, or §6TBU§r for short, is made from nine clumps of §6Thorium 232§r enriched in a §3Thermal Centrifuge§r.\n\nThe depleted fuel provides tiny clumps of §6Uranium 233§r, §6Uranium 235§r, §6§6Neptunium 236§r, and §6Neptunium 237§r.",
+          "desc:8": "nomifactory.quest.db.671.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34712,7 +34713,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Thorium Fission",
+          "name:8": "nomifactory.quest.db.671.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34765,7 +34766,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Climbing the ladder of fissile materials will require some specific raw materials and machinery.\n\n§2Uraninite is the base resource you will need, which comes from Uraninite and Pitchblende Ore. You will need to react it with Fluorine and Hydrofluoric Acid in a Chemical Reactor to form Uranium Hexafluoride.\n\nThe Uranium Hexafluoride must then be separated into Depleted and Enriched Uranium Hexafluoride in a Centrifuge. The Depleted UF₆ will grant Uranium-238, while the Enriched UF₆ will grant Uranium-235.\n\n",
+          "desc:8": "nomifactory.quest.db.672.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34776,7 +34777,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Nuclear Fuel Infrastructure",
+          "name:8": "nomifactory.quest.db.672.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34823,7 +34824,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Low-Enriched Neptunium 236, or §6LEN-236§r, is the next step in the fissile material fuel chain.\n\nThis fuel requires an 8:1 ratio of §6Neptunium 237§r to §6Neptunium 236§r. Using only the results from Thorium fission, it will take two batches of §6Depleted TBU Fuel§r to make your first LEN fuel.\n\nOf course, higher order reactions also will result in small amounts of Neptunium that you can work with as well.\n\n§6Depleted LEN 236§r gives a small bit of Neptunium 237 back, but principally provides §6Plutonium§r and §6Americium§r isotopes.\n",
+          "desc:8": "nomifactory.quest.db.673.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34834,7 +34835,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Neptunium Fission",
+          "name:8": "nomifactory.quest.db.673.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34893,7 +34894,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Uranium 233§r is obtained exclusively from the fission of §6TBU Fuels§r.\n\n§6LEU-233§r is made from one §6U233§r and eight §6U238§r.\n\n§6Depleted LEU-233§r will give you various §6Plutonium§r isotopes and some §6Americium§r.",
+          "desc:8": "nomifactory.quest.db.674.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34904,7 +34905,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LEU-233",
+          "name:8": "nomifactory.quest.db.674.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34952,7 +34953,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Low-Enriched Plutonium 239, or §6LEP-239§r, is made from the usual 8:1 ratio of two isotopes of §6Plutonium§r acquired from earlier depleted fuels.\n\n§6Depleted LEP-239§r will give you some §6Curium§r for further enrichment.\n\nHigh-Enriched Plutonium fuels will give better results, but §cgenerate a lot more heat§r. Make sure your reactor cooling is up to the task.",
+          "desc:8": "nomifactory.quest.db.675.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34963,7 +34964,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Plutonium Fission",
+          "name:8": "nomifactory.quest.db.675.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -35023,7 +35024,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Low-Enriched Curium 243, or §6LECm-243§r, is made from §6Curium-243§r and §6Curium-246§r.\n\n§6Depleted LECm-243 Fuel§r gives mostly Curium-246 back, but also small quantities of §6Berkelium§r and §6Californium§r isotopes.\n\n§6HECm-247§r is a better alternative for strictly Californium, if your reactor can withstand the heat.",
+          "desc:8": "nomifactory.quest.db.676.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35034,7 +35035,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Curium Fission",
+          "name:8": "nomifactory.quest.db.676.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -35093,7 +35094,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Americium 242§r and §6Americium 243§r are used to make §6LEA-242 Fuel§r.\n\nThere\u0027s also §6Americium 241§r, but this is only useful for making RTGs (which produce small amounts of RF continuously) or decaying down into §6Neptunium§r.\n\n§6Depleted LEA 242 Fuels§r§r will return large amounts of §6Curium 246§r and small amounts of other isotopes.",
+          "desc:8": "nomifactory.quest.db.677.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35104,7 +35105,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Americium Fission",
+          "name:8": "nomifactory.quest.db.677.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35163,7 +35164,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Depleted LEB-248 Fuel§r results in several different isotopes of §6§6Californium§r.",
+          "desc:8": "nomifactory.quest.db.678.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35174,7 +35175,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Berkelium Fission",
+          "name:8": "nomifactory.quest.db.678.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35233,7 +35234,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Californium§r is the final fissile material in the NuclearCraft processing chain.\n\n§6Depleted LECf-249 Fuel§r results in... different isotopes of Californium.\n\nUnless you want §6Californium RTGs§r or are experimenting with further fission routes, this step is probably unnecessary for general materials processing.",
+          "desc:8": "nomifactory.quest.db.679.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35244,7 +35245,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Californium Fission",
+          "name:8": "nomifactory.quest.db.679.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35304,7 +35305,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have all the basic building blocks of nuclear fission, you\u0027ll need to start creating breeding chains to mass produced stabilized versions of each element, for the synthesis of §dOmnium§r.\n\nExperiment around with larger breeder reactors that can handle highly enriched fuels.\n\nYou\u0027ll probably want to build multiple reactors to make all the fissile elements in any reasonable amount of time.",
+          "desc:8": "nomifactory.quest.db.680.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35315,7 +35316,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Further Adventures In Fission",
+          "name:8": "nomifactory.quest.db.680.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35344,7 +35345,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aImplosion Compressor§f is like an autoclave that uses explosions instead of water. It is the only way to turn most gem dusts into gemstones.\n\nIt will also be vital for processing §5Motes of Omnium§f.\n\nIn addition to the controller and casings, you will need one §eLV or better§r §6Item Input Bus§r, §6Item Output Bus§r, and §6Energy Input Hatch§r.\n\n§2If desired, you may upgrade this directly to an Electric Implosion Compressor, which can accept Parallel Control hatches.",
+          "desc:8": "nomifactory.quest.db.681.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35355,7 +35356,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Implosion Compressor",
+          "name:8": "nomifactory.quest.db.681.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35396,7 +35397,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §2CEu§r§r version of Nomi is already slightly harder than the original, due to various progression changes CEu makes.\n\nBut if you want a §charder§r, or perhaps a more \"§5true§r\" §dGregTech§r experience, check out the §cExpert§r mode. This pack mode is based on the §bSelf-Torture Edition fork§r of the original pack.\n\nHighlights include:\n\n- No §bDML§r for easy infinite resources\n- §6Omnicoins§r can\u0027t be spent\n- The §7Steam Age§r\n- No §3Creative Tank§r; instead...\n- §6Stabilized Micro Miners§r for late-game infinite resources\n- Harder recipes for assorted things like §6Iridium§r, §3Numismatic Dynamos§r, and more\n\nTo enable §cExpert§r mode, change the pack mode (Options -\u003e Pack Mode) to Expert, then run §e/bq_admin default load ExpertQuests§r. The same command should be used for updating the quest book on Expert mode.\nTo go back, change the pack mode to §aNormal§r and run §e/bq_admin default load§r.\n\nTo tune your challenge even further, check out the various recipe configs in the GregTech config file.",
+          "desc:8": "nomifactory.quest.db.682.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35407,7 +35408,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Hard Mode",
+          "name:8": "nomifactory.quest.db.682.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -35434,7 +35435,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Provide your §3Simulation Chamber§r with RF power and §6Pulsating Polymer Clay§r. Then insert a §6Data Model§r of your choice. The Simulation Chamber will consume Polymer Clay and a decent amount of power to begin simulating mob kills. This will generate §6Overworldian Matter§r and may occasionally provide you with §6Pristine Matter§r.\n\n§6Overworldian Matter§r can be eaten to gain experience, or can be combined with other materials to obtain drops from Overworld mobs. With these drops, you can then create Data Models for other mob types as well.",
+          "desc:8": "nomifactory.quest.db.683.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35445,7 +35446,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Overworldian Matter",
+          "name:8": "nomifactory.quest.db.683.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35486,7 +35487,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6String§r and §6Coal Dust§r can be baked together into a §6Carbon Mesh§r in an §3Alloy Furnace§r.\n\nCombine that with §6Pulsating Dust§r to get a §6Pulsating Mesh§r.\n\n",
+          "desc:8": "nomifactory.quest.db.684.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35497,7 +35498,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pulsating Mesh",
+          "name:8": "nomifactory.quest.db.684.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35556,7 +35557,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Loot Fabricator",
+          "name:8": "nomifactory.quest.db.191.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35692,7 +35693,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Feeding §3Steam producers§r with water by hand is a pretty silly idea.\n\nA §2Primitive Water Pump§r will take care of that for you.",
+          "desc:8": "nomifactory.quest.db.687.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35703,7 +35704,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Infinite Water",
+          "name:8": "nomifactory.quest.db.687.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -35878,7 +35879,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Graphene§r is the cable material required for §6IV Motors§r, and it\u0027s not trivial to make anymore.\n\nPresently, you can make it by reducing §6Graphene Oxide§r with §9Argon§r and §9Hydrazine§r. §9Hydrazine§r is produced in multiple steps using §9Ammonia§r and §9Hydrogen Peroxide§r with §9Acetone§r as a recycled reagent.\n\nLater, you can use a §6Magnetron§r to make it from §6Graphite§r directly. Note that the other recipe requires no §6Graphite§r.",
+          "desc:8": "nomifactory.quest.db.690.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -35889,7 +35890,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Graphene",
+          "name:8": "nomifactory.quest.db.690.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -35998,7 +35999,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Confused about all the Wrenches yet?\n\nThe §aCrescent Hammer§r is for use on machines from §bThermal Expansion§f, but can be used for basic wrench interactions with blocks from almost every mod.\n\nThe §aYeta Wrench§r is used with machines and conduits from §bEnderIO§f, and has several special display modes (§6sneak-mouse wheel§f to switch between them).\n\nThe §aGregTech Wrench§r is used to rotate GregTech machines and redefine their output sides. §2It also has some of the capabilities of the other Wrenches now.§r\n\nYou can see which mod a machine is from with the §9blue text§f at the bottom of its tooltip.",
+          "desc:8": "nomifactory.quest.db.692.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36009,7 +36010,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Wrenches Galore",
+          "name:8": "nomifactory.quest.db.692.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -36068,7 +36069,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Give me a little juice, FRIDAY!",
+          "desc:8": "nomifactory.quest.db.693.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36083,7 +36084,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinity War",
+          "name:8": "nomifactory.quest.db.693.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -36129,7 +36130,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "I\u0027m running out of MCU puns.\n\nThe §aAngel Ring§r is actually slower than a jetpack, but it grants creative flight and requires no fuel (except a bit of GP).\n\nUp to you if you want to use it over a jetpack for day to day stuff, but it\u0027s an ingredient in the next jetpack, so if you want that you\u0027ll need to make one eventually.",
+          "desc:8": "nomifactory.quest.db.694.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36140,7 +36141,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Captain... Marvel? IDK",
+          "name:8": "nomifactory.quest.db.694.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -36182,7 +36183,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the flight of our lives.",
+          "desc:8": "nomifactory.quest.db.695.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36197,7 +36198,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Endgame",
+          "name:8": "nomifactory.quest.db.695.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -36242,7 +36243,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Naquadah Reactor Mk2§r is an upgraded reactor that can generate immense amounts of EU energy from the same types of fuels as the Mk1. The materials it requires are similar to the Mk1, and you can almost reuse the same structure. Make sure you are prepared for the UV power output by adding a §6UV Energy Output Hatch§r.\n\nThis is a pretty expensive structure though, as it needs blocks of §dOmnium§r. Maybe wait until after you get the §dCreative Tank§r?\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "nomifactory.quest.db.696.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36253,7 +36254,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Reactor Mk2",
+          "name:8": "nomifactory.quest.db.696.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37416,7 +37417,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "When you first started the pack, we told you that ore doubling can wait, and that\u0027s true... But you will need to start doing some rudimentary ore processing for §ebyproducts§r.\n\nByproducts are additional materials that can only be obtained from processing ores in certain machines. For example, there is no \"Gallium Ore\" or \"Arsenic Ore\". You get §6Gallium§r and §6Arsenic §ras a byproduct from processing other ores.\n\nOres have various means of processing, and eventually you\u0027ll use machine pipelines to process ores in specific ways to optimize what byproducts you gain. You can look at the §b§b§6Ore Byproduct Page§6§r of an ore in §bJEI§r, accessed by pressing \u0027U\u0027 on an ore and navigating to the byproduct tab, to see the required route to obtain desired byproducts. \n\nThe relevant machines are as follows:\n \n- §3Macerator§r: turns ores into §6Crushed Ores§r, Crushed Ores into §6Impure Dusts§r, and §6Purified Crushed Ores§r into §6Pure Dusts§r. Higher tiers of macerators have byproduct slots and gain a chance to get a full pile of byproduct from ores and both types of crushed ores.\n\n- §3Ore Washer§r: cleans Crushed Ores with §9Water§r, making Purified Crushed Ores§r, and a guaranteed 3 tiny piles of byproduct. Using §9Distilled Water§r makes them go faster. §2You can also perform a simple wash with this similar to Cauldron washing, which is extremely fast, but grants no byproducts.§r\n\n- §3Chemical Bath§r: §2uses Sodium Persulfate or Mercury to purify certain ores, granting a chance to yield a full pile of a byproduct.\n\n§r- §3§3Centrifuge§r: separates Pure or Impure dusts into the final material, producing a guaranteed §21 (nerfed from 3) tiny pile of byproduct§r.\n\n- §3Electrolyzer§r: uses power to split compounds into individual elements, sometimes gaining useful byproducts in the process. §2Be warned that certain dusts may be better to directly smelt instead of electrolyze!§r\n\n- §3Thermal Centrifuge§r: not to be confused with the regular Centrifuge. §2Less slow and power-hungry now, but still so. However, it yields 3 additional tiny piles of byproduct, and macerating the Centrifuged Ore can grant a special third byproduct.\n\n§2- Sifter: filters high-quality Gems from Purified Crushed gem Ores for an overall higher yield.\n\n- Electromagnetic Separator: filters magnetic metals from certain ores, increasing their yields.§r\n\nYour first forays into ore processing for byproducts will be the Electrolyzer and the Centrifuge.\n",
+          "desc:8": "nomifactory.quest.db.727.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37427,7 +37428,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Ore Processing for Byproducts",
+          "name:8": "nomifactory.quest.db.727.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37455,7 +37456,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Uraninite Ore§r is the first source of §6Pulsating Dust§r but is not a very good one in the long term. Instead you should make §6Resonant Clathrates§r, which are an infinitely-renewable and effective source of Pulsating Dust.\n\nResonant Clathrates are made by melting §6Ender Pearls§r with a §3Fluid Extractor§r into §9Resonant Ender§r, then mixing that with §6Nether Quartz§r in an MV or better §3Chemical Reactor§r. Smelting this clathrate gives Pulsating Dust.\n\nWith Resonant Clathrates now accessible, everything you need for crafting §6Pulsating Polymer Clay§r can be automated in a net-positive loop.§r Doing so is a boon to automation of §bDeep Mob Learning§r, which is §ea primary source of important materials for the rest of the pack§r.\n\nThe exact implementation is up to you. Make use of the various LV and MV machines you have, and look through §bJEI§r for the automatable infinite sources of each ingredient (like §aEnderman Models§r for pearls).\n\n",
+          "desc:8": "nomifactory.quest.db.728.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37466,7 +37467,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Resonant Clathrate",
+          "name:8": "nomifactory.quest.db.728.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37507,7 +37508,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is the fluid counterpart to the standard §aME Interface§r.\n\nFluids inserted into it are automatically digitized into the network, though it does have internal storage that can back up if you run out of space.\n\nYou can configure the interface to stock up to six different fluids (or for faster throughput later on, several tanks of the same fluid). You can use §aPump covers§r on §bGregTech§r machines to pull fluids from or extract fluids into an interface. This is useful for routing fluids if you\u0027re already using the output side for items or a different fluid.\n\nIt is also far more performant and scales better without lag than §aFluid Import/Export Buses§r.",
+          "desc:8": "nomifactory.quest.db.729.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37518,7 +37519,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fluid Interface",
+          "name:8": "nomifactory.quest.db.729.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37559,7 +37560,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Working with fluids is a bit tricky. AE2 §aPatterns§r have no notion of fluids, meaning that you have to §ededicate separate machines to specific fluid combinations§r, ensuring they remain stocked.\n\nAE2 has a §aFluid Import Bus§r and §aFluid Export Bus§r, and this is the usual go-to for players experienced with AE2. A §aCapacity Card§r will let you export or import five specific chemicals through a single bus, which is enough for, say, §3Chemical Reactors§r. However, §cexcessive use of AE2 buses will cause lag§r.\n\nA better approach for §bGregTech§r machines is using a stocked §aFluid Interface§r and a §aPump§r or a §aFluid Regulator§r. This works almost identically to passive autocrafting with Robot Arms, and §aFluid Filters§r can allow routing specific fluids to adjacent machines. This method is much more performant, scaling without causing lag like buses. For machines from other mods, you can route fluids from a Fluid Interface with conduits.\n\n",
+          "desc:8": "nomifactory.quest.db.730.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37570,7 +37571,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Fluids and Autocrafting",
+          "name:8": "nomifactory.quest.db.730.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37598,7 +37599,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your §3Chemical Reactors§r will be making a lot of different fluids. You\u0027ll need to manage the logistics of routing and storing all the different fluids you\u0027re automating.\n\nWherever possible, having one Chemical Reactor output directly into another machine that needs its output chemical saves you from having to figure out additional storage and routing. §aFluid Filters§r and §aPump covers§r are very useful for moving fluids around a compact processing pipeline.\n\nBut what about the final output fluids that you need elsewhere?\n\nOne option is to use the output tanks of the Chemical Reactors as a small storage buffer, letting it back up and stop crafting automatically. A §aFluid Storage Bus§r on the machine will expose the fluid to your ME Network. Whenever you need some of this fluid, your AE2 system will pull the needed fluid out and the machine will resume processing.\n\nThere\u0027s some catches with this approach though. First is that the inaccessible input tanks will also show up in AE but you won\u0027t be able to access them. You will want to set the Storage Bus to §eExport Only§r so AE doesn\u0027t try to store random fluids in the Chemical Reactor, and you may want to §ereduce the priority§r of the Storage Bus as well: this will signal to AE that you want it to remove fluids from that location first. Also, if multiple fluids are produced, §ethe machine will not resume processing if it doesn\u0027t have room for all fluid outputs§r.\n\nWhen you get access to them, it\u0027s probably just better to use single-fluid-formatted §aFluid Storage Cells§r and dump outputs into AE via Fluid Interfaces. You can fill up the cells, then pull the fluids out wherever else you need them.\n\n",
+          "desc:8": "nomifactory.quest.db.731.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37609,7 +37610,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Fluid Logistics",
+          "name:8": "nomifactory.quest.db.731.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37637,7 +37638,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Hard Carbon Alloy§r is an alloy made from §2Steel§r and §6Diamonds§r.",
+          "desc:8": "nomifactory.quest.db.732.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37648,7 +37649,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Hard Carbon Alloy",
+          "name:8": "nomifactory.quest.db.732.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -37689,7 +37690,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aDraconic Evolution Information Tablet§r contains useful information about the mod as well as diagrams for valid Fusion Crafting block placement.\n\nYou might also be interested in the §oDraconic Evolution Fusion Core Automation§r guide linked to in §9#omnicompendium§r in the official §5Nomifactory§r Discord server.",
+          "desc:8": "nomifactory.quest.db.733.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -37700,7 +37701,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Draconic Evolution Information Tablet",
+          "name:8": "nomifactory.quest.db.733.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38074,7 +38075,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§eUSE JEI!!!§r\n\n§bJEI§r stands for §bJust Enough Items§r. It\u0027s the list of all items that you see every time you open your inventory. It\u0027s the better(tm) recipe book that shows you all available items and recipes in the modpack.\n\nTo see it in action, pull up a quest that requires an item of some sort and just click the item!\n\nIf you want to know how to craft an item, just hover your mouse over it and press §6R§r. JEI will list all available recipes.\n\nIf you instead want to know what recipes use an item, hover over it and press §6U§r.\n\nHover over an item and press §6A§r to bookmark it. To remove a bookmarked item from the list, press A on the bookmark.\n\nOne of the remarkable features of JEI is that it\u0027s also capable of helping you with recipes. Right-click a crafting table, look up the recipe you need and press the §a[+]§r button: if you have all required items for the recipe, this will put them all into the crafting table for you.",
+          "desc:8": "nomifactory.quest.db.743.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38085,7 +38086,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Use JEI! Use JEI! USE. JEI.",
+          "name:8": "nomifactory.quest.db.743.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38113,7 +38114,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "That\u0027s a lot of foil. §2These use Platinum Foil instead of Electrum now.§r\n\nThese boards are required for §6Crystal Circuits§r, as well as the future basis of §6Wetware Lifesupport Circuit Boards§r. These will get you from tier five to tier eight.",
+          "desc:8": "nomifactory.quest.db.744.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38124,7 +38125,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Multi-Layer Fiber-Reinforced Epoxy Substrate",
+          "name:8": "nomifactory.quest.db.744.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38177,7 +38178,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Not glowing.\n\nThis one takes a significant amount of time to cook, so make sure to have it going constantly.\n\n§6Signalum§r is noteworthy as the long-awaited next tier upgrade for your §bThermal Expansion§r machines and dynamos following \"Reinforced\" back in MV.",
+          "desc:8": "nomifactory.quest.db.745.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38188,7 +38189,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Signalum",
+          "name:8": "nomifactory.quest.db.745.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38229,7 +38230,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A very power-efficient, if slow before upgrades, means of creating plates. Also the only way to directly make plates from single gems.\n\nUpgrading the machine tier with §aUpgrade Kits§r and applying §aAugments§r to boost its crafting speed is a good idea.",
+          "desc:8": "nomifactory.quest.db.746.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38254,7 +38255,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Compactor",
+          "name:8": "nomifactory.quest.db.746.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38310,7 +38311,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Vanilla enchanting mechanics are just so tedious. Don\u0027t you wish you could just make a specific enchant instead of grinding levels and rolling the dice?\n\n§eOh wait- you can!§r\n\nThe §3Dark Steel Enchanter§r is a device that uses §6Book and Quill§r, experience levels, lapis, and enchant-specific items to create an §6Enchanted Book§r with an enchantment of your choosing. Then you can just use an Anvil to enchant your item like usual.\n\nThis is a good time to bring up the §dHolding§r enchant, which can be applied to most items from §bThermal Foundation§r and its related mods. Holding can be crafted up to level IV, which massively boosts the storage capacity of items like §aSatchels§r, §aFlux Capacitors§r, and §aPortable Tanks§r.\n\nYou can also make the §dMending§r enchant which allows you to infinitely repair the item when damaged using §9Liquid XP§r in an §bEnderIO §aFluid Tank§r or §aPressurized Fluid Tank§r.\n\n",
+          "desc:8": "nomifactory.quest.db.747.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38321,7 +38322,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dark Steel Enchanter",
+          "name:8": "nomifactory.quest.db.747.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38362,7 +38363,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §3Compactor§r§r§r specialized to a §aGear Press§r is a very power efficient way to make gears. It is slower than its overclocking GTCE counterparts, but is required for some gears, most notably the crystal and gemstone ones.\n\nLike all §aAugments§r, the Gear Press specialization takes up an upgrade slot, but you can still use the rest of the slots for other ones like speed upgrades.",
+          "desc:8": "nomifactory.quest.db.748.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38373,7 +38374,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Gearworking Die",
+          "name:8": "nomifactory.quest.db.748.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38416,7 +38417,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Upgrade time! \n...or building a new one, which is probably better.\n\nYet again this quest asks for the minimal number of casings. Make an extra 28 if you don\u0027t want more than §a2 Fluid Inputs§r§r and §a1 Fluid Output§r.\n\nIf you insist on upgrading instead of making a new one, don\u0027t dismantle the current one before you\u0027re sure you\u0027ve got everything you need to upgrade it, or you might end up having to rebuild the §3Mark 1 Fusion Reactor§r again.\n\nThe §3Mark 2 Fusion Reactor§r has an energy buffer of §e320M EU§r.",
+          "desc:8": "nomifactory.quest.db.749.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38427,7 +38428,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fusion Reactor MK2",
+          "name:8": "nomifactory.quest.db.749.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38492,7 +38493,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A complex material from §bThermal Expansion§r cooked in an §3Electric Blast Furnace§r.\n\n§6Enderium§r doesn\u0027t require much power (running on as little as MV) but it does need a lot of heat and is incredibly slow without overclocking. §2You can use small amounts of Krypton from Liquid Ender Air distillation to significantly decrease the smelting time.§r\n\nAs with all later blast furnace materials, dedicate a furnace to keeping these in stock and have it running constantly to ensure a stable supply (turning it off when you have an acceptably vast stockpile).\n\nIn addition to its other uses, Enderium gets you access to §aResonant Upgrade Kits§r for machines and the §6Resonant Satchel§r. These quests can be found on the §eProgression§r tab.\n\n",
+          "desc:8": "nomifactory.quest.db.750.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38503,7 +38504,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Enderium Ingot",
+          "name:8": "nomifactory.quest.db.750.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38544,7 +38545,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Aqueous Accumulators§r in §5Nomifactory§r are infinite water sources; they §l§ndo not§r require any water blocks nearby.\n\nThis machine can produce §9Water§r as fast as you can extract it (the only downside being that it makes some annoying noises).\n\nFriendship with §aEndervoirs§r ended.",
+          "desc:8": "nomifactory.quest.db.751.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38568,7 +38569,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Infinitest Water",
+          "name:8": "nomifactory.quest.db.751.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38622,7 +38623,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Universal Crystallizer§r can make §6Crystal Matrix Ingots§r at about a ninth of the §6Diamond§r cost, makes §6Wyvern§r and §6Awakened Cores§r and §6Awakened Draconium§r far faster than §3Fusion Crafting§r, and crafts §6Empowered Blocks§r without hassle.\n\nThis is the final machine you will make, and the most costly. You will need §d12 Hearts of a Universe§r and §d80 Chaos Shards§r, among others.\n\nIt requires a small amount of Enriched Naquadah to run, and an immense amount of power - but with §6Creative RF Source§r, it shouldn\u0027t be a problem.",
+          "desc:8": "nomifactory.quest.db.752.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38633,7 +38634,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Universal Crystallizer",
+          "name:8": "nomifactory.quest.db.752.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -38716,7 +38717,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Carry the most stuff.\n\nIf you need more space than this, enchant it with §aHolding IV§r.",
+          "desc:8": "nomifactory.quest.db.753.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38730,7 +38731,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Resonant Satchel",
+          "name:8": "nomifactory.quest.db.753.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38787,7 +38788,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Before you travel to the Moon, you\u0027ll want to set up a way to easily return.\n\nLay out nine of the §6Telepad Blocks§r in a 3x3 pattern. They should turn into a multiblock. While having some §6Paper§r in your inventory, use the §aCoordinate Selector§r to create a §6Location Printout§r of an area near the Telepad. Keep track of this Printout and make sure to bring it with you to the Moon!\n\nMake sure the Telepad on the Overworld is ready to go. It needs power, a tank of §9Dew of the Void§r, and the chunk it\u0027s in needs to be §eChunkloaded§r. Bring the other nine Telepad Blocks with you when you go to the Moon, and once there, set up a similar layout. The one on the Moon will also need power, Dew of the Void and its chunk loaded. Consider making a solar panel and a capacitor bank to keep it powered.\n\nOnce your Moon Telepad is up and running, put your Overworld coordinates into it. Then record your current location on the Moon with the Coordinate Selector. Teleport home, and put those coordinates into the Overworld Telepad. Now you can travel back and forth easily!\n\nYou might consider building a room dedicated to Telepad transit, both on the Overworld and to other Planets, and label them. You\u0027ll be visiting many other worlds soon enough.",
+          "desc:8": "nomifactory.quest.db.754.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38798,7 +38799,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Telepad",
+          "name:8": "nomifactory.quest.db.754.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38851,7 +38852,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bBuilding Gadgets§r.\n\nThese devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn\u0027t make them from nothing.\n\nAlso important to note that it won\u0027t work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines).\n\nBy default, the config GUI is bound to §6G§r.",
+          "desc:8": "nomifactory.quest.db.755.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38868,7 +38869,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Inspector Gadget",
+          "name:8": "nomifactory.quest.db.755.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -38947,7 +38948,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Taranium§r is an exotic material found in tiny quantities from... §6Stone Dust§r.\n\nProcess Stone Dust through a long chain (and enjoy the byproducts), and eventually, you\u0027ll reach the §6Taranium Dust§r. It\u0027s used in several powerful endgame tools, such as §6UV Field Generator§r and §3Advanced Ore Drilling Plant II§r. ",
+          "desc:8": "nomifactory.quest.db.756.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -38958,7 +38959,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Taranium",
+          "name:8": "nomifactory.quest.db.756.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -38998,7 +38999,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You may have noticed that The End portals in Strongholds are disabled.\n\nThe only way to access The End is to... §ebake a cake§r. You can refill it with §6Eyes of Ender§r.\n\nPrepare some gear, eat a slice, and get ready for a fight!",
+          "desc:8": "nomifactory.quest.db.757.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39009,7 +39010,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The End...?",
+          "name:8": "nomifactory.quest.db.757.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39050,7 +39051,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Find a clever way to make the Ender Dragon\u0027s Egg to fall onto a torch. This neat trick will turn it into a collectible item so you can bring it home with you.\n\nYou might be interested in getting yourself a §3Dragon Egg Mill§r to place it on for free 500 GP.",
+          "desc:8": "nomifactory.quest.db.758.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39061,7 +39062,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Egg Thief",
+          "name:8": "nomifactory.quest.db.758.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39108,7 +39109,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Fire Water§r is a great way of producing §6Grains of Infinity§r. Spill a bucket over a patch of bare bedrock and watch it drop grains every so often. There\u0027s a 2% chance per random tick for one to be generated on each block of bedrock the Fire Water is flowing on.\n\nMake sure to chunkload the area.",
+          "desc:8": "nomifactory.quest.db.759.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39123,7 +39124,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Fire Water",
+          "name:8": "nomifactory.quest.db.759.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39180,7 +39181,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you\u0027ve dealt with the dragon, seek the bedrock structure floating mid-air around the edge of the main island.\n\nCarefully throw an §6Ender Pearl§r inside one (where there\u0027s a portal-looking texture) to teleport to a distant island.\n\nOnce there, gather some §6Chorus Flowers§r. You\u0027ll have to smash the flower itself to get it: simply breaking the stem of a plant will not drop the flower.\n\nAnd finally, obtain some §6Draconium Dust§r. Its ore spawns in small quantities, but should be everywhere.\n\nTo get back to the main island, throw an Ender Pearl into another bedrock portal structure.\n\n",
+          "desc:8": "nomifactory.quest.db.760.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39191,7 +39192,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "The Outer Islands",
+          "name:8": "nomifactory.quest.db.760.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39238,7 +39239,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Dislocator Pedestals§f are a very simple way of inter-dimensional transport.\n\nHold a §6Dislocator§f in your hand and §6sneak-right click§f to bind it to your position. Now, place it inside a Pedestal so you can travel to the bound spot anytime you want.\n\nBefore going to the Moon, you\u0027ll need §etwo Dislocators§f and §etwo Pedestals§f.\n\nBind one Dislocator to a location in the Overworld, then take it with you to the Moon and put it down on a Pedestal.\n\nBind the other Dislocator to a location on the Moon, then use the first Pedestal to return home. Place the second Dislocator on the second Pedestal, then you can warp between the two locations at will. Neat!\n\n§aTip: Dislocators don\u0027t lose durability on use when placed in a Pedestal!",
+          "desc:8": "nomifactory.quest.db.761.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39249,7 +39250,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Thinking with Dislocators",
+          "name:8": "nomifactory.quest.db.761.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39297,7 +39298,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have §einterdimensional teleportation§r, you can travel to and from the Moon without launching a rocket each way.",
+          "desc:8": "nomifactory.quest.db.762.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39308,7 +39309,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Interdimensional Transport",
+          "name:8": "nomifactory.quest.db.762.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39337,7 +39338,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A good, but slightly gated way of teleporting back to your telepads.\n\nIt won\u0027t be possible to make this until you reach EV tier power.",
+          "desc:8": "nomifactory.quest.db.763.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39348,7 +39349,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Rod of Return",
+          "name:8": "nomifactory.quest.db.763.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39391,7 +39392,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are LV, and can all be substituted in recipes.\n\n§7§2Electronic Circuits§r are the worst in terms of cost and effort required to produce, but you have to start with something.\n\n§2§2Integrated Circuits§r are the middle layer between §2Electronic Circuits and Microprocessors.§r\n\nAnd finally, §2Microprocessors§r, which take the lowest effort.",
+          "desc:8": "nomifactory.quest.db.764.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39402,7 +39403,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Circuits",
+          "name:8": "nomifactory.quest.db.764.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39425,7 +39426,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Progression tab was added so you can keep track of the important bits of the pack.\n\nCircuits are the baseline of the entire Nomifactory progression, so keep climbing!",
+          "desc:8": "nomifactory.quest.db.765.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39436,7 +39437,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "What is This?",
+          "name:8": "nomifactory.quest.db.765.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39467,7 +39468,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are MV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.",
+          "desc:8": "nomifactory.quest.db.766.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39478,7 +39479,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "MV Circuits",
+          "name:8": "nomifactory.quest.db.766.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39504,7 +39505,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are HV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.",
+          "desc:8": "nomifactory.quest.db.767.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39515,7 +39516,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "HV Circuits",
+          "name:8": "nomifactory.quest.db.767.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39541,7 +39542,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are EV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.",
+          "desc:8": "nomifactory.quest.db.768.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39552,7 +39553,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "EV Circuits",
+          "name:8": "nomifactory.quest.db.768.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39578,7 +39579,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are IV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.",
+          "desc:8": "nomifactory.quest.db.769.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39589,7 +39590,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "IV Circuits",
+          "name:8": "nomifactory.quest.db.769.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39615,7 +39616,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are LuV, and can all be substituted in recipes.\n\nThe pattern stays the same: the rightmost circuit comes in larger quantities and is overall easier to produce.\n\nMake sure to set up the wetware board production as soon as possible! These take a very long time to make.\n\nIt\u0027s LuV, not LUV.\n",
+          "desc:8": "nomifactory.quest.db.770.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39626,7 +39627,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LuV Circuits",
+          "name:8": "nomifactory.quest.db.770.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39651,7 +39652,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are ZPM, and can all be substituted in recipes.",
+          "desc:8": "nomifactory.quest.db.771.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39662,7 +39663,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "ZPM Circuits",
+          "name:8": "nomifactory.quest.db.771.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39685,7 +39686,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Circuits along this line are UV, and can both be substituted in recipes.",
+          "desc:8": "nomifactory.quest.db.772.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39696,7 +39697,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "UV Circuits",
+          "name:8": "nomifactory.quest.db.772.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -39753,7 +39754,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Lathe§r is an important machine that makes rods less expensive to craft.",
+          "desc:8": "nomifactory.quest.db.774.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39764,7 +39765,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "LV Lathe",
+          "name:8": "nomifactory.quest.db.774.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39805,7 +39806,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2GregTechCEu§r adds an §einteractive in-world preview§r for all §bGregTech§r multiblocks! §6Shift-right-click§r a placed controller §2with an empty hand§r to activate a hologram depicting the default layout of the structure to help you with building. As you place blocks, the structure will be validated and the §efirst incorrect block§r it detects will be highlighted in red.\n\n§6Sneak-right-click§r to cycle from the full view through each layer. When on the final layer of the preview, this will remove the preview.\n\n§6Sneak-left-click§r to go back to the previous layer, or close the preview from the full view.\n\nIn the §eJEI previews§r for multiblocks, §6left-click§r and drag the mouse to rotate the preview.\n\nAdditionally, you can §6right-click§r and drag the mouse to pan the preview or §6shift-right-click§r and drag to zoom in or out.\n\nSome blocks in the multiblock preview have additional tooltips to provide more information on how the multiblock can form.",
+          "desc:8": "nomifactory.quest.db.775.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39816,7 +39817,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Multiblock Machine Previews",
+          "name:8": "nomifactory.quest.db.775.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39844,7 +39845,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Awakened Cores§6§r are the third tier of §bDraconic Evolution§r core, and are common components of endgame recipes.\n\nThese cores are made with §6Awakened Draconium§r and also cost §e3 Billion RF§r to craft.",
+          "desc:8": "nomifactory.quest.db.776.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39855,7 +39856,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Awakened Core",
+          "name:8": "nomifactory.quest.db.776.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39896,7 +39897,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A gear forged from §6Empowered Diamantine Crystal§6§r.\n\nMade from fluid solidification.",
+          "desc:8": "nomifactory.quest.db.777.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39907,7 +39908,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Empowered Diamantine Gear",
+          "name:8": "nomifactory.quest.db.777.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -39948,7 +39949,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have §6Awakened Cores§r, you can make the §eEnergy Storage Core§r from §bDraconic Evolution§r. It\u0027s a great way to store all the energy required to craft power-hungry late game items.\n\nThe §eEnergy Storage Core§r is a multiblock structure that can be upgraded to store increasingly immense amounts of RF energy. See the §bDraconic Evolution§r manual for more information on the material requirements for each tier.\n\n§2You cannot use regular Draconium Blocks to build this structure. You must treat it with Enriched Naquadah to make Activated Draconium before it can be used in the Energy Storage Core.\n\n§6Energy Pylons§r are required to input and output energy from the core. Each pylon allows movement in a single direction, so you need at least two.\n\nOnce you have the materials together for your desired tier, § the structure can build itself: simply access the GUI of the §6Energy Core§r, set the tier, and click Assemble. Items will be automatically used from your inventory. Once the structure is built, you can access the core\u0027s GUI again through §6Energy Core Stabilizers§r to activate it.\n\nIt is recommended to postpone Tier 8 until after you reach the §dCreative Portable Tank§r, as it requires large amounts of §2Activated §6Awakened Draconium§r.\n\n",
+          "desc:8": "nomifactory.quest.db.778.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -39959,7 +39960,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Power Storage on a Massive Level",
+          "name:8": "nomifactory.quest.db.778.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -40006,7 +40007,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Cobblestone can be processed into many useful materials:\n\n§6Stone Dust§r is useful for small amounts of a whole host of useful materials.\n\n§6Gravel§r is useful for making conduits and §9Concrete§r.\n\n§6Sand§r is useful for §6Glass§r, which can be turned into §6Nether Quartz§r or §6Silicon Dioxide§r for §6Oxygen§r.\n\nFinally, §6Dust§r can be turned into §6Netherrack§r.\n\nSet up a §ecobbleworks§r soon, so you can stockpile all these useful materials.\n",
+          "desc:8": "nomifactory.quest.db.779.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40017,7 +40018,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Infinite Cobblestone",
+          "name:8": "nomifactory.quest.db.779.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40074,7 +40075,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §eNether§r contains quite a few useful resources:\n- Some initial pieces of §6Sulfur§r\n- §6Glowstone§r and §6Soul Sand§r\n- §6Fluorine§r, §6Certus Quartz§r, §6Molybdenum§r, §6Antimony§r, and §6Gold§r-bearing ores\n- §9§2Nether Air§r, which can be distilled for useful gases\n- §eLava§r and §eNatural Gas§r from §2Fluid Rigs\n\n§rNether ores also contain §ddouble§r the resources per ore block compared to Overworld ores.",
+          "desc:8": "nomifactory.quest.db.780.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40085,7 +40086,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2To the Nether",
+          "name:8": "nomifactory.quest.db.780.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -40166,7 +40167,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Large Turbines have been improved in CEu. They are quite complex to run, but can generate lots of power when done well and scale very well.§r\n\nRight now, you can make the §6Large Steam Turbine§r and §6Large Gas Turbine§r. Once you get a §3Fusion Reactor§r going, you can make the §6Large Plasma Turbine§r.\n\nEach Large Turbine will need a §3Rotor Holder§r of the same or higher tier than the Large Turbine itself, and a §3Dynamo Hatch§r capable of handling the energy output. Each §3Rotor Holder§r tier above the Large Turbine §ddoubles§r the energy production and adds 10% to fuel efficiency.\n\nYou will need a §aRotor§r to go into each §3Rotor Holder§r§r. The Rotor will grant multiplicative Power and Efficiency bonuses depending on its material. Each Rotor also has a Durability, which is the number of seconds it will last.\n\n§aExample: §r§6Large Gas Turbine§r, with §3HSS-E Rotor§r and §3IV Rotor Holder§r:\n§aProduction:§r 4096 * 2.80 * 2 \u003d 22938 EU/t (91752 RF/t)\n§aEfficiency:§r 1.40 * 1.10 \u003d 154.0%\n§aDurability:§r 205,600 s (57.1 h)\n\nYou can run the §6Large Gas Turbine§r off §9LPG§r and §9Methane§r from §3Fluid Rigs§r, or §9Nitrobenzene§r from §6Wood§r.\nThe best §6Large Steam Turbine§r fuel is a closely-guarded government secret.",
+          "desc:8": "nomifactory.quest.db.783.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40177,7 +40178,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Large Turbines",
+          "name:8": "nomifactory.quest.db.783.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40204,7 +40205,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "These are the basic cables used by §3Applied Energistics§r to transport network connectivity. Due to the fact that channels are disabled, these cables will be your main method of transporting network connectivity, rather than the dense cables.\n\nThese cables do not share blockspace with conduits or cables for other mods, so they can be somewhat unweildy to build with, but they do accept §3Applied Energistics§r§6§r §6Facades§r, so they can be hidden very easily.\n\nLater you can make a variant of the cable that can share blockspace with §3Ender IO§r conduits.",
+          "desc:8": "nomifactory.quest.db.784.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40215,7 +40216,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "ME Cables",
+          "name:8": "nomifactory.quest.db.784.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40255,7 +40256,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Rubber§r has been sufficient for making cables so far, but you will soon discover that this basic type of rubber won\u0027t withstand more than §2Extreme Voltage§r. Higher quality rubber is necessary to properly insulate your wires.\n\nThere are two better types of rubber, and you will eventually need to make both of them. §eThese can also be used for insulating lower voltage wires more efficiently, requiring less fluid§r!\n\n§9§2Both Styrene-Butadiene Rubber (SBR) and Silicone Rubber (SiR) can wrap any Cable tier.§r However, SBR requires petrochemistry infrastructure you may not have yet, and is not mandatory until you are making late-game components. On the other hand, SiR can conveniently be made from chemicals you are already familiar with. By setting this up now, you won\u0027t have to change your wire coating material later!\n\nTo make Silicone Rubber, you will need to create §6Polydimethylsiloxane Dust§r in one of several ways, then mix it with §6Sulfur§r in a §3Chemical Reactor§r. You can then coat wires with it in an §3Assembling Machine§r.\n\n",
+          "desc:8": "nomifactory.quest.db.785.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40270,7 +40271,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2New Cable Coverings",
+          "name:8": "nomifactory.quest.db.785.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40307,7 +40308,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bEffortless Building§r is a mod that makes it much easier to build. You can create large platforms or various other shapes in just a few clicks, and even build multiple identical structures at the same time!\n\nTo use §bEffortless Building§r, start by pressing and holding the §6Alt§r key. This opens a wheel-shaped menu displaying §especial building modes§r. With this menu open, simply move your cursor over the desired building mode and release §6Alt§r. This will select that mode and you can begin building.\n\nChoose the starting location for your shape by §6right-clicking§r on a blockspace while holding your desired building block. Next, move your cursor to another blockspace to see a preview of the final structure. §6Right-click§r again on the desired ending block to actually build the shape from blocks in your inventory.\n\nMost shapes are flat and are defined using a starting and ending location, but 3D shapes have a third location to complete the shape. Some special modes also have §eoptions§r, like making a §ehollow cube§r instead of a §efilled cube§r.\n\nIf you made a mistake, you can use the §aUndo§r button in the menu to break the blocks you just placed so you can collect them and try again.\n\nTo change building modes, just open the menu with §6Alt§r as before and pick a different one. To exit the special building modes, select the §eNormal§r mode.\n\n§cMake sure you return to Normal mode when you\u0027re done building shapes, since the special building modes will interfere with normal gameplay.§r\n\nThe size of shapes you can make in special building modes is limited by your §ereach§r, which is how far away you can click from yourself to start building, or from the previous location to complete a shape. You can craft and eat several tiers of §areach upgrades§r in succession to increase your reach to very high numbers.\n\nOverall, §bEffortless Building§r is a powerful mod that is very useful for construction. Experiment with it and you\u0027ll see how much time it can save you!",
+          "desc:8": "nomifactory.quest.db.786.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40318,7 +40319,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Effortless Building",
+          "name:8": "nomifactory.quest.db.786.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40347,7 +40348,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Farming Station§r is a machine that automates growing and harvesting trees and crops around it, based on what items you put in it.\n\nThe Farming Station will principally collect crops, saplings, and wood, but it will also collect things like §6Apples§r from Oak Trees and §6Sticky Resin§r from Rubber Trees. It can also collect leaves if you want it to.\n\nLike other §bEnderIO§r machines, it requires an §6RF capacitor§r. The quality of capacitor affects the overall size of the farm as well as the speed and energy at which it operates.\n\nYou can configure which crops or tree types will be planted relative to the Farming Station by placing the crop or sapling in the various quadrants in the GUI. Clicking the lock button will ensure that the stack placed there won\u0027t be completely consumed, as that could lead to plants migrating to other quadrants.\n\nIn addition to power, the Farming Station§r requires specific §etools§r (and usually a supply of §9Water§r) to operate. If you\u0027re missing anything, the machine will refuse to operate and displays a message over itself to let you know.\n\nFor planting §6crops§r or §6saplings§r, you need a §aHoe§r.\nFor chopping §6trees§r, you need an §aAxe§r. To collect §6leaves§r, you also need §aShears§r.\n\nTool durability is consumed as the farm performs work, so the tools will eventually break. You can make §aStone Tools§r from a cobblestone generator and some sticks, or even §aDiamond Tools§r using diamonds from your §3Deep Mob Learning§r setup.\n\nAlternately, you can invest in fancier tools such as th§re §aDark Backhoe§r (which is designed for use in the Farming Station), or even unbreakable tools much later like the §aFlux Infused Axe§r and §aOmniwrench§r (shears).\n\nThe Farming Station also has a lesser-known feature: it respects enchantments and upgrades on your tools. Tools with §eEmpowered§r upgrades will be ejected into the output slots when they run out of charge (if they don\u0027t break first). Tools with the §eMending§r enchantment are similarly ejected when they are about to break.\n\nYou can use these properties to your advantage.\n\n",
+          "desc:8": "nomifactory.quest.db.787.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40358,7 +40359,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Farming Station",
+          "name:8": "nomifactory.quest.db.787.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40398,7 +40399,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Smart Item Filter§r from §3GregTech§r is an important tool when automating otherwise troublesome machines. It is a cover which filters item transfer based on whether a valid recipe exists for those items in a specified machine.\n\nThis is powerful in combination with movement covers like the §6Robot Arm§r. If you place this filter on the §eElectrolyzer§r mode in a Robot Arm set to §eSupply Exact§r mode, the Robot Arm will transfer precisely the right amounts of all valid items into an §3Electrolyzer§r so it will operate without clogging. There\u0027s no other way to accomplish this feat!\n\nThis filter also has §eSifter§r and §eCentrifuge§r§r modes for use with those machines. It does not have modes for any other machines.\n\nThe §eDefault§r button lets you click it to §eIgnore Fluids§r, which is useful when you have recipes that also require fluids (like §9Hydrogen§r in an Electrolyzer). Since Robot Arms can\u0027t move fluids, it would otherwise prevent the cover from working.\n",
+          "desc:8": "nomifactory.quest.db.788.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40409,7 +40410,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Smart Item Filter",
+          "name:8": "nomifactory.quest.db.788.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40449,7 +40450,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§aFilters§r are a type of machine cover that controls what items or fluids are allowed to pass through it. They can be used directly on the side of a machine to affect external automation or the Machine\u0027s §aAuto-Output Functionality§r.\n\nYou can also §eplace filters inside of other covers§r to control what items or fluids that cover will interact with. When used in a §6Robot Arm§r, §aItem Filters§r make for a powerful automation tool for §ekeeping specific items in stock§r in specific quantities in Machines. With §6Fluid Regulators§r, similar behavior is possible with fluids using a §aFluid Filter§r. For §6Conveyors§r and §6Pumps§r, it simply limits what that cover will move.\n\n§aFilters§r all have 9 configurable slots and whitelist/blacklist modes, and can be applied to multiple sides of machines. When placed inside a §6Robot Arm§r in §eKeep Exact§r or §eSupply Exact§r mode§r, the item count in a filter can be incremented by §eRight Clicking§r and decremented by §eLeft Clicking§r. Holding §eShift§r causes the count to increase/decrease by a factor of 2. This controls the number of each type of item that will be kept in stock or moved at a time.\n\nSimilar controls are available for the §aFluid Filter§r when placed inside a §6Fluid Regulator§r.\n\nAdditionally, the §aOre Dictionary Filter§r§r is a powerful tool that has a specialized filter which uses ore dictionary entries and §2uses regular expressions (regex)§r, e. g. \"§6ingotHot*§r\" will match all hot ingots, \"§6dustRegular*§r\" will match all regular dusts, and \"§6dustTiny*§r\" will match all tiny piles.\n\nAll §bGregTech§r Filters can be configured using ghost items from §bJEI§r.",
+          "desc:8": "nomifactory.quest.db.789.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40460,7 +40461,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Filters",
+          "name:8": "nomifactory.quest.db.789.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40512,7 +40513,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Machine Controller§r is a cover that manages the operation of §bGregTech§r machines, similar to a §aSoft Hammer§r. These are crucial for §epassive automation§r, where a machine is dedicated to keeping something in stock for you.\n\n\"Machines\" here is broader than you might think. It of course works on single-block machines, but can also be used on §eMultiblock Controllers§r like your §3Electronic Blast Furnace§r. But it\u0027s even more flexible than that: you can use it on any §bGregTech§r block that accepts transfer covers, as long as the controllable cover is placed on it first! This means it also works for things like §6Chests§r, §6Drums§r, and Multiblock inputs.\n\nThe cover works by detecting a §eredstone signal§r. By default, the entire machine will be disabled if a sufficiently strong signal is detected by the cover.\n\nWhen you open the Machine Controller\u0027s GUI with a §aScrewdriver§r, you will see several options for configuring its behavior:\n\nThe strength of the signal required to trigger the Machine Controller is configurable using the top slider.\n\nAnother button allows you to select whether to control the whole machine (where applicable) or a specific cover. This lets you do things like stop moving items into a machine, but also allow the machine to continue working.\n\nSwitching from §eNormal§r to §eInverted§r mode will make the Machine Controller instead disable the machine until it receives the requisite redstone signal. This is often preferable when working with §6Level Emitters§r to prevent machines from starting up if your §eME Network§r is offline.\n\nSome use cases:\n• Control machines through vanilla redstone contraptions or a simple lever.\n\n• The §6Redstone Upgrades§r from §bStorage Drawers§r can be used when outputting into a drawer to make the drawer emit redstone that can control the machine.\n\n• When you progress to digital storage, an §6ME Level Emitter§r or §6ME Fluid Level Emitter§r can be used to emit signal based on specific items or fluids in your network.\n",
+          "desc:8": "nomifactory.quest.db.790.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40523,7 +40524,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Machine Controllers",
+          "name:8": "nomifactory.quest.db.790.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40564,7 +40565,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Processing Array§r is a §bGregTech§r multiblock that allows for processing multiple recipes in parallel in a single stucture and is extremely useful for saving space.\n\nUp to 16 of the same recipe can be processed in parallel by placing the machines for the recipe in exactly one §aMachine Access Interface§r in the multiblock structure, as well as the ingredients and non-consumable items (like §6Integrated Circuits§r) for the recipe you want to process in one or more input buses. While a recipe is running, the Machine Access Interface is §elocked§r and machines cannot be added or removed.\n\nNote that each machine will still draw the full voltage required for the recipe, which may be more than a single §aEnergy Input Hatch§r can provide. This is why the §6Processing Array§r has an astounding Hatch limit, and can support up to §e4 Energy Inputs§r on the structure. This allows you to get the needed 16 Amps of power to the machine from a single tier-appropriate §3CEF§r.\n\nProcessing Arrays distribute their buffered power at the appropriate voltage, so there\u0027s no danger of your machines exploding if you, for example, operate 16 HV machines off one amp of IV power.\n\nBecause the required number of Inputs, Outputs, and Casings is highly variable, this quest only asks you to craft the §6Processing Array Controller§r and the §aMachine Access Interface§r. Make sure your buses and hatches are large enough to hold the ingredients and outputs for the number of parallel crafts you\u0027re attempting, and that you\u0027re providing enough power for all those machines!\n\nAn advanced feature of the Processing Array is §eDistinct Bus Mode§r. This makes the Processing Array only consider a single item input bus at a time when determining whether it can run a recipe. This is useful when recipes for a particular machine require different catalyst items, like §6Integrated Circuits§r on different configurations or §6Extruder Shapes§r.\n\nDistinct Bus Mode may be enabled or disabled via the Processing Array controller by clicking in the designated area.\n\n",
+          "desc:8": "nomifactory.quest.db.791.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40575,7 +40576,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Processing Array",
+          "name:8": "nomifactory.quest.db.791.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40622,7 +40623,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Dynamite§r is an explosive made from §9Glyceryl Trinitrate§r, which is itself made of §9Glycerol§r and §9Nitration Mixture§r. You can throw dynamite to blow things up, but it is primarily a crafting ingredient you can use in the §3Implosion Compressor§r.\n\n§6TNT§r is another explosive that could be made instead of Dynamite. It\u0027s a stronger explosive so you need fewer TNT per recipe it\u0027s used in relative to dynamite, but it has its own unique processing chain.",
+          "desc:8": "nomifactory.quest.db.792.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40633,7 +40634,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Dynamite",
+          "name:8": "nomifactory.quest.db.792.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40673,7 +40674,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6TNT§r is an explosive made from §9Toluene§r, a distillation byproduct of §9Wood Tar§r or various §eSteam-Cracked Fuels§r. Besides its typical uses in Minecraft, it is a crafting ingredient you can use in the §3Implosion Compressor§r.\n\n§6Dynamite§r is an alternative explosive for the Implosion Compressor, though you need relatively more of them per craft.",
+          "desc:8": "nomifactory.quest.db.793.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40684,7 +40685,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "TNT",
+          "name:8": "nomifactory.quest.db.793.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40764,7 +40765,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Advanced System-on-Chip§r (or §6ASoC§r) is the §2penultimate§r component miniaturization. These unlock the most efficient recipe for producing §2Nanocircuits and §6Quantum Circuits§r.\n\nThe latter circuits must be made in a §aZPM Assembling Machine§r.",
+          "desc:8": "nomifactory.quest.db.795.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40775,7 +40776,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Advanced System-on-Chip",
+          "name:8": "nomifactory.quest.db.795.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40815,7 +40816,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Naquadah-Doped Boule§r produces even more wafers per boule. It also is relatively cheap, due to the abundance of Naquadah that is gained from the §eTier 5 Micro Miner Mission§r.\n\nThis boule also allows the production of §6Advanced System on Chip§r wafers, which are used to make the final forms of the circuits very cheaply. However, you might not be able to take advantage of the §6Advanced System on Chip§r yet, due to the power requirements.",
+          "desc:8": "nomifactory.quest.db.796.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40826,7 +40827,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Naquadah Boules",
+          "name:8": "nomifactory.quest.db.796.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40918,7 +40919,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Sunnarium§r is an alloy formed from §6Stabilized Plutonium§r and §6Stabilized Curium§r in an IV or better §3Alloy Smelter§r.\n\nIt is a common ingredient in higher tier §6Solar Panels§r, as well as a crucial ingredient of the §3Processing Array§r.\n\nThis stuff takes a long time to produce so consider stocking it passively.",
+          "desc:8": "nomifactory.quest.db.798.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40929,7 +40930,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Sunnarium",
+          "name:8": "nomifactory.quest.db.798.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -40970,7 +40971,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Carry a whole lotta stuff!",
+          "desc:8": "nomifactory.quest.db.799.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40984,7 +40985,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Signalum Satchel",
+          "name:8": "nomifactory.quest.db.799.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41074,7 +41075,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6§3Pyrolyse Oven§r can make more interesting products than just §9Phenol§r.\n\n§a§9Charcoal Byproducts§r breaks down into various wood products, such as§9 Wood Tar§r,§9 Wood Gas§r, and §a§9Wood Vinegar§r, each of which can be further broken down into various useful chemical compounds, such as §a§9Toluene§r, §a§9Methanol§r, etc.\n\nHowever, to take full advantage of decomposing these wood products, a §6§3Distillation Tower§r is required, so that all possible outputs can be obtained. You will need more§e Distillation Tower Slices§r than requested in the§r Distillation Tower quest, so be prepared to spend some more §6Stainless Steel§r.",
+          "desc:8": "nomifactory.quest.db.801.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41089,7 +41090,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Pyrolyse Products",
+          "name:8": "nomifactory.quest.db.801.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41138,7 +41139,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Fusion Coils§r are §2no longer EBF coil materials, but they are used in the next Fusion Reactors.",
+          "desc:8": "nomifactory.quest.db.802.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41149,7 +41150,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Fusion Coils",
+          "name:8": "nomifactory.quest.db.802.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41189,7 +41190,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Whether or not you (or your server admin) picked the default §bLost Cities§r overworld type, you have the option of teleporting yourself to the §eLost Cities Dimension§r. This is useful if you like other world types but want to still be able to explore cities for things like §eloot and spawners§r§r.\n\nTo create a portal, you must place a §aBed§r§r down on two §6Blocks of Diamond§r. Then, you surround the bed with any kind of §eMonster Skulls§r. Sleep in this bed and you will be teleported there.\n\n§cDon\u0027t forget to have a way to get back!§r§r You can use the §e/sethome§r§r command to register where your house is, and §e/home§r§r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some §erestrictions§r on this though: §eit takes a few seconds of standing still to activate§r and there is a §ecooldown§r between uses.\n\nLater on you\u0027ll have other means of teleportation.\n\nMonster Skulls might take a little while to get if you\u0027re playing in §ePeaceful§r§r. §6Skeleton Skulls§r would be the way to go in that case.",
+          "desc:8": "nomifactory.quest.db.803.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41200,7 +41201,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Lost Cities and Registering Homes",
+          "name:8": "nomifactory.quest.db.803.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41253,7 +41254,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §a§r§3Assembly Line§r is a particularly unusual multiblock from an automation standpoint. Up until now, it has been possible to dump ingredients into a single input bus. Clearly, this won\u0027t work for the Assembly line, since it has a whole bunch of ULV inputs buses that hold one item stack each.\n\nYou might be tempted to dump everything into a chest and route items around to specific buses with §aItem Conduits§r. You\u0027ll probably find this to be slow, prone to jamming, and inflexible when you want to run different recipes.\n\nIf you\u0027ve unlocked §3§3The Empowerer§r§r, you might have considered §aPhantomfaces§r. These would certainly be an improvement over item conduits, but there\u0027s an even better solution.\n\nEnter §aItem Laser Relays§r§r: these handy tools from §bActually Additions§r allow you to create a virtual inventory out of multiple real ones; that is, you can use them to make other automation think that all of the input buses are the same inventory.\n\n§eOne important thing to note is that lasers appear to be \"placed\" on a particular block but they will interact with all adjacent (non-laser) blocks.§r Take this into account when placing them.\n\nTo start, place a laser on each of the input buses. Then, place the §a§aItem Interface§r adjacent to the laser on the first input bus. This will serve as the access point to the virtual inventory where you can connect things like an §3Unpackager§r or §aME Interface§r.\n\nTake your §aLaser Wrench§r and right click the first laser relay, then the second laser relay, to link them together. Repeat this with the second and third relays, third and fourth relays, etc. until they have all been linked together. Now you have a laser network virtualizing all of the input buses!\n\n§cWarning: be careful not to place a second laser on a laser network adjacent to the network\u0027s Item Interface. This will immediately crash your game because it creates a cycle in the network. You will have to either restore from backup or edit the level.dat directly to remove the block to play again.§r\n\nIf you need to do recipes with an §6§6Integrated Circuit§r, you can leave it in an input bus and skip placing a laser there. Remember to always use §eBlocking Mode§r when connecting the laser network to on-demand crafting. As long as you do, you can have §edifferent circuits in the Assembly Line without recipe conflicts§r. If you don\u0027t use Blocking Mode, you are likely to accidentally craft something else and jam your Assembly Line.",
+          "desc:8": "nomifactory.quest.db.804.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41264,7 +41265,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Assembly Line Automation",
+          "name:8": "nomifactory.quest.db.804.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41350,7 +41351,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2You only need this step if you are using normal Chemical Reactors. If you are using LCRs, the Allyl Chloride step is skipped.\n\n§9Allyl Chloride§r provides an alternative means of producing §9Epichlorohydrin§r for §9Epoxy§r.\n\nReacting §9Chlorine§r and §9Propene§r will produce Allyl Chloride. Propene is distilled in a §3Distillation Tower§r from any of various cracked petroleum products like §9Steam-Cracked Naphtha§r.",
+          "desc:8": "nomifactory.quest.db.806.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41365,7 +41366,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Allyl Chloride",
+          "name:8": "nomifactory.quest.db.806.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41393,7 +41394,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Plant some crops, fluid extract some seeds, bam! §9Seed Oil§r.",
+          "desc:8": "nomifactory.quest.db.807.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41404,7 +41405,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Seed Oil",
+          "name:8": "nomifactory.quest.db.807.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41448,7 +41449,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§5Nomifactory§r has an official Discord server which serves as a useful community resource.\n\nOn the server, the dev team posts links to in-depth guides on a variety of topics related to the pack, makes development announcements, assists with tech support questions, and investigates possible bug reports.\n\nYou can also chat with many fellow players there if you like, who are largely willing to help with general questions one might have.\n\nTo join the server, you can use the button on the Main Menu to go to the join URL, or if you\u0027re not into Discord you can find our projects on GitHub at our organization page: §9https://github.com/Nomifactory§r.\n\nIssue tracking and development, including many community-submitted guides, is handled on our respective GitHub project repositories.\n\n§2This fork\u0027s GitHub page can be found at §9https://github.com/m2r1k5/nomi-ceu§2",
+          "desc:8": "nomifactory.quest.db.808.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41459,7 +41460,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "Discord and GitHub",
+          "name:8": "nomifactory.quest.db.808.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41486,7 +41487,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6§6Vanadium Pentoxide§r is a catalyst used in the production of §9Sulfuric Acid§r and §9Phthalic Anhydride§r. It\u0027s also the way you get §6Vanadium§r metal.\n\nYou will need §6Salt§r, §9Ammonia§r, and §9Hydrochloric Acid§r for the multi-step processing of §6Vanadium Magnetite Ore§r into §6V₂O₅§r.",
+          "desc:8": "nomifactory.quest.db.810.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41497,7 +41498,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Vanadium Pentoxide",
+          "name:8": "nomifactory.quest.db.810.ste.title",
           "partysinglereward:1": 0,
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
@@ -41572,7 +41573,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Check out the new Material Tree tab! It will show you nearly all the different forms of a GregTech material (Plates, Rods, Screws, Dusts...) on a single page. You can then click on those to see their recipes.",
+          "desc:8": "nomifactory.quest.db.813.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41583,7 +41584,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Material Tree",
+          "name:8": "nomifactory.quest.db.813.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41610,7 +41611,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Technically not new to CEu, but it was disabled in the original version, and it had much less functionality in CE.§r\n\nThe Arc Furnace allows you to make §6Annealed Copper§r, which will be used in the MV Age. It can also make 2 pieces of Glass from 1 Sand. Later, it can make §2Tempered Glass§r§r for use in higher-tier recipes.\n\nThe Arc Furnace also functions as a §auniversal recycling machine§r. Pretty much anything can be recycled into ingots and dusts of its base components.\n\nAll of its recipes require Oxygen.\n\nAll Arc Furnace recipes use exactly 30 EU/t, so you can get away with using LV Arc Furnaces for the whole pack!",
+          "desc:8": "nomifactory.quest.db.814.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41621,7 +41622,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2LV Arc Furnace",
+          "name:8": "nomifactory.quest.db.814.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41661,7 +41662,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Bending Machine makes, depending on what Programmable Circuit it\u0027s given:\n- Plates from a single ingot (instead of the Compressor)\n- 4 Foils from a Plate (instead of the Cluster Mill, which is no more)\n- Double Plates from two Plates\n- Dense Plates from nine Plates\n- Small Springs from one Rod\n- Springs from one Long Rod. \n\nWhy was this removed?!",
+          "desc:8": "nomifactory.quest.db.815.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41672,7 +41673,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2LV Bending Machine",
+          "name:8": "nomifactory.quest.db.815.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41729,7 +41730,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Circuit Assemblers§r are the linchpin of your factory, gating progression through the §6Circuits§r. \n\nEach time you upgrade to a new voltage of Circuit Assembler, you will be able to craft more advanced §ethemes§r of circuits. These use more complex ingredients and require new infrastructure to be in place, but are more efficient to craft overall than the same tier of circuit from the prior theme.\n\n§2The LV Circuit Assembler allows you to make Electronic Circuits far more easily.\n\nThe circuit progression has been largely replaced with the progression native to CEu, with a few minor changes to reflect the progression of this pack better.§r Check out the §dProgression quest book tab§r to see the flow of circuit progression.\n",
+          "desc:8": "nomifactory.quest.db.816.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41740,7 +41741,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2LV Circuit Assembler",
+          "name:8": "nomifactory.quest.db.816.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41780,7 +41781,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Steam Grinder functions as 5.3 LV Macerators in parallel. It requires an input of Steam through a Steam Hatch, but it uses very little Steam.\n\nYou may want to consider setting up a rudimentary ore-doubling setup with it. Point the output in the direction of several upgraded Furnaces.\n\nYou may wish to wait until you have a Metal Bender at LV to reduce the cost.",
+          "desc:8": "nomifactory.quest.db.817.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41791,7 +41792,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Steam Grinder",
+          "name:8": "nomifactory.quest.db.817.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41831,7 +41832,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "An advanced component used for the Circuit Assembling Machine.",
+          "desc:8": "nomifactory.quest.db.818.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41842,7 +41843,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "LV Emitter",
+          "name:8": "nomifactory.quest.db.818.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41882,7 +41883,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2With MV Batteries unlocked, you can make Power Units for electric GT tools. Most notable among them is the Drill, which at MV tier can mine a 3x3x3 area of blocks.\n\nHigher tier drills can mine 5x5x5, 7x7x7 and 9x9x9 areas! Shift-right-click to change the breaking area.\n\nCharge these with a Battery of appropriate tier, or in an appropriately tiered machine.\n\nYou may want to look into Chainsaws for mass tree felling as well. The other electric tools are probably not worth making.",
+          "desc:8": "nomifactory.quest.db.819.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41899,7 +41900,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2GregTech Drill",
+          "name:8": "nomifactory.quest.db.819.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41941,7 +41942,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Diodes are a component in the next Circuit tiers. They are made from liquid Glass, Fine Copper Wire and Gallium Arsenide, which is made in a Mixer with Gallium and Arsenic.\n\nLater, you will unlock better recipes for this.",
+          "desc:8": "nomifactory.quest.db.820.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41952,7 +41953,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Diodes",
+          "name:8": "nomifactory.quest.db.820.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -41992,7 +41993,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Sodium Persulfate§r §2and Iron III Chloride§r are used to make cheaper §9Good Circuit Boards§r, as it cuts the Silver amount by a factor of four. They are also §drequired§r to make §9Plastic Circuit Boards§r.\n\nMaking §aSodium Persulfate§r will yield §aHydrochloric Acid§r as a coproduct, which you may re-use to make §aIron III Chloride§r. This should the best approach right now, but the decision is entirely yours. With more automation later in the game, Iron III Chloride will be the cheaper and more straight forward path.\n\nSodium Persulfate§r can also be used in §9Ore Processing§r in the §3Chemical Bath§r, to get various bonus outputs you would not normally obtain. It is completely optional, but pretty rewarding.",
+          "desc:8": "nomifactory.quest.db.821.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42007,7 +42008,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Sodium Persulfate and Iron III Chloride",
+          "name:8": "nomifactory.quest.db.821.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42048,7 +42049,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Phenolic Substrates need to be turned into Circuit Boards with Silver before being usable in Circuit production.\n\nSodium Persulfate and Iron III Chloride are troublesome to get right now, but using them in making Circuit Boards will reduce the amount of Silver required by 4 times.",
+          "desc:8": "nomifactory.quest.db.822.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42059,7 +42060,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Good Circuit Boards",
+          "name:8": "nomifactory.quest.db.822.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42099,7 +42100,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This quest accepts an LV or MV Sifter.\n\nThe Sifter gets you Flawless and Exquisite Gems from Crushed Purified Gem Ores. Overall it results in a higher yield. Higher tiers of Sifter increase the yield further.\n\nYou will need small quantities of Flawless Emeralds for MV Emitter and Sensor components.",
+          "desc:8": "nomifactory.quest.db.823.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42110,7 +42111,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Sifter",
+          "name:8": "nomifactory.quest.db.823.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42150,7 +42151,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The successor of Small Coils, Inductors are another circuit component you will need.\n\nFor the best results, use Nickel Zinc Ferrite and Annealed Copper to make these.\n\nBut depending on which setups you build first, you may not need to make many of the basic version over the SMD version.",
+          "desc:8": "nomifactory.quest.db.824.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42161,7 +42162,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Inductors",
+          "name:8": "nomifactory.quest.db.824.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42202,7 +42203,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Polytetrafluoroethylene (PTFE, or Teflon) is a polymer made from Carbon and Fluorine.\n\nThis polymer is most importantly used to make Large Chemical Reactors. It\u0027s also required for IV and LuV Machine Hulls, and can be substituted in some cases for higher yields.",
+          "desc:8": "nomifactory.quest.db.825.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42217,7 +42218,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Polytetrafluoroethylene",
+          "name:8": "nomifactory.quest.db.825.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42254,7 +42255,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The §3§2Large Chemical Reactor (LCR)§r §2is a multiblock §3§2Chemical Reactor§r §2with more input/output slots.§r\n\nThe §3LCR§r can perform some exclusive reactions which allow you to combine multiple normal §3Chemical Reactor§r steps into a §6single step§r, such as:\n- §aNitrogen Dioxide§r\n- §r§aSulfuric Acid§r\n-§r §aEpichlorohydrin§r, needed for...\n-§r §aEpoxy§r\n\nThe §3LCR§r also is required to perform some recipes, such as §aRaw Gasoline§r production.\n\nAny other recipe which could be done in a normal §9Chemical Reactor§r, as well as certain §9Mixer§r recipes, can also be done in an §3LCR§r.\n\nAll §dOverclocks§r in the §3LCR§r are §6100% efficient§r; each overclock will §5quadruple the speed§r, as opposed to doubling it.",
+          "desc:8": "nomifactory.quest.db.826.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42265,7 +42266,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Large Chemical Reactor",
+          "name:8": "nomifactory.quest.db.826.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42323,7 +42324,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A rudimentary version of Platinum Group Sludge (PGS) processing existed in the base pack. Here, it is a strong source of the Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum - as well as Gold. All of these elements will be used in IV-tier and above materials.\n\n§rYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.",
+          "desc:8": "nomifactory.quest.db.827.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42334,7 +42335,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Platinum Group Processing",
+          "name:8": "nomifactory.quest.db.827.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42380,7 +42381,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This is the highest tier of polymer. It is used in crafting Advanced SMD components, ZPM+ Machine Hulls, among other things.\n\nThis polymer requires at least 14 processing steps to craft. Good luck!",
+          "desc:8": "nomifactory.quest.db.828.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42395,7 +42396,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Polybenzimidazole (PBI)",
+          "name:8": "nomifactory.quest.db.828.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42432,7 +42433,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The next tier of Assembling Machine. This one can make quite a few nice things - check the surrounding quests.",
+          "desc:8": "nomifactory.quest.db.830.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42443,7 +42444,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "HV Assembler",
+          "name:8": "nomifactory.quest.db.830.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42483,7 +42484,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A more compact infinite Water source. Place this as a cover on any GT machine and it will insert 16B of water every second.",
+          "desc:8": "nomifactory.quest.db.831.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42494,7 +42495,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Greggy Infinite Water",
+          "name:8": "nomifactory.quest.db.831.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42534,7 +42535,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Ender Fluid Link Covers are GTCEu\u0027s Ender Tanks§r. Each Cover sends their fluids through a frequency defined by an §68-digit hexadecimal number§r (0-9, then A-F for each digit). That gives you §64.29 billion§r channels to work with! \n\nEnder Fluid Link Covers work as long as their chunk is loaded - regardless of distance or dimension.\n\nSetting the mode to Import will §o§c§opull§r fluids from the world location it is attached to, while Export will §o§9§opush§r fluids to the world. You must turn the I/O to Enabled for it to start working. Each channel has a buffer of §d64 buckets§r.\n\nThe \"Virtual Tank Viewer\" app in your §4Terminal§r allows you to see the contents of all Ender Fluid Link channels. Regardless, I recommend you set up a system to organise all those channels. I would also advise against using the default channel (FFFFFFFF) in all cases.\n",
+          "desc:8": "nomifactory.quest.db.832.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42545,7 +42546,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Super Ender Tanks",
+          "name:8": "nomifactory.quest.db.832.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42604,7 +42605,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Central Monitor allows you to... monitor... parts of your factory. Coupled with Wireless Digital Interface Covers, you can see the status, capacity, and more of machines, and even access their GUI remotely!\n\nCheck out the GTCEu wiki on GitHub for more of its details.",
+          "desc:8": "nomifactory.quest.db.833.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42615,7 +42616,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Central Monitor",
+          "name:8": "nomifactory.quest.db.833.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42667,7 +42668,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Super Tanks are the high-tier GT Fluid storage solution.§r\n\nThe first tier holds §64,000 buckets§r, and higher tiers hold more. They can also be used like Drums to put fluids in and out of machines.\n\nYou can conveniently configure §cvoiding§r for them to always void, start voiding at 95% capacity, or never void.\n\nThe item equivalent are §3Super Chests§r, which are used in certain §6Microminer§r recipes. Higher-tier versions of these are called §3Quantum Tanks§r and §3Quantum Chests§r. They all require their respective tier §3Hermetic Casings§r to craft.",
+          "desc:8": "nomifactory.quest.db.834.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42678,7 +42679,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Super Tanks",
+          "name:8": "nomifactory.quest.db.834.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42718,7 +42719,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Oil Cracking Unit gives you higher yields from cracking organic substances.\n\nNew in GTCEu, many organic substances offer the option of being Severely or Lightly cracked, each one granting different ratios of distillates.",
+          "desc:8": "nomifactory.quest.db.835.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42729,7 +42730,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Oil Cracking Unit",
+          "name:8": "nomifactory.quest.db.835.title",
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42770,7 +42771,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2In GTCEu, higher-tier blends of dusts require higher-tier Mixers to mix. The MV Mixer is required for making Vanadiumsteel and Stainless Steel.\n\nThere will not be more mixer quests above this one. Remember this when making higher-tier dust blends.",
+          "desc:8": "nomifactory.quest.db.836.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42781,7 +42782,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2MV Mixer",
+          "name:8": "nomifactory.quest.db.836.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42823,7 +42824,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A bit of Vanadiumsteel is used for progression. It\u0027s also a very strong tool material.\n\n§6Vanadium§r is an element acquired by processing §6Vanadium Magnetite Ore§r.",
+          "desc:8": "nomifactory.quest.db.837.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42834,7 +42835,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Vanadiumsteel",
+          "name:8": "nomifactory.quest.db.837.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42875,7 +42876,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Systems on Chip can be engraved with HV power and Glowstone Boules. This unlocks the ultimate tier one circuit recipe in the EV Circuit Assembler.\n\nThe ultimate tier two circuit recipe requires an IV Circuit Assembler.",
+          "desc:8": "nomifactory.quest.db.838.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42886,7 +42887,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Systems on Chip",
+          "name:8": "nomifactory.quest.db.838.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42927,7 +42928,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Your first few Raw Crystal Chips must be grown in an Autoclave from liquid Europium, and Exquisite Emeralds or Exquisite Olivine.\n\nAfter the first few, you can smash them into pieces using a Forge Hammer, and duplicate them with Bacterial Sludge, Mutagen, or more Europium.\n\nBacterial Sludge can later be obtained in the byproducts of getting Stem Cells.",
+          "desc:8": "nomifactory.quest.db.839.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42938,7 +42939,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Crystal Growing",
+          "name:8": "nomifactory.quest.db.839.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -42980,7 +42981,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Advanced Processing Array can handle up to 64 parallel recipes at once.\n\nYou may need some 4A or 16A Energy Hatches to keep up with its power draw.",
+          "desc:8": "nomifactory.quest.db.840.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -42991,7 +42992,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Advanced Processing Array",
+          "name:8": "nomifactory.quest.db.840.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43031,7 +43032,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Made by adding some Cobalt, Manganese and Silicon to your HSS-G.",
+          "desc:8": "nomifactory.quest.db.841.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43042,7 +43043,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "High Speed Steel Type E",
+          "name:8": "nomifactory.quest.db.841.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43083,7 +43084,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Use the Stem Cells and more advanced materials to build a Neuro Processing Unit. This is used in the first Wetware Circuit.",
+          "desc:8": "nomifactory.quest.db.842.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43094,7 +43095,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Neuro Processing Unit",
+          "name:8": "nomifactory.quest.db.842.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43134,7 +43135,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2There are 3 materials you will need from processing Naquadah: Enriched Naquadah (Nq+), Naquadria (Nq*), and Trinium (Ke). And there are 3 different ways to process Naquadah, each resulting in different materials.§r\n\nFirst is by §dprocessing ores§r from the §6Tier Five Micro Miner§r. §6Kaemanite Ore§r yields §6Trinium§r.\n\nSecond is by combining §6Naquadah Dust§r with certain heavy elements and EnderIO crystal grains. This can provide §6Enriched Naquadah§r and §6Naquadria§r.\n\nFinally, you can do the full CEu processing of §6Naquadah Dust§r with §9Fluoroantimonic Acid§r, the strongest acid known to man. This is a decently involved process, but not only does it yield all 3 Nq materials, it also grants byproducts of §6Titanium, Sulfur, Indium, Phosphorus, Barium, and Gallium§r.",
+          "desc:8": "nomifactory.quest.db.843.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43149,7 +43150,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Naquadah Processing",
+          "name:8": "nomifactory.quest.db.843.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43187,7 +43188,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Trinium Coils§r are the eighth coil material available, increasing your EBF\u0027s operating temperature to 9001K so it can process more advanced materials.\n",
+          "desc:8": "nomifactory.quest.db.844.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43198,7 +43199,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Trinium Coils",
+          "name:8": "nomifactory.quest.db.844.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43239,7 +43240,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A heavy Naquadah isotope with more nuclear capability.\n\n§r§6Enriched Naquadah§r is meant to be used in as-of-yet-unimplemented CEu-native reactors. It\u0027s used in small amounts for §3Trinium Coil blocks§r, or in Nomi reactors, though Naquadria is better for that purpose.\n\nAt least it\u0027s the easiest to obtain, and you can get it by mixing, the full Naquadah chain, or by passing Purified Naquadah Dust through an Electromagnetic Separator.",
+          "desc:8": "nomifactory.quest.db.845.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43250,7 +43251,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Enriched Naquadah",
+          "name:8": "nomifactory.quest.db.845.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43290,7 +43291,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A lighter and unstable Naquadah isotope.\n\n§r§6Naquadria§o§r is used in the construction of §6UV components§r, the §3Fusion Reactor Mk2§r, and in fusing §6Neutronium§r. Each piece of Naquadria also makes §d4 times§r more power than §6Enriched Naquadah§r in §3Naquadah Reactors§r.",
+          "desc:8": "nomifactory.quest.db.846.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43301,7 +43302,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Naquadria",
+          "name:8": "nomifactory.quest.db.846.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43342,7 +43343,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A strong heavy element obtained from the Naquadah chain.\n\n§r§6Trinium§r can come from §6Kaemanite Ore§r, but you will probably want to bolster its production with §6Naquadah Dust§r processing. It comes out at the second stage, so if you don\u0027t mind storing the intermediates and have Fluorine under control, you can hold off doing the full chain if you don\u0027t need to yet. You get §d1 Trinium per 6 Naquadah processed§r.\n\nThis will be required in large quantities for §6Trinium Coils§r, §6Superconducting Coil Blocks§r, §6Naquadah Alloy§r, among other things. You will need 14 stacks at least for a §3Fusion Reactor Mk1§r, so stock up on it.",
+          "desc:8": "nomifactory.quest.db.847.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43353,7 +43354,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Trinium",
+          "name:8": "nomifactory.quest.db.847.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43393,7 +43394,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Naquadah Alloy is different in CEu, it requires Naquadah, Osmiridium and Trinium.",
+          "desc:8": "nomifactory.quest.db.848.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43404,7 +43405,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Naquadah Alloy",
+          "name:8": "nomifactory.quest.db.848.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43444,7 +43445,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Used for Advanced SMD components.",
+          "desc:8": "nomifactory.quest.db.849.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43455,7 +43456,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2IV Assembling Machine",
+          "name:8": "nomifactory.quest.db.849.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43498,7 +43499,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Advanced SMD Components are new to CEu and are required for Crystal and Wetware circuits. They can also be substituted for the equivalent of 4 normal SMD components in Nano and Quantum circuits.\n\nAll of these components require IV power and liquid PBI.\n\nAdvanced SMD Transistor: Vanadium-Gallium Foil and Fine HSS-G Wire\n\nAdvanced SMD Resistor: Graphene Dust and Fine Platinum Wire\n\nAdvanced SMD Capacitor: Thin PBI Sheet and HSS-S Foil\n\nAdvanced SMD Diode: Small Pile of InGaP Dust and Fine Niobium-Titanium Wire\n\nAdvanced SMD Inductor: HSS-E Ring and Fine Palladium Wire\n\nAs with the normal SMD components, invest in an extremely robust automation system for these, as you won\u0027t stop needing them.",
+          "desc:8": "nomifactory.quest.db.850.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43509,7 +43510,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Advanced SMD Components",
+          "name:8": "nomifactory.quest.db.850.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43573,7 +43574,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Made by adding some Iridium and Osmium to your HSS-G.",
+          "desc:8": "nomifactory.quest.db.851.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43584,7 +43585,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "High Speed Steel Type S",
+          "name:8": "nomifactory.quest.db.851.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43625,7 +43626,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You can get Americium from NuclearCraft progression, but you can also fuse it. First combine Lanthanum with Silicon to make Lutetium, then combine it with Chrome to get Americium.\n\n§2Americium is used in larger quantities in CEu progression. You cannot convert this form of Americium to NuclearCraft Americium isotopes.",
+          "desc:8": "nomifactory.quest.db.852.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43636,7 +43637,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Americium Ingot",
+          "name:8": "nomifactory.quest.db.852.title",
           "questlogic:8": "OR",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43676,7 +43677,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Ruridit is a Ruthenium-Iridium alloy used in LuV machine components.",
+          "desc:8": "nomifactory.quest.db.853.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43687,7 +43688,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Ruridit",
+          "name:8": "nomifactory.quest.db.853.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43727,7 +43728,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Tritanium Coils are the final coil material. At 10800K, it\u0027s capable of smelting every material.",
+          "desc:8": "nomifactory.quest.db.854.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43738,7 +43739,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Tritanium Coils",
+          "name:8": "nomifactory.quest.db.854.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43778,7 +43779,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The final Boule. It grants the most wafers, and is required for Highly Advanced Systems-on-Chip.",
+          "desc:8": "nomifactory.quest.db.855.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43789,7 +43790,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Neutronium Boules",
+          "name:8": "nomifactory.quest.db.855.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43829,7 +43830,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2For making Wetware Circuits more easily. You need UV-tier power to make them that way.",
+          "desc:8": "nomifactory.quest.db.856.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43840,7 +43841,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Highly Advanced SoCs",
+          "name:8": "nomifactory.quest.db.856.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43880,7 +43881,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Used in building the Alloy Blast Smelter. \n\n§r§6Tantalum§r is obtained from §6Tantalite Ore§r, or in small quantities from centrifuging §eLava§r.\n\n§6Molybdenum§r is obtained from §6Molybdenum, Molybdenite, Powellite, and Wulfenite ores§r. They spawn together in the §eNether§r rarely, or some of them come from §3Tier One§r and §3Five Micro Miners§r.\n\n§2Remember, you need an appropriately tiered Mixer (HV for HSLA Steel, and EV for the others).",
+          "desc:8": "nomifactory.quest.db.857.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43891,7 +43892,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Advanced Alloys",
+          "name:8": "nomifactory.quest.db.857.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -43950,7 +43951,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Alloy Blast Smelter directly smelts dust combinations into molten Alloys, skipping the Mixer step. Some molten alloys may need to be cooled in a Vacuum Freezer before being usable.\n\n§rThis is the only way to create some of the advanced alloys used in multiblock machines. You can also use it for most normal alloys if you want. In particular, the yield of §6Energetic Alloy§r and §6Vibrant Alloy§r is §ddoubled§r.",
+          "desc:8": "nomifactory.quest.db.858.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -43961,7 +43962,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Alloy Blast Smelter",
+          "name:8": "nomifactory.quest.db.858.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44014,7 +44015,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2With advanced alloys from the Alloy Blast Smelter and IV Machines, you can make large versions of most GT machines.\n\n§rThese are formed like multiblocks. You can add a §3Parallel Control Hatch§r in order to allow them to process §dmore recipes§r at the same time, similarly to a §3Processing Array§r. The highest tier of Parallel Control Hatch can facilitate processing §d256 recipes§r at once!\n\nSearch \"@gregicality\" or look up the usages of Parallel Hatches in JEI to see details of all the multiblock machines.",
+          "desc:8": "nomifactory.quest.db.859.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44025,7 +44026,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Gregicality Multiblocks",
+          "name:8": "nomifactory.quest.db.859.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44143,7 +44144,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Upgraded forms of the EBF and Vacuum Freezer. Can run up to 2,048 recipes in parallel.\n\nThe Rotary Hearth Furnace is quite big!",
+          "desc:8": "nomifactory.quest.db.861.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44154,7 +44155,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Upgraded EBF and Freezer",
+          "name:8": "nomifactory.quest.db.861.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44200,7 +44201,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium. §e",
+          "desc:8": "nomifactory.quest.db.862.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 64,
@@ -44211,7 +44212,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 041: Niobium",
+          "name:8": "nomifactory.quest.db.862.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44251,7 +44252,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.863.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44262,7 +44263,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 042: Molybdenum",
+          "name:8": "nomifactory.quest.db.863.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44302,7 +44303,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.864.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44313,7 +44314,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 044: Ruthenium",
+          "name:8": "nomifactory.quest.db.864.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44353,7 +44354,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.865.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44364,7 +44365,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 045: Rhodium",
+          "name:8": "nomifactory.quest.db.865.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44404,7 +44405,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.866.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44415,7 +44416,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 048: Cadmium",
+          "name:8": "nomifactory.quest.db.866.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44455,7 +44456,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.867.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44466,7 +44467,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 055: Caesium",
+          "name:8": "nomifactory.quest.db.867.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44506,7 +44507,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.868.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44517,7 +44518,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 056: Barium",
+          "name:8": "nomifactory.quest.db.868.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44557,7 +44558,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.869.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44568,7 +44569,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 058: Cerium",
+          "name:8": "nomifactory.quest.db.869.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44608,7 +44609,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.870.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44619,7 +44620,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 060: Neodymium",
+          "name:8": "nomifactory.quest.db.870.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44659,7 +44660,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.871.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44670,7 +44671,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 062: Samarium",
+          "name:8": "nomifactory.quest.db.871.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44710,7 +44711,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.872.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44721,7 +44722,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 063: Europium",
+          "name:8": "nomifactory.quest.db.872.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44761,7 +44762,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.873.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44772,7 +44773,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 071: Lutetium",
+          "name:8": "nomifactory.quest.db.873.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44812,7 +44813,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.874.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44823,7 +44824,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 073: Tantalum",
+          "name:8": "nomifactory.quest.db.874.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44863,7 +44864,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium. (It wasn\u0027t before!)",
+          "desc:8": "nomifactory.quest.db.875.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44874,7 +44875,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 082: Lead",
+          "name:8": "nomifactory.quest.db.875.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44914,7 +44915,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.876.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44925,7 +44926,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 119: Tritanium",
+          "name:8": "nomifactory.quest.db.876.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -44965,7 +44966,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.877.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44976,7 +44977,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 120: Duranium",
+          "name:8": "nomifactory.quest.db.877.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45016,7 +45017,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.878.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45027,7 +45028,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 125: Trinium",
+          "name:8": "nomifactory.quest.db.878.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45067,7 +45068,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.879.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45078,7 +45079,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 174: Naquadah",
+          "name:8": "nomifactory.quest.db.879.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45118,7 +45119,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Configurable to output any number of GT Volts and Amps.",
+          "desc:8": "nomifactory.quest.db.880.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45129,7 +45130,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Infinite GT EU Emitter",
+          "name:8": "nomifactory.quest.db.880.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45169,7 +45170,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+          "desc:8": "nomifactory.quest.db.881.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45180,7 +45181,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Polyphenylene Sulfide",
+          "name:8": "nomifactory.quest.db.881.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45251,7 +45252,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.883.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45262,7 +45263,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 110: Darmstadtium",
+          "name:8": "nomifactory.quest.db.883.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45302,7 +45303,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2This element is now required in Omnium.",
+          "desc:8": "nomifactory.quest.db.884.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45313,7 +45314,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Element 149: Draconium",
+          "name:8": "nomifactory.quest.db.884.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45353,7 +45354,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Do you remember Darmstadtium tools in CE? Well you can make their material now!\n\nIt is formed by fusing Arsenic and Ruthenium, and is the main material for UV machines.",
+          "desc:8": "nomifactory.quest.db.885.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45364,7 +45365,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Darmstadtium",
+          "name:8": "nomifactory.quest.db.885.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45404,7 +45405,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Portable Scanner, or Tricorder, is GTCEu\u0027s debug tool. §rIt shows you a block\u0027s details, the details of the energy network, its current status and contents, and its impact on performance.\n\nUsing this anywhere will also display a percentage of fluid remaining in the fluid vein, for the §3Fluid Rigs§r.",
+          "desc:8": "nomifactory.quest.db.886.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45415,7 +45416,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Debug Scanner",
+          "name:8": "nomifactory.quest.db.886.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45456,7 +45457,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2A new, oily path to Polyethylene is available in GTCEu. §rCrack §9Light Fuel§r to §9Severely Steam-Cracked Light Fuel§r in a §3Chemical Reactor§r, then distill it to §eEthylene§r.\n\nThe advantage of this path is that it requires §6no MV machines§r. You lose a few Oil byproducts, but you get so much Oil from future processes that the loss is insignificant.",
+          "desc:8": "nomifactory.quest.db.887.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45471,7 +45472,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Patriot\u0027s Plastic",
+          "name:8": "nomifactory.quest.db.887.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45510,7 +45511,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Gasoline is a powerful combustion fuel, generating 1600 EU per mB of fluid.\n\nGasoline is made of:\n- 16 parts Naphtha\n- 2 parts Refinery Gas\n- 1 part Toluene\n- 1 part Methanol\n- 1 part Acetone\n\nTo get the most out of this, run it in an Extreme Combustion Engine with Liquid Oxygen.",
+          "desc:8": "nomifactory.quest.db.888.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45525,7 +45526,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Gasoline",
+          "name:8": "nomifactory.quest.db.888.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45595,7 +45596,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§dGregTech Power§r can be tricky to handle. Luckily, there are several tools you can use to tackle some of the problems.\n\n- §aDiode§r: A block which accepts energy on 5 sides, and outputs it on a single side. Its main purpose is to limit Amperage flow through it - adjust it by right-clicking it with a Soft Hammer. Not to be confused with the Diodes used as crafting components.\n\n- §aTransformer§r: A block which changes between 4A of a lower voltage and 1A of a voltage one tier higher.\n\n- §2Adjustable Transformer§r: Similar to the Transformer, but can be configured to transform up to 64A Low \u003c-\u003e 16A High.\n\n- §aBattery Buffer§r: A block which can hold GregTech Batteries. Each battery accepts up to 2A and can provide up to 1A. §2They have been reworked in CEu to not be as terrible to use.",
+          "desc:8": "nomifactory.quest.db.890.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45606,7 +45607,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2GT Power Management",
+          "name:8": "nomifactory.quest.db.890.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45681,7 +45682,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Large Ore Drilling Plants mine ores from under them in a large radius. They require Drilling Fluid to operate.\n\nThey automatically macerate the ores, yielding 3 times more crushed ore than a normal Macerator, plus the normal amount of byproduct.",
+          "desc:8": "nomifactory.quest.db.892.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45692,7 +45693,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "§2Large Miners",
+          "name:8": "nomifactory.quest.db.892.title",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -45745,7 +45746,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Certain multiblocks in CEu will require a Maintenance Hatch and/or Muffler Hatch. These cannot be shared between multiblocks. If you knew Maintenance in GT5u, fret not - Maintenance mechanics are far less punishing in CEu.\n\n§r- §aMuffler§r: This hatch must be §cunobstructed§r so it can output its beautiful smoke particles. When a recipe is performed, there is a small chance for the §3Muffler Hatch§r to give bonus items, typically tiny Dusts of Ash. It voids excess when full, so do not worry about it stopping machines from running.\n\n- §aMaintenance§r: You will need to do Maintenance for the Multiblock to begin operating. This is done by having a §9Wrench§r, a §9Screwdriver§r, a §9Soft Mallet§r, a §9Hammer§r, a §9Wire Cutter§r, and a §9Crowbar§r in your inventory, opening the Maintenance Hatch and §eclicking the center spot once§r. §cNo need to move tools individually§r. Alternatively, you can fix problems by placing §9Tape§r in the Maintenance Hatch. \n\nMaintenance problems may occur after §d48 real hours of activity§r. Needless to say, they are very rare. Each problem increases the recipe durations by 10%. Fixing the problems is done the same way as above.\n\nLater, you will unlock other Maintenance Hatches that do not enforce fixing the problems manually. Both start with §6no Maintenance required§r:\n\n- §3Automatic Maintenance Hatch§r (§1IV§r): Eliminates the need for Maintenance, §6forever§r.\n\n- §3Configurable Maintenance Hatch§r (§6HV§r): You can configure it to cut off §a10% duration§r on recipes, at the cost of making Maintenance issues happen three times as fast. That is §d16 real hours§r of activity. §9Tape§r can fix problems in this Hatch as well.\n",
+          "desc:8": "nomifactory.quest.db.893.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45756,7 +45757,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Maintenance and Muffler Mechanics",
+          "name:8": "nomifactory.quest.db.893.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45783,7 +45784,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2With the MV Assembling Machine, you can assemble a few necessary parts for the next Circuit tier.",
+          "desc:8": "nomifactory.quest.db.894.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45794,7 +45795,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2MV Assembling Machine",
+          "name:8": "nomifactory.quest.db.894.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45835,7 +45836,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The MV Assembling Machine allows you to craft Medium Voltage Coils, and your Precision Laser Engraver can make Ultra Low Power ICs with a Sapphire Lens.\n\nCombine them with some MV parts and you can finally craft an MV Energy Hatch.\n\nHigher tiers of energy hatch will require similar resources.\n\nNote: For extracting energy from GT multiblock generators, you will need Dynamo Hatches instead. Those are crafted similarly to Energy Hatches, but with Springs in place of 1x Cables.",
+          "desc:8": "nomifactory.quest.db.895.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45846,7 +45847,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2MV Energy Input",
+          "name:8": "nomifactory.quest.db.895.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45892,7 +45893,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Sodium Potassium is an alloy of... take a guess. \n\nIt\u0027s used in the construction of HV and above Energy and Dynamo hatches.",
+          "desc:8": "nomifactory.quest.db.896.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45907,7 +45908,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Sodium Potassium",
+          "name:8": "nomifactory.quest.db.896.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -45945,7 +45946,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2With Silver, LPICs, NaK, and an HV Assembler, you can finally make HV Energy and Dynamo hatches.\n\nYou should get the gist of making these now, so there will not be further quests on Energy and Dynamo hatches.",
+          "desc:8": "nomifactory.quest.db.897.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45956,7 +45957,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2HV Energy Hatch",
+          "name:8": "nomifactory.quest.db.897.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46054,7 +46055,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Hydrofluoric Acid is a dangerous acid made by mixing Hydrogen and Fluorine. It is used in the production of Polytetrafluoroethylene, and in Uranium and Naquadah processing.\n\nFluorine is best obtained from Topaz or Bastnasite Ore processing from their Microminer missions, or in small amounts from renewable Black Granite.",
+          "desc:8": "nomifactory.quest.db.899.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46069,7 +46070,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Hydrofluoric Acid",
+          "name:8": "nomifactory.quest.db.899.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46106,7 +46107,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2High-Octane Gasoline is the most powerful combustion fuel, generating 3200 EU per mB of fuel. This is required for production of Draconium.\n\nTo refine Gasoline to High-Octane Gasoline, you will need:\n- 20 parts Gasoline\n- 2 parts Octane\n- 2 parts Nitrous Oxide\n- 1 part Toluene\n- 1 part Ethyl Tert-Butyl Ether\n\nTo get the most out of this, run it in an Extreme Combustion Engine with Liquid Oxygen.",
+          "desc:8": "nomifactory.quest.db.900.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46121,7 +46122,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2High-Octane Gasoline",
+          "name:8": "nomifactory.quest.db.900.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46192,7 +46193,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The Tablet device you spawned with is very valuable to do plenty of tasks in GregTech.§r\n\nThis Quest explains how you can use the §4Terminal§.. §bThis is merely basic information, you can skip this for a while as the Terminal isn\u0027t used much in the early game§r.\n\nThe Terminal runs on §4GregOS™§r (not an actual Trademark), an operating system which works with §5Applications§r.\n\n§9Machines Guides§r, §9Multiblock Guides§r, §9Item Guides§r, §9§9Tutorials§r are what they sound like. Note that they are currently still being worked on.\n\n§9System Settings§r changes... settings (duh) related to the Terminal. You can §bset your own background picture§r, remove the double confirmation on exit, and more. Most of the keybinds apply to the §5Home§r button. Double clicking by default exists any open Application.\n\n§9Multiblock Helper§r is split into two functionalities. The first one requires a requires a §dLV§r Battery and a §dCamera§r mounted to enable §bVR visualization§r of multiblock structures. The upgrade unlocked at §6HV§r allows you to §6debug§r and §6auto-build§r.\n\n§9Battery Manager§r, assuming you have a Battery mounted, checks the Energy level and indicates energy usage of other Apps.\n\n§9Hardware Manager§r is used to mount Hardwares, such as Battery, to enable other Apps.\n\n§9App Store§r (not exactly a Store) adds Apps to your collection, and allows upgrades for some of them. Keep in mind Apps may still require specific mounted devices to function.\n\n§9Ore Prospector§r works the same way as the portable §dProspector§r and can be upgraded several times.\n\n§9Fluid Prospector§r works the same way as the portable §dProspector§r (but for fluids!) and can be upgraded several times.\n\n§9Recipe Chart§r is a wonderful chart planner to build Recipe Chains and visualize them.\n\n§9GT Console§r configures machines as if you were using regular tools, but without using them! This is similar to the remote access from the §3Central Monitor§r.\n\n§9World Prospector§r is a §dX-Ray VR§r for filtered blocks.\n\n§9Virtual Tank Viewer§r is used in combination with §3Ender Fluid Covers§r. It stores information about all your §dVirtual Tanks§r.\n\n§9Cape Selector§r lets you become fancy! You can have your characters wear a fancy §dCape§r.\",\n",
+          "desc:8": "nomifactory.quest.db.902.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46208,7 +46209,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Terminal",
+          "name:8": "nomifactory.quest.db.902.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46236,7 +46237,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2The coil recipes are harder in CEu, not only do they require their base material, they also need some extra material types and they must be made in Assembling Machines of their tier.\n\nFor Cupronickel Coils, you will need 8 Cupronickel, 2 Bronze, and 1 Tin Alloy for each coil. You need 16 for the Electric Blast Furnace and 16 for the Pyrolyse Oven. That totals to 176 Copper, 128 Nickel, 32 Tin, and 16 Iron.",
+          "desc:8": "nomifactory.quest.db.903.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46247,7 +46248,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Cupronickel Coils",
+          "name:8": "nomifactory.quest.db.903.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46287,7 +46288,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Bacterial Sludge will be used in the Crystal and Wetware processes.\n\nPlant matter in Plant Ball can be broken down to Bio Chaff, and broken down to Bacteria. Then, combine it with your Biomass to get Bacterial Sludge.\n\nYou will also get a bit back from growing Stem Cells later.",
+          "desc:8": "nomifactory.quest.db.904.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46302,7 +46303,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Bacterial Sludge",
+          "name:8": "nomifactory.quest.db.904.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46339,7 +46340,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Use §cCalifornium-252 §rto enrich Bacterial Sludge, and distill it to Mutagen.\n\nMutagen is used in Growth Medium production.",
+          "desc:8": "nomifactory.quest.db.905.ste.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46354,7 +46355,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Mutagen",
+          "name:8": "nomifactory.quest.db.905.ste.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46391,7 +46392,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Multiblock version of the Circuit Assembler. Can accept Parallel Control Hatches, and allows tiering it up more easily.",
+          "desc:8": "nomifactory.quest.db.906.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46402,7 +46403,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Large Circuit Assembler",
+          "name:8": "nomifactory.quest.db.906.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46534,7 +46535,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A mixture of §6Clay, Brick, §cQuartz Sand, Calcite, Gypsum, Stone Dust§r produces §6Firebricks§r, used in building the §3Primitive Blast Furnace§r. This allows you to make §6Steel§r from §6Wrought Iron§r, which forms the basis of LV Machine Hulls.",
+          "desc:8": "nomifactory.quest.db.909.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46545,7 +46546,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2§2Primitive Steelworks",
+          "name:8": "nomifactory.quest.db.909.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46598,7 +46599,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§2Rhodium Plated Lumium-Palladium is a mixture of Rhodium, Lumium and Palladium. It forms the basis of LuV Machine Hulls.",
+          "desc:8": "nomifactory.quest.db.910.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46609,7 +46610,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "§2Rhodium Plated Lumium-Palladium",
+          "name:8": "nomifactory.quest.db.910.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,
@@ -46649,7 +46650,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §6Battery Buffer§r is a machine which can hold §6Batteries§r for energy storage. Each Battery accepts up to 2 amps and outputs up to 1 amp.\n\nYou can also charge §6Electric tools§r in them.\n\n§cRF batteries such as Flux Capacitors cannot be drained by Battery Buffers!",
+          "desc:8": "nomifactory.quest.db.911.desc",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46660,7 +46661,7 @@
           "ismain:1": 0,
           "issilent:1": 0,
           "lockedprogress:1": 0,
-          "name:8": "LV Battery Buffer",
+          "name:8": "nomifactory.quest.db.911.title",
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
           "repeattime:3": -1,

--- a/overrides/resources/questbook/lang/en_us.lang
+++ b/overrides/resources/questbook/lang/en_us.lang
@@ -1,14 +1,14 @@
 # line 0
 nomifactory.quest.line.0.title=The Beginning
-nomifactory.quest.line.0.desc=GregTech Low Voltage Tier: start building a factory!%n%nUnlock access to §bDeep Mob Learning§r, early §bEnderIO§r tech, and §bApplied Energistics 2§r Digital Storage.%n%nBuild an §3Electric Blast Furnace§r for smelting advanced materials and alloys.
+nomifactory.quest.line.0.desc=GregTech §7Low Voltage§r Tier: start building a factory!%n%nUnlock access to §bDeep Mob Learning§r, early §bEnderIO§r tech, and §bApplied Energistics 2§r Digital Storage.%n%nBuild an §3Electric Blast Furnace§r for smelting advanced materials and alloys.
 
 # line 1
 nomifactory.quest.line.1.title=Early Game
-nomifactory.quest.line.1.desc=GregTech Medium Voltage Tier: new machines and rudimentary ore processing.%n%nOrganic Chemistry for §6Plastics§r, and build a §3Distillation Tower§r.%n%n§bApplied Energistics 2§r automation. Explore §bActually Additions§r.
+nomifactory.quest.line.1.desc=GregTech §bMedium Voltage§r Tier: new machines and rudimentary ore processing.%n%nOrganic Chemistry for §6Plastics§r, and build a §3Distillation Tower§r.%n%n§bApplied Energistics 2§r automation. Explore §bActually Additions§r.
 
 # line 2
 nomifactory.quest.line.2.title=Mid Game
-nomifactory.quest.line.2.desc=GregTech High Voltage, Extreme Voltage, and Insane Voltage tiers:%n%n§6§3Cryogenic Distillation§r, and petrochemistry for §6Epoxy§r and §9Nitro Diesel§r.%n%nCraft §6Nether Stars§r and unlock §bThermal Expansion§r machines.%n%nBuild a§b NuclearCraft§r fission reactor to obtain new materials.%n%nBuild a Space Station and Warp Core.
+nomifactory.quest.line.2.desc=GregTech §6High Voltage§r, §5Extreme Voltage§r, and §1Insane Voltage§r tiers:%n%n§6§3Cryogenic Distillation§r, and petrochemistry for §6Epoxy§r and §9Nitro Diesel§r.%n%nCraft §6Nether Stars§r and unlock §bThermal Expansion§r machines.%n%nBuild a§b NuclearCraft§r fission reactor to obtain new materials.%n%nBuild a Space Station and Warp Core.
 
 # line 3
 nomifactory.quest.line.3.title=Progression
@@ -16,7 +16,7 @@ nomifactory.quest.line.3.desc=It's always rewarding to take a step forward.%n%nT
 
 # line 4
 nomifactory.quest.line.4.title=Late Game
-nomifactory.quest.line.4.desc=GregTech LuV, ZPM, and UV tiers:%n%nBuild §3Assembly Lines§r, §3Fusion Reactors§r, and more!%n%nAutomate in style with §bPackagedAuto§r. Climb the tiers of §6Micro Miners§r.%n%n§bDraconic Evolution§r for fusion crafting and energy storage.
+nomifactory.quest.line.4.desc=GregTech §dLuV§r, ZPM, §3UV§r, §4UHV§r tiers:%n%nBuild §3Assembly Lines§r, §3Fusion Reactors§r, and more!%n%nAutomate in style with §bPackagedAuto§r. Climb the tiers of §6Micro Miners§r.%n%n§bDraconic Evolution§r for fusion crafting and energy storage.
 
 # line 5
 nomifactory.quest.line.5.title=End Game
@@ -44,7 +44,7 @@ nomifactory.quest.line.10.desc=Convert between matter and energy with §bApplied
 
 # db 0
 nomifactory.quest.db.0.title=Charging Quartz
-nomifactory.quest.db.0.desc=The main purpose for this device is to turn §6Certus Quartz Crystal§r into §6Charged Certus Quartz Crystal§r.%n%nThis device can be powered with RF via energy conduits or use AE energy from a network via ME conduits or cables.%n%nIt accepts power from two sides. Which two sides? It's pretty easy to guess.%n%n%n%n%n%n%n%n%nOk, ok. It's the top and bottom.%n%n
+nomifactory.quest.db.0.desc=The main purpose for this device is to turn §6Activated Certus Quartz Crystal§r into §6Charged Certus Quartz Crystal§r.%n%nThis device can be powered with RF via energy conduits or use AE energy from a network via ME conduits or cables.%n%nIt accepts power from two sides. Which two sides? It's pretty easy to guess.%n%n%n%n%n%n%n%n%nOk, ok. It's the top and bottom.
 
 # db 1
 nomifactory.quest.db.1.title=Crystal Growth Chamber
@@ -55,44 +55,44 @@ nomifactory.quest.db.2.title=Canning Machine and Assorted Stuff
 nomifactory.quest.db.2.desc=Note: this quest accepts both LV and MV Canning Machines.%n%n§aLV Batteries§r were very simple to make, but more effective forms of power storage will be more complex to build, so we'll need to lay the groundwork now.%n%nPut your §3Centrifuge§r to work for the §6Antimony§r you'll need, which comes in tiny piles from processing §6Tetrahedrite Ore§r and §6Stibnite Ore§r.%n%n
 
 # db 3
-nomifactory.quest.db.3.title=Genesis
-nomifactory.quest.db.3.desc=Welcome to §5Nomifactory§f!%n%nThis pack is intended to be played in a §bLost Cities / Overworld dimension§f.%n%nIf you're playing with friends, don't forget to invite them to the §equestbook party§f.%n%n§fIf you wish to build your base in a skyblock world, place the §6Void World Cake§f down on the ground, and eat a slice to be sent to the void. Please note that you'll still need to return to the Lost Cities / Overworld dimension to mine, but you can freely build in complete safety in the §eVoid World§f.
+nomifactory.quest.db.3.title=§2Genesis
+nomifactory.quest.db.3.desc=Welcome to §5Nomifactory§f §2GTCEu Edition§r!%n%nThis pack is intended to be played in a §bLost Cities / Overworld dimension§f.%n%nIf you're playing with friends, don't forget to invite them to the §equestbook party§f.%n%n§fIf you wish to build your base in a skyblock world, place the §6Void World Cake§f down on the ground, and eat a slice to be sent to the void. Please note that you'll still need to return to the Lost Cities / Overworld dimension to mine, but you can freely build in complete safety in the §eVoid World§f.%n%nFeatures new to §2CEu§r and quests with new content will be highlighted in §2dark green (colour 2)§r.
 
 # db 4
 nomifactory.quest.db.4.title=Iron Supply
-nomifactory.quest.db.4.desc=§c§rOres in §5Nomifactory§f exist in large clusters, or '§eveins§f'. These veins are scattered around the world, and are relatively common. The §aScanner§f in your inventory can detect any ore within 16 blocks of you, so digging down and scanning should show you any nearby veins. Try scanning now by holding §6right-click§f until the progress meter completes.%n%nWhile the Scanner requires energy to work, you are unlikely to deplete its battery. That said, the quest book will later guide you towards making a §aFlux Capacitor§f to charge tools in your inventory.%n%nIn order to proceed, you'll need to locate a source of §6Iron§f. You have a few options. §6Magnetite§f veins are higher up and contain large amounts of iron, as well as some §6Vanadium§f and §6Gold§f. Another good source of iron is §6Limonite§f veins, which contain several types of iron. Finally, §6Pyrite§f can be found paired with §6Copper§f in several types of veins.%n%n§6Wrought Iron§f is obtained simply by §esmelting Iron a second time§f. It has more durability than Iron, so it is better for making tools, but §cdo not convert your entire Iron supply over to Wrought Iron§f. The two materials are not interchangeable and you'll need Iron or Wrought Iron as demanded by various recipes.
+nomifactory.quest.db.4.desc=§c§rOres in §5Nomifactory§f exist in large clusters, or '§eveins§f'. These veins are scattered around the world, and are relatively common. §2The upgraded HV Electric Prospector's Scanner you were given will tell you the types of ores you can find within a 7x7 chunk area!%n§r%nWhile the Scanner requires energy to work, you are unlikely to deplete its battery. That said, the quest book will later guide you towards making §2an HV Battery§r to charge §aHV tools §rin your inventory.%n%nIn order to proceed, you'll need to locate a source of §6Iron§f. You have a few options. §6Magnetite§f veins are higher up and contain large amounts of iron, as well as some §6Vanadium§f and §6Gold§f. Another good source of iron is §6Limonite§f veins, which contain several types of iron. Finally, §6Pyrite§f can be found paired with §6Copper§f in several types of veins.%n%n§6Wrought Iron§f is obtained simply by §esmelting Iron a second time§f. It has more durability than Iron, so it is better for making tools, but §cdo not convert your entire Iron supply over to Wrought Iron§f. The two materials are not interchangeable and you'll need Iron or Wrought Iron as demanded by various recipes.
 
 # db 5
 nomifactory.quest.db.5.title=Mining Hammers
-nomifactory.quest.db.5.desc=§aMining Hammers§r offer a relatively cheap way to mine out areas much faster. They clear a 3x3 of blocks and mine quickly, so they're absolutely worth investing your first few ingots of metal into§..%n%n§6Stone§f is the cheapest Mining Hammer, but naturally it breaks quickly. Since you have some §6Iron§f already, consider using those on your first few mining expeditions.%n%nThe best Mining Hammers are §6Diamond§f and §6Platinum§f. Other Mining Hammers are also good but wear out more quickly.
+nomifactory.quest.db.5.desc=§aMining Hammers§r offer a relatively cheap way to mine out areas much faster. They clear a 3x3 of blocks and mine quickly, so they're absolutely worth investing your first few ingots of metal into§..%n%n§2GTCEu now has Mining Hammers natively! You can craft them with any GT tool material.
 
 # db 6
-nomifactory.quest.db.6.title=More Materials
-nomifactory.quest.db.6.desc=Before you continue, you'll need access to some more materials.%n%n§6Redstone§f: Found only deep in the world, in massive veins paired with §6Cinnabar§f and §6Ruby§f.%n%n§6Copper§f: Two primary sources. §6Tetrahedrite§f veins are higher up, while §6Chalcopyrite§f veins are lower, paired with some small amounts of §6Iron§f. You'll also find §6Malachite§f inside of Iron veins, this is another type of copper ore.%n%n§6Tin§f: Found essentially at ground level, and almost always detectable by §aScanner§f from the surface. §6Cassiterite§f is another type of tin ore, and they're always found together. If you cannot find a vein of tin, there are small amounts of tin inside veins of §6Aluminium§f and §6Rock Salt§f, which might be enough to hold you over until you find a proper tin vein.%n%n§6Coal§f: Found in relatively shallow depths. §6Lignite Coal§f is just a less pure and less effective form of Coal.%n%n§6Gold§f: Found inside of §6Magnetite§f veins, close to the surface.
+nomifactory.quest.db.6.title=§2More Materials
+nomifactory.quest.db.6.desc=Before you continue, you'll need access to some more materials. %n%n§6Redstone§f: Found only deep in the world, in massive veins paired with §6Cinnabar§f and §6Ruby§f.%n%n§6Copper§f: Two primary sources. §6Tetrahedrite§f veins are higher up, while §6Chalcopyrite§f veins are lower, paired with some small amounts of §6Iron§f. You'll also find §6Malachite§f inside of Iron veins, this is another type of copper ore.%n%n§6Tin§f: Found essentially at ground level. §6Cassiterite§f is another type of tin ore, and they're always found together. If you cannot find a vein of tin, there are small amounts of tin inside veins of §6Aluminium§f and §6Rock Salt§f, which might be enough to hold you over until you find a proper tin vein.%n%n§6Coal§f: Found in relatively shallow depths. §6Lignite Coal§f is §2removed.%n%n§6Gold§f: Found inside of §6Magnetite§f veins, close to the surface.
 
 # db 7
-nomifactory.quest.db.7.title=Cables
-nomifactory.quest.db.7.desc=The most basic cables, such as these §6Red Alloy Cables§f, can be wrapped in their §6Rubber§f insulation by hand.%n%nMore advanced types of cables will require an §3Assembling Machine§f and liquid §9Rubber§f, but you can do it the simple way for now.
+nomifactory.quest.db.7.title=§2Cables
+nomifactory.quest.db.7.desc=The most basic cables, such as these §6Red Alloy Cables§f, can be wrapped in their §6Rubber§f insulation by hand.%n%nMore advanced types of cables will require an §3Assembling Machine§f and liquid §9Rubber§f, but you can do it the simple way for now.%n%n§2CEu has GT6-style pipes and cables on by default. §rYou will need to use §aWire Cutters§r to connect each side of a cable to machines or other cables. Placing it against the machine or cable automatically connects it as well. The same behaviour follows for GT pipes, whose tool is the §aWrench§r.%nThis can save you from energy or fluids going the wrong way. But if you don't like this, disable the config option for "GT6 style pipes and cables" in the GregTech config file.%n%n§2GT cables now support RF conversion natively! §rYou can plug an §dRF§r machine into an §dEU§r cable directly and it will convert the energy.%n
 
 # db 8
 nomifactory.quest.db.8.title=The Third Tier Three Circuits
 nomifactory.quest.db.8.desc=With three §6Microcircuits§r and some standard components, you can upgrade to the penultimate Tier Three circuit: a §6Microprocessor§r.
 
 # db 9
-nomifactory.quest.db.9.title=Ore Doubling?
-nomifactory.quest.db.9.desc=In most expert packs, you want to try to process as little ore as possible before you get access to ore doubling. It's a habit most of us pick up.%n%n§eYou shouldn't feel any pressure to do that in Nomifactory, though§f. Ore veins are massive, and mining is extremely fast with §aMining Hammers§f. What's more, even once you get access to §3Macerators§f, they initially process ore slowly and require power to operate.%n%nObvious exceptions would be rare materials or anything you buy with §dOmnicoins §fbecause you can't find it. Those are worth doubling, if possible.%n%nBut at least for now, you shouldn't feel any guilt about smelting the more common ores without doubling them! §eOre doubling can be safely ignored until you have Medium Voltage machines or even later.§r
+nomifactory.quest.db.9.title=§2Ore Doubling?
+nomifactory.quest.db.9.desc=In most expert packs, you want to try to process as little ore as possible before you get access to ore doubling. It's a habit most of us pick up.%n%n§eYou shouldn't feel any pressure to do that in Nomifactory, though§f. Ore veins are massive, and mining is extremely fast with §aMining Hammers§f. What's more, even once you get access to §3Macerators§f, they initially process ore slowly and require power to operate.%n%nObvious exceptions would be rare materials or anything you buy with §dOmnicoins §fbecause you can't find it. Those are worth doubling, if possible.%n%nBut at least for now, you shouldn't feel any guilt about smelting the more common ores without doubling them! §eOre doubling can be safely ignored until you have the §2Steam Grinder§r§e, or Medium Voltage machines or even later.§r
 
 # db 10
-nomifactory.quest.db.10.title=Tier Two Micro Miner
-nomifactory.quest.db.10.desc=The Second Micro Miner!%n%nThis uses an §bExtended Crafting§r table so it's not possible to automate the Miner itself with §bApplied Energistics 2§r just yet (this requires more advanced technology not easy to access until the Tier Four Micro Miner). You can make it semi-automatically by prestocking the components you need, and filling up the Extended Crafting Table with §bJEI§r!%n%nThis Micro Miner can get you:§6%n* Bauxite Ore%n* Niobium Ore%n* Copper Ore%n* Tungstate Ore%n* Scheelite Ore%n* Cassiterite Ore%n* Radium Salt§r%n%nAs well as the §6Stellar Creation Data§r, which will be useful much, much later.
+nomifactory.quest.db.10.title=§2Tier Two Micro Miner
+nomifactory.quest.db.10.desc=The Second Micro Miner!%n%nThis uses an §bExtended Crafting§r table so it's not possible to automate the Miner itself with §bApplied Energistics 2§r just yet (this requires more advanced technology not easy to access until the Tier Four Micro Miner). You can make it semi-automatically by prestocking the components you need, and filling up the Extended Crafting Table with §bJEI§r!%n%nThis Micro Miner can get you:§6%n* Bauxite Ore%n§2* Pyrochlore Ore§6%n* Copper Ore%n* Tungstate Ore%n* Scheelite Ore%n* Cassiterite Ore%n* Radium Salt§r%n%nAs well as the §6Stellar Creation Data§r, which will be useful much, much later.
 
 # db 11
-nomifactory.quest.db.11.title=Electronics Subcomponents
-nomifactory.quest.db.11.desc=A "§esubstrate§f" is the "board" part of a circuit board... the backing that the circuit components and wires are laid into. A good substrate needs to not conduct electricity, for obvious reasons. §6Wood§r coated in §6Sticky Resin§r is a primitive but effective material to use as your first substrate.%n%nYou'll also need to make §6Vacuum Tubes§f, as well as some primitive §6Resistors§r. §6Paper§r will work as a material for these, for now.%n%nMake sure to code these recipes into a §3Crafting Station§r... you'll be making a LOT of these things.
+nomifactory.quest.db.11.title=§2Electronics Subcomponents
+nomifactory.quest.db.11.desc=A "§esubstrate§f" is the "board" part of a circuit board... the backing that the circuit components and wires are laid into. A good substrate needs to not conduct electricity, for obvious reasons. §6Wood§r coated in §6Sticky Resin§r is a primitive but effective material to use as your first substrate.%n%n§2CEu circuit progression means you also have to put wires on your substrates for them to be usable. In this case, use some Fine Copper Wires.§r%n%nYou'll also need to make §6Vacuum Tubes§f, as well as some primitive §6Resistors§r. §6Paper§r will work as a material for these, for now.%n%nMake sure to code these recipes into a §3Crafting Station§r... you'll be making a LOT of these things.
 
 # db 12
 nomifactory.quest.db.12.title=Some Starter Tools
-nomifactory.quest.db.12.desc=One of the eccentricities of the pack you'll need to get used to is the way the tools are displayed. Most tools can be made out of nearly any metal, and §bJEI§f will display a huge number of options... every combination of every tool with every material. However, the pattern to make the tool is always identical, so §ejust arrange the plates and ingots in the same manner as the examples, ignoring whatever material it says§f. Rods where rods go, plates where plates, etc. The only restriction is that tools §emust be made from all of the same material§f... you cannot mix and match different metals in a single item.%n%nRecipes will default to showing a "§6Darmstadtium§f" tool (or sometimes §6Aluminium§f) of the appropriate type if a tool is required, but the correct type of tool made out of any metal will work. Just ignore the tool's material in the recipes: it can be whatever you'd like.%n%nFor now, make a §aHammer§f (not a §aMining Hammer§f, mind you... six ingots, not five). Hammers can be used to turn §etwo ingots into one plate§f. §6Plates§f can make a §aFile§f, Files can make §6Rods§f, etc. Use JEI to work your way down the list of tools.%n%n§6Wrought Iron§f is probably your best bet for a tool material right now, but better materials will become available as you progress.
+nomifactory.quest.db.12.desc=One of the eccentricities of the pack you'll need to get used to is the way the tools are displayed. Most tools can be made out of nearly any metal, and §bJEI§f will display a huge number of options... every combination of every tool with every material. However, the pattern to make the tool is always identical, so §ejust arrange the plates and ingots in the same manner as the examples, ignoring whatever material it says§f. Rods where rods go, plates where plates, etc. The only restriction is that tools §emust be made from all of the same material§f... you cannot mix and match different metals in a single item.%n%nRecipes will default to showing a §6Neutronium tool §rof the appropriate type if a tool is required, but the correct type of tool made out of any metal will work. Just ignore the tool's material in the recipes: it can be whatever you'd like.%n%nFor now, make a §aHammer§f (not a §aMining Hammer§f, mind you... six ingots, not five). Hammers can be used to turn §etwo ingots into one plate§f. §6Plates§f can make a §aFile§f, Files can make §6Rods§f, etc. Use JEI to work your way down the list of tools.%n%n§6Wrought Iron§f is probably your best bet for a tool material right now, but better materials will become available as you progress.
 
 # db 13
 nomifactory.quest.db.13.title=Batch Crafting In Style
@@ -127,12 +127,12 @@ nomifactory.quest.db.20.title=Furnace v6.0
 nomifactory.quest.db.20.desc=§3Diamond Furnaces§f are the fastest available, taking only §a25 ticks§f to smelt an item.
 
 # db 21
-nomifactory.quest.db.21.title=Steel
-nomifactory.quest.db.21.desc=§6Steel§r is a basic component in all sorts of machines and alloys. It is made in the §3Alloy Smelter§r.%n%nYou might want to save your §6Coal Dust§r for circuits and use §6Charcoal Dust§r instead. Later, you can also centrifuge either of these dusts or §6Coal Coke Dust§r into §6Carbon Dust§r, which can be used for Steel and other useful things.
+nomifactory.quest.db.21.title=§2Steel
+nomifactory.quest.db.21.desc=You already have §6Steel§r, but it can be made much faster in the §3Alloy Smelter§r, at the cost of EU.%n%nYou might want to save your §6Coal Dust§r for circuits and use §6Charcoal Dust§r instead. Later, you can also process either of these dusts, §6Coal Coke Dust§r, §2or Diamond Dust§r into §6Carbon Dust§r, which can be used for Steel and other useful things.
 
 # db 22
-nomifactory.quest.db.22.title=Pyrolyse Oven
-nomifactory.quest.db.22.desc=The main function of this oven is to increase the fuel values of your wood and coal while also recovering some of the various potentially useful waste products.%n%nTurning §6Coal§r into §6Coal Coke§r will not only make it more useful as fuel, but will also produce §9Phenol§r, which you'll need for circuits.%n%nThe Pyrolyse Oven is also the source of several other fluids that can be distilled for useful ingredients.%n%nYou can §6sneak-right click§r the controller to enable the in-world preview.%n
+nomifactory.quest.db.22.title=§2Pyrolyse Oven
+nomifactory.quest.db.22.desc=The main function of this oven is to increase the fuel values of your wood and coal while also recovering some of the various potentially useful waste products.%n%nTurning §6Coal§r into §6Coal Coke§r will not only make it more useful as fuel, but will also produce §9Phenol§r, which you'll need for circuits.%n%nThe Pyrolyse Oven is also the source of several other fluids that can be distilled for useful ingredients.%n%nYou can §6sneak-right click§r the controller to enable the in-world preview.%n%n§2As stated in the tooltip, higher tier coils will make this faster.%n
 
 # db 23
 nomifactory.quest.db.23.title=Obsidian
@@ -179,20 +179,20 @@ nomifactory.quest.db.33.title=Basic Capacitor Bank
 nomifactory.quest.db.33.desc=Expandable multi-block storage for RF power.%n%nThis first tier isn't much, but you can upgrade them over time to hold substantial amounts of power.
 
 # db 34
-nomifactory.quest.db.34.title=Energetic Alloy
-nomifactory.quest.db.34.desc=An §bEnderIO§r alloy, made from §6Energetic Blend§r and a §6Gold Ingot§r in your new §3Electric Blast Furnace§r.%n%nThrow both ingredients into the input bus and in twenty seconds your §6Energetic Alloy Ingot§r will be in the output bus.
+nomifactory.quest.db.34.title=§2Energetic Alloy
+nomifactory.quest.db.34.desc=An §bEnderIO§r alloy, made from §2mixing§r §22 Gold Dust, 1 Redstone Dust, and 1 Glowstone Dust§r §2and putting it §rin your new §3Electric Blast Furnace§r.%n%nThrow §2the prepared dust into the input bus§r and in twenty seconds your §6Energetic Alloy Ingot§r will be in the output bus.%n%n§2In EV Age, you can build an Alloy Blast Smelter which doubles the yield.
 
 # db 35
-nomifactory.quest.db.35.title=Vibrant Alloy
-nomifactory.quest.db.35.desc=An EnderIO alloy.
+nomifactory.quest.db.35.title=§2Vibrant Alloy
+nomifactory.quest.db.35.desc=An EnderIO alloy.%n%n§2In EV Age, you can build an Alloy Blast Smelter which doubles the yield.
 
 # db 37
 nomifactory.quest.db.37.title=Rubber Sheets
 nomifactory.quest.db.37.desc=Going out in search of a §6Rubber Tree§f is a viable option for sure. However, if this isn't appealing, you can also §eshear leaves§f and make §6Plantballs§f out of them. Plantballs smelt into §6Slime§f, and Slime smelts into §6Rubber§f.%n%nYou'll want to transition to Rubber Trees at some point, though, since the §eratio of leaves to rubber is quite poor§f.%n%nRubber can be hammered into sheets just like metals can be turned to plates. It's quite inefficient to do it this way, but such is the life of early game §bGregTech§f. At least rubber isn't particularly hard to come by.
 
 # db 38
-nomifactory.quest.db.38.title=LV CEF
-nomifactory.quest.db.38.desc=§oNote: this quest accepts the 4x or 16x CEF (LV).§r%n%nUntil now you have been generating §aRF power§r with your §3Steam Dynamos§r, but §bGregTech§r machines require §aEU power§r. With your first §6circuit§r in hand, you are ready to build a §eLow Voltage (LV) §3CEF§r.%n%nThe §3CEF§r is a special device that §econverts §aRF power§r into §aEU power§r. CEFs come in two sizes: §e4 Amps§r and §e16 Amps§r, which have 4 and 16 inventory slots, respectively. Each slot in a CEF can hold a single §6Battery§r.%n%nYou don't §oneed§r to put §bGregTech§r batteries inside the CEF§r, but keep in mind that §ethe CEF will be restricted to at most outputting one amp per battery inside§r if you do. With no batteries, they will output up to their rated number of amps as needed.%n%n§aRF§r converts into §aEU§r at a §e4 to 1 ratio§r. §a100 RF§r becomes §a25 EU§r, and vice-versa. If you ever switch over to being primarily powered by §aEU§r, a device called the §3CEU§r can switch power from §aEU§r into §aRF§r.
+nomifactory.quest.db.38.title=§2LV Power
+nomifactory.quest.db.38.desc=§oNote: this quest accepts any §2§oLV Energy Converter§r§o.%n%n§rUntil now you have been generating §aRF power§r with your §3Steam Dynamos§r, but §bGregTech§r machines require §aEU power§r. With your first §6circuit§r in hand, you are ready to build a §eLow Voltage (LV) §3§2Energy Converter§r.%n%nThe §2Energy Converter§r is a special device that §econverts §2between §aRF power§r and §aEU power§r. They come in §2four sizes: 1A, 4A, 8A, and 16A.%n%n§aRF§r converts into §aEU§r at a §e4 to 1 ratio§r. §a100 RF§r becomes §a25 EU§r, and vice-versa. §2Use a Soft Hammer to change the conversion direction.
 
 # db 39
 nomifactory.quest.db.39.title=Item Conduits
@@ -231,52 +231,52 @@ nomifactory.quest.db.49.title=Air Centrifuging
 nomifactory.quest.db.49.desc=Note: this quest accepts LV/MV/HV Centrifuge.%n%nCentrifuging air is a reliable way to get §9Nitrogen§r before you have access to §3Cryogenic Distillation§r.%n%n
 
 # db 50
-nomifactory.quest.db.50.title=Pressurized Fluid Conduits
-nomifactory.quest.db.50.desc=§bEnderIO§f conduits are the preferred way to move fluids around, rather than GregTech pipes. Incredibly flexible and powerful, they'll make fluid crafting almost bearable.
+nomifactory.quest.db.50.title=§2Fluid Transport
+nomifactory.quest.db.50.desc=§b§2GTCEu Fluid Pipes have been reworked and work much better now. There are also Quadruple and Nonuple pipes for transporting multiple fluid types through the same block. Their advantage over EnderIO Fluid Conduits is their higher throughput - 414 mB/t for a low-tier (Normal Potin) pipe.%n%n§rHowever, EnderIO Fluid Conduits still have the advantage of being EnderIO Conduits, allowing them to fit in the same block as other Conduits. Pick your poison.
 
 # db 51
 nomifactory.quest.db.51.title=Inscriber
 nomifactory.quest.db.51.desc=§3Inscribers§r are machines used to make §6inscribed circuits§r for §bApplied Energistics§r.
 
 # db 52
-nomifactory.quest.db.52.title=LV Cluster Mill
-nomifactory.quest.db.52.desc=Before you get access to easier circuits, you will need to be able to make §6Foils§r.%n%nThat's the purpose of the §3Cluster Mill§r.
+nomifactory.quest.db.52.title=§2Cleanroom
+nomifactory.quest.db.52.desc=§2Coming soon!
 
 # db 53
-nomifactory.quest.db.53.title=LV Wiremill
-nomifactory.quest.db.53.desc=The §3Wiremill§r is a major efficiency boost, giving you a much greater yield of §6wires§r for your ingots. But first, you'll need to make some §6Motors§r.%n%n§bGregTech§r machines are built from a number of components, many of which are shared between the machines. Motors§r are used in a great number of recipes, even including other components.%n%nMake sure to encode the recipes needed for motors into a §3Crafting Station§r. You'll need quite a lot of them.%n%nAfter you make the Wiremill, §econsider making a few stacks§r of LV motors. This might sound extreme, but §ebatch crafting§r in this manner is an important habit to pick up. This way you won't have to craft more for a while, and you §owill §ruse all those motors eventually, so you're not wasting materials.%n%nAs you get access to more machinery you will no longer need to craft things manually. Instead, you will engineer factories to automate the production for you. It is useful to keep a stockpile of frequently used things like circuits and components crafted so you don't have to wait for them when you need them.%n%n
+nomifactory.quest.db.53.title=§2LV Wiremill
+nomifactory.quest.db.53.desc=The §3Wiremill§r is a major efficiency boost, giving you a much greater yield of §6wires§r for your ingots. But first, you'll need to make some §6Motors§r.%n%n§bGregTech§r machines are built from a number of components, many of which are shared between the machines. Motors§r are used in a great number of recipes, even including other components.%n%nMake sure to encode the recipes needed for motors into a §3Crafting Station§r. You'll need quite a lot of them.%n%nAfter you make the Wiremill, §econsider making a few stacks§r of LV motors. This might sound extreme, but §ebatch crafting§r in this manner is an important habit to pick up. This way you won't have to craft more for a while, and you §owill §ruse all those motors eventually, so you're not wasting materials.%n%nAs you get access to more machinery you will no longer need to craft things manually. Instead, you will engineer factories to automate the production for you. It is useful to keep a stockpile of frequently used things like circuits and components crafted so you don't have to wait for them when you need them.%n%n§2If the machine sounds start to get on your nerves, you can mute GT machines with a GT Hammer.
 
 # db 54
 nomifactory.quest.db.54.title=Quantum Eyes
 nomifactory.quest.db.54.desc=When §6Ender Eyes§r just aren't creepy enough.%n%nYou'll need an HV or better §3Chemical Bath§r to make these. The recipe is quite slow, so invest in the highest tier Chemical Baths you can and consider parallelizing the recipe.
 
 # db 55
-nomifactory.quest.db.55.title=Centrifuge
-nomifactory.quest.db.55.desc=Note: this quest accepts an LV, MV or HV Centrifuge.%n%n§3Centrifuges§r provide you with 3 tiny piles of additional materials when processing ore dusts (§e9 tiny piles=1 dust§r). Sometimes it's the main dust, but often it's a different useful material that is otherwise unobtainable.%n%nInstead of washing §6impure dusts§r (made from macerating or hammering ores) in a cauldron, you can get more out of each dust by centrifuging it. The same is true of §6pure dusts§r, when you eventually make a §3Washer§r or §3Chemical Bath§r. Note however that pure and impure dusts will usually give different byproducts (always check in §bJEI§r).%n%nCentrifuges also have other uses like unmixing compound dusts and fluids, or getting §6Rubber Pulp§r, which can be chemically reacted with §6Sulfur§r to efficiently make §9liquid Rubber§r.%n%n
+nomifactory.quest.db.55.title=§2Centrifuge
+nomifactory.quest.db.55.desc=§3Centrifuges§r provide you with §21 tiny pile§r of additional materials when processing ore dusts (§e9 tiny piles=1 dust§r). Sometimes it's the main dust, but often it's a different useful material that is otherwise unobtainable.%n%nInstead of washing §6impure dusts§r (made from macerating or hammering ores) in a cauldron, you can get more out of each dust by centrifuging it. The same is true of §6pure dusts§r, when you eventually make a §3Washer§r or §3Chemical Bath§r. Note however that pure and impure dusts will usually give different byproducts (always check in §bJEI§r).%n%nCentrifuges also have other uses like unmixing compound dusts and fluids, or getting §6Rubber Pulp§r, which can be chemically reacted with §6Sulfur§r to efficiently make §9liquid Rubber§r.%n%n
 
 # db 56
 nomifactory.quest.db.56.title=Putting It All Together
-nomifactory.quest.db.56.desc=Now that you have everything you need to power your machines, it's time to put it all together.%n%nYour Steam Dynamo needs burnable fuel (like §6Coal§r) and §9water§r. It will output RF power through the Excitation Coil (the red bit at the top). The orientation of the Steam Dynamo can be adjusted with a §aCrescent Hammer§r, if needed.%n%n§6Energy Conduits§r can be used to transfer that RF power, but the dynamo can also output RF directly into a CEF by making the Excitation Coil touch the CEF.%n%nThe CEF transforms RF power into EU, outputting the resulting EU through the side with a red dot. The orientation can be adjusted using a §aWrench§r. Attach your §6Conductive Iron Cables§r to the output side of the CEF.%n%nNow all you need are some §bGregTech§r machines to hook up to the cables! You can make whatever you want, but its recommended that you get these two first:%n%nThe §6Wiremill§r will make crafting wires much, much easier.%n%nThe §6Compressor§r will make Plates from one ingot instead of two.
+nomifactory.quest.db.56.desc=Now that you have everything you need to power your machines, it's time to put it all together.%n%nYour Steam Dynamo needs burnable fuel (like §6Coal§r) and §9water§r. It will output RF power through the Excitation Coil (the red bit at the top). The orientation of the Steam Dynamo can be adjusted with a §aCrescent Hammer§r, if needed.%n%n§6Energy Conduits§r can be used to transfer that RF power, but the dynamo can also output RF directly into an Energy Converter by making the Excitation Coil touch the Energy Converter.%n%nThe Energy Converter transforms RF power into EU, outputting the resulting EU through the side with a red dot. The orientation can be adjusted using a §aWrench§r. Attach your §6Conductive Iron Cables§r to the output side of the Energy Converter.%n%nNow all you need are some §bGregTech§r machines to hook up to the cables! You can make whatever you want, but its recommended that you get these two first:%n%nThe §6Wiremill§r will make crafting wires much, much easier.%n%nThe §2Metal Bender§r will make Plates from one ingot instead of two.
 
 # db 57
 nomifactory.quest.db.57.title=Ender Fluid Conduits
 nomifactory.quest.db.57.desc=§aEnder Fluid Conduits§r are the most powerful fluid transportation mechanism offered by §bEnderIO§r.%n%nNot only are these faster than §aPressurized Fluid Conduits§r, but because they teleport fluids instead of flowing them in the conduits, it possible to have a large number of fluids moving through a single line.%n%nIn addition to §aFilters§r they also have multiple channels which can be used to direct fluids through the same conduits to various destinations.%n%nIf you don't want to (or haven't unlocked access to) routing fluids through §bAE§r, these are your best alternative.
 
 # db 58
-nomifactory.quest.db.58.title=LV Power Storage
-nomifactory.quest.db.58.desc=§6Batteries§r are §bGregTech §rpower storage for §aEU§r energy.%n%nAlthough there are several types of rechargeable batteries you can make, §6Cadmium Batteries§r are the best ones, as they have the most storage capacity. §6Lithium§r is second best, and §6Sodium§r is third.%n%n§6Lithium§r is possible to find inside of §6Tungsten§r veins, however, they are fairly rare. Consider "buying" some Lithium with §dOmnicoins§r.%n%n§6Cadmium§r is so tough to get at this point, it's not even worth considering. However, §6Sodium§r is plentiful. You can get Sodium by smelting §6Salt§r, with other options becoming available later.
+nomifactory.quest.db.58.title=§2LV Power Storage
+nomifactory.quest.db.58.desc=§6Batteries§r are §bGregTech §rpower storage for §aEU§r energy.%n%nAlthough there are several types of rechargeable batteries you can make, §2Lithium Batteries§r are the best ones, and the only ones you should really consider making.%n%n§6Lithium§r is possible to find inside of §6Tungsten§r veins, however, they are fairly rare. Consider "buying" some Lithium with §dOmnicoins§r.
 
 # db 59
 nomifactory.quest.db.59.title=Copper... Nickel... Cupronickel?
 nomifactory.quest.db.59.desc=Nickel comes from several different ores, including Pentlandite and Garnierite, but they're all found in the same vein.%n%nNickel is used mostly for several very important alloys, including Invar and Cupronickel.
 
 # db 60
-nomifactory.quest.db.60.title=Blast Furnace Fun
-nomifactory.quest.db.60.desc=The §3Electric Blast Furnace§r is a major, major milestone in your §bGregTech§r career. It has the power to smelt more advanced materials. The first of which, §6Aluminium§r, is going to be important in the immediate future.%n%nThere is a diagram of how to build the EBF in §bJEI§r. The second and third levels must be a 3x3 square shape of Coil Blocks (§6Cupronickel§r is the only type of coil block you have access to for now) with an empty center. You can also §6sneak-right click§r the controller to enable the in-world preview.%n%nHowever, the bottom and top layers are very flexible. The §6EBF Controller§r must be on the §ebottom layer§r of the structure, and on the §emiddle of an outer edge§r. Otherwise, you can put the hatches and buses wherever you want, filling in all gaps in each layer with §6Heatproof Machine Casings§r. It's worth noting that you must §euse at least 10 Heatproof Machine Casings in your layout or the structure will not form§r.%n%nThis quest calls for two energy hatches, a fluid input and output, and an item input and output, which is a total of six positions. Their specific order and placement don't matter, as long as you can access them. The seventh position is your EBF controller, leaving eleven gaps to be filled by Heatproof Machine Casings. If you did everything right, the structure will form: the colors on its hatches and casings will unify, and the controller will say "Idling."%n%nYou'll most likely want to locate your power quite near to the EBF. It is very power hungry, and if it cannot get enough energy, progress on the current item smelting will start to regress. Be careful to ensure the EBF has enough power, and keep a Soft Hammer nearby to pause it by tapping the controller if you run out of power.
+nomifactory.quest.db.60.title=§2Blast Furnace Fun
+nomifactory.quest.db.60.desc=The §3Electric Blast Furnace§r is a major, major milestone in your §bGregTech§r career. It has the power to smelt more advanced materials. The first of which, §6Aluminium§r, is going to be important in the immediate future.%n%nThere is a diagram of how to build the EBF in §bJEI§r. The second and third levels must be a 3x3 square shape of Coil Blocks (§6Cupronickel§r is the only type of coil block you have access to for now) with an empty center. You can also §6sneak-right click§r the controller to enable the in-world preview.%n%nHowever, the bottom and top layers are very flexible. The §6EBF Controller§r must be on the §ebottom layer§r of the structure, and on the §emiddle of an outer edge§r; the §6Muffler Hatch§r must be in the §eexact middle of the top layer§r. Otherwise, you can put the hatches and buses wherever you want, filling in all gaps in each layer with §6Heatproof Machine Casings§r. It's worth noting that you must §euse at least §29§e Heatproof Machine Casings in your layout or the structure will not form§r.%n%nThis quest calls for a §2maintenance hatch§r, two energy hatches, a fluid input and output, and an item input and output, which is a total of 7 positions. Their specific order and placement don't matter, as long as you can access them. The 8th position is your EBF controller, leaving 9 gaps to be filled by Heatproof Machine Casings. If you did everything right, the structure will form: the colors on its hatches and casings will unify, and the controller will say "Idling."%n%nYou'll most likely want to locate your power quite near to the EBF. It is very power hungry, and if it cannot get enough energy, progress on the current item smelting will start to regress. Be careful to ensure the EBF has enough power, and keep a Soft Hammer nearby to pause it by tapping the controller if you run out of power.%n%n§2In GTCEu, all hatches except Maintenance can be shared between Multiblocks!
 
 # db 61
-nomifactory.quest.db.61.title=Gemstone Sensor
-nomifactory.quest.db.61.desc=Some Micro Miner missions use a §6Gemstone Sensor§r to scout out gems instead of ores.%n%nSeveral materials like §6Exquisite Gems§r can only be obtained from such missions.
+nomifactory.quest.db.61.title=§2Gemstone Sensor
+nomifactory.quest.db.61.desc=Some Micro Miner missions use a §6Gemstone Sensor§r to scout out gems instead of ores.%n%n§6§2Perfect Gems§r can be obtained from such missions.
 
 # db 62
 nomifactory.quest.db.62.title=Terminal
@@ -291,8 +291,8 @@ nomifactory.quest.db.64.title=Digital Storage At Last
 nomifactory.quest.db.64.desc=§bApplied Energistics§r uses §6Storage Cells§r as its primary means of digital item and fluid storage.%n%nAll unformatted Storage Cells are limited to at most 63 distinct item types, with the first item of each new type taking up a chunk of the total bytes of cell storage, and subsequent items of existing types taking a small number of bytes thereafter.%n%nA §61k ME Storage Cell§r is the first and smallest cell for storing items. If you are going to be storing many different kinds of items in your network, you will need to make an §6ME Drive§r and fill it with multiple Storage Cells.%n%nThe §64k ME Storage Cell§r is the next size up. With four times the bytes it holds substantially more items per type, but it requires a more advanced technology than you currently have available: AE §6Processors§r made in an §3Inscriber§r.
 
 # db 65
-nomifactory.quest.db.65.title=Tier Three Micro Miner
-nomifactory.quest.db.65.desc=The Third Micro Miner.%n%nThis one can get you:%n§6* Tetrahedrite Ore%n* Cassiterite Ore%n* Tungstate Ore%n* Scheelite Ore%n* Redstone Ore%n* Quartz Ore%n* Vanadium Magnetite Ore%n* Rutile Ore%n* Tin Ore%n* Sapphire Ore§r%n%nWhen equipped with Gemstone Sensor:%n§6* Exquisite Emeralds%n* Exquisite Diamonds%n* Exquisite Rubies%n* Silver Ore%n* Gold Ore%n* Almandine Ore§r
+nomifactory.quest.db.65.title=§2Tier Three Micro Miner
+nomifactory.quest.db.65.desc=The Third Micro Miner.%n%nThis one can get you:%n§6* Tetrahedrite Ore%n* Cassiterite Ore%n* Tungstate Ore%n* Scheelite Ore%n* Redstone Ore%n* Quartz Ore%n* Vanadium Magnetite Ore%n§2* Ilmenite Ore§6%n* Tin Ore%n* Sapphire Ore§r%n§6* Almandine Ore§r%n%nWhen equipped with Gemstone Sensor:%n§6§2* Perfect Emeralds%n* Perfect Diamonds%n* Perfect Rubies%n* Perfect Topaz%n§6* Silver Ore%n* Gold Ore
 
 # db 66
 nomifactory.quest.db.66.title=From Dusts To Wires
@@ -307,20 +307,20 @@ nomifactory.quest.db.68.title=Experience Obelisk
 nomifactory.quest.db.68.desc=The §3Experience Obelisk§r is a mass storage device for player experience in the form of §9Liquid XP§r.%n%nVia the GUI you can insert or extract levels as needed, as well as configure interactions with neighboring blocks (as is typical of §bEnderIO§r machines).%n%nLiquid XP can also be pumped in directly from your automation such as §3Fluid Extractors§r.
 
 # db 69
-nomifactory.quest.db.69.title=Aluminium Ingots
-nomifactory.quest.db.69.desc=With your EBF running, start to create a supply of §6Aluminium Ingots§r. These are crucial ingredients for MV machines, including §bApplied Energistics§r.%n%nIf you find your power supply is faltering, you may want to make additional dynamos and turn them into steam boilers and turbines. Upgrading your dynamos is also advisable.%n%nHowever, you're also about to reach MV. You're bound to discover a better power source than steam before long.
+nomifactory.quest.db.69.title=§2Aluminium Ingots
+nomifactory.quest.db.69.desc=With your EBF running, start to create a supply of §6Aluminium Ingots§r. These are crucial ingredients for MV machines, including §bApplied Energistics§r.%n%n§2With LV power, you can only get Aluminium Dust from electrolyzing Clay Dust, Sapphire Dust or Green Sapphire Dust. Once you make an MV Electrolyzer, you can get it from a plethora of other raw resources.§r%n%nIf you find your power supply is faltering, you may want to make additional dynamos and turn them into steam boilers and turbines. Upgrading your dynamos is also advisable.%n%nHowever, you're also about to reach MV. You're bound to discover a better power source than steam before long.%n%n§2You can cut by a third the smelting time of Aluminium and some other smelting processes with Nitrogen gas. Higher-tier processes may take different gases.
 
 # db 70
 nomifactory.quest.db.70.title=MV Power Storage
-nomifactory.quest.db.70.desc=§aMV Batteries§r function essentially the same as §aLV Batteries§r, only stronger. They also need to be put into an §3MV CEF§r or §3MV Battery Buffer§r.
+nomifactory.quest.db.70.desc=§aMV Batteries§r function essentially the same as §aLV Batteries§r, only stronger. They also need to be put into an §3MV Machine§r or §3MV Battery Buffer§r.
 
 # db 71
 nomifactory.quest.db.71.title=MV Electrolyzer
 nomifactory.quest.db.71.desc=An §3MV Electrolyzer§r allows you to process recipes that require up to 128 EU/t, and can optionally overclock recipes costing at most 32 EU/t.%n%nThis means you can split more kinds of things for useful products.%n
 
 # db 72
-nomifactory.quest.db.72.title=LV Assembling Machine
-nomifactory.quest.db.72.desc=§3Assembling Machines§r are the linchpin of your factory, gating progression through the §6Circuits§r. %n%nEach time you upgrade to a new voltage of Assembling Machine, you will be able to craft more advanced §ethemes§r of circuits. These use more complex ingredients and require new infrastructure to be in place, but are more efficient to craft overall than the same tier of circuit from the prior theme.%n%nCheck out the §dProgression quest book tab§r to see the flow of circuit progression.%n%nAssembling Machines also open up a plethora of §eequal or more efficient recipes that don't require hand tools§r. Hand tool recipes also don't play nice with §bApplied Energistics§r.%n%nTake advantage of Assembling Machines: §cphase out all use of hand tools for crafting items in your automation going forward.§r Once you have all the important machines, you will never need hand tools for crafting.
+nomifactory.quest.db.72.title=§2LV Assembling Machine
+nomifactory.quest.db.72.desc=§2Assembling Machines come early in CEu! Circuit recipes are handled through a separate machine, the Circuit Assembler. §r%n%nAssembling Machines open up a plethora of §eequal or more efficient recipes that don't require hand tools§r. §2For example, you can make up to 6 Vacuum Tubes in a single craft! Many of its recipes will require fluids.§r Hand tool recipes also don't play nice with §bApplied Energistics§r.%n%nTake advantage of Assembling Machines: §cphase out all use of hand tools for crafting items in your automation going forward.§r Once you have all the important machines, you will never need hand tools for crafting.
 
 # db 73
 nomifactory.quest.db.73.title=ME Conduit
@@ -335,24 +335,24 @@ nomifactory.quest.db.75.title=Machine Block
 nomifactory.quest.db.75.desc=The §6Machine Block§r is the first step into a mod called §bExtra Utilities 2§r.
 
 # db 76
-nomifactory.quest.db.76.title=The First Tier Two Circuits
-nomifactory.quest.db.76.desc=Your first §6Tier Two Circuits§r will require four §6Tier One Circuits§r plus a §6Diode§r made with §6Gallium§r to craft.%n%nThese are rather expensive... Always be on the lookout for a cheaper way to make your circuits- new sets of recipes become available each time you make a new tier of §3Assembling Machine§r.
+nomifactory.quest.db.76.title=§2The First Tier Two Circuits
+nomifactory.quest.db.76.desc=Your first §6Tier Two Circuits§r will require §2two §6Tier One Circuits§r plus §2two §6Diodes§r.%n%nThese are rather expensive... Always be on the lookout for a cheaper way to make your circuits - new sets of recipes become available each time you make a new tier of §2Circuit Assembler§r. Conveniently, this tier of Circuit unlocks one now!
 
 # db 77
-nomifactory.quest.db.77.title=Exquisite Gems
-nomifactory.quest.db.77.desc=§6Exquisite Gems§r are mostly needed for crafting special materials.%n%nIf you don't need them for that though, they can be cut through two cycles in a §3Cutting Machine§r into eight of the basic version of that gem.
+nomifactory.quest.db.77.title=§2Perfect Gems
+nomifactory.quest.db.77.desc=§2Perfect Gems are equivalent to 8 of the base gem.%n%n§211 Perfect Diamonds are used in crafting each Crystal Matrix Ingot.
 
 # db 78
-nomifactory.quest.db.78.title=Gallium
-nomifactory.quest.db.78.desc=Throwing §6Impure Piles of Sphalerite§r into Cauldrons is the first way of obtaining §6Sphalerite§r, which can be electrolyzed as a good source of §6Gallium§r. The §6Zinc§r and §6Sulfur§r you get from doing this will be quite useful as well. Sphalerite Ore§r spawns in §6Zinc§r veins. %n%nA §3Centrifuge§r instead of a Cauldron is slower and requires power, but it gets you more Gallium while separating the impure dust into Sphalerite.%n%nIf you're having trouble getting the quest to complete, check to see if you are holding §6small piles§r instead of §6tiny piles§r. If so, combine four small piles into a regular dust, then split that into tiny piles. A §3Crafting Station§r can help you quickly convert between pile types.
+nomifactory.quest.db.78.title=§2Gallium Arsenide
+nomifactory.quest.db.78.desc=§2Initial circuit components are a bit more difficult in CEu, and you need Arsenic in addition to Gallium.§r%n%nFor §dGallium§r, you may, ranged from worst to best:%n%n- §3Electrolyze §aSphalerite§r for a low chance of small dust. Note that you lose on direct smelting value.%n%n-§r Put §aCrushed Bauxite§r in the §3Chemical Bath§r. Note that this requires §9Sodium Persulfate§r. %n%n- Obtain it as a Byproduct of §aSphalerite§r Ore Processing, in the §3Thermal Centrifuge§r or §3Centrifuge§r.%n%n§2For Arsenic, you must centrifuge Realgar Dust, or (more involvedly) flash smelt Cobaltite Dust in the EBF, and electrolyse the resultant Arsenic Trioxide.%n%nCombine both in a Mixer to make Gallium Arsenide.
 
 # db 79
-nomifactory.quest.db.79.title=MV Cutting Machine
-nomifactory.quest.db.79.desc=Cuts things up.%n%nThe §3Cutting Machine§r is able to cut wafers, rods, wood, and various other things for you, making it a versatile crafting tool. Cutting blocks into 9 plates is much faster than using a §3Compressor§r to make them one at a time, and some plates can't be made in a Compressor at all.%n%nThe blade will require you to make §6Cobalt Brass§r. §6Cobalt§r is a byproduct obtained (likely first as tiny piles) from processing any of various ores, §6Zinc§r you should have already from electrolyzing §6Sphalerite§r, and the other materials are just §6Copper§r and §6Aluminium§r. If you're having trouble, keep in mind that §bJEI§r has a tab for ore processing byproducts that you can get to by looking up recipes for the regular-sized dust.%n%nCutting Machines work with plain §9Water§r for all recipes. You can also use §9Distilled Water§r which speeds up the processing somewhat, or §9Lubricant§r that speeds it up greatly (and uses very little per operation). These might be a little tricky to make right now, but are very worthwhile upgrades in the future.%n%nYou might consider waiting until you have §6Electronic Processors§r before progressing too far down the path of MV machines, since these circuits are much easier to make than §6Primitive Processors§r.
+nomifactory.quest.db.79.title=§2Cutting Machine
+nomifactory.quest.db.79.desc=Cuts things up.%n%nThe §3Cutting Machine§r is able to cut wafers, rods, wood, and various other things for you, making it a versatile crafting tool. Cutting blocks into 9 plates may be faster than using a §2Metal Bender §rto make them one at a time.%n%nThe MV version is required for cutting §6Silicon Boules§r for easier §6Diodes§r, and for cutting §6Wafers§r into usable components. %n%nThe blade will require you to make §2Vanadiumsteel§r.%n%nCutting Machines work with plain §9Water§r for all recipes. You can also use §9Distilled Water§r which speeds up the processing somewhat, or §9Lubricant§r that speeds it up greatly (and uses very little per operation). These might be a little tricky to make right now, but are very worthwhile upgrades in the future.%n%nYou might consider waiting until you have §2Integrated Circuits§r before progressing too far down the path of MV machines, since these circuits are much easier to make than §2Electronic Circuits§r.
 
 # db 80
-nomifactory.quest.db.80.title=Silicon Boules
-nomifactory.quest.db.80.desc=A hefty amount of §6Silicon Dust§r and a pinch of §6Gallium§r cooked in an §3EBF§r will net you a §6Silicon Boule§r, the starting point for §6Circuit Wafers§r.%n%nMake sure your power system is up to the task. These take a long time to process so you'll need a significant amount of energy to safely complete the job.
+nomifactory.quest.db.80.title=§2Silicon Boules
+nomifactory.quest.db.80.desc=A hefty amount of §6Silicon Dust§r and a pinch of §2Gallium Arsenide §rcooked in an §3EBF§r will net you a §6Silicon Boule§r, the starting point for §6Circuit Wafers§r.%n%nMake sure your power system is up to the task. These take §27.5 minutes and 1,080,000 EU§r to process.
 
 # db 81
 nomifactory.quest.db.81.title=Silicon Wafers
@@ -360,7 +360,7 @@ nomifactory.quest.db.81.desc=§6Wafers§r are thin pieces of silicon cut from a 
 
 # db 82
 nomifactory.quest.db.82.title=Phenol Coated Substrate
-nomifactory.quest.db.82.desc=§9Phenol§r is produced as a byproduct from making §6Coal Coke§r in a §3Pyrolyse Oven§r.%n%nThese boards will enable a much cheaper method of circuit production.
+nomifactory.quest.db.82.desc=§9Phenol§r is produced as a byproduct from making §6Coal Coke§r in a §3Pyrolyse Oven§r.%n%nThese boards will enable the next tier of circuits, as well as a much cheaper method of circuit production.
 
 # db 83
 nomifactory.quest.db.83.title=MV Precision Laser Engraver
@@ -371,24 +371,24 @@ nomifactory.quest.db.84.title=Circuit Wafers
 nomifactory.quest.db.84.desc=§6Circuit Wafers§r are batches of integrated circuits engraved onto a wafer of electronics-grade silicon.%n%nYou need to run these through the §3Cutting Machine§r to dice the wafers into individual integrated circuits (called dies).%n%nThese are important components and will be used for making more advanced Circuits.
 
 # db 86
-nomifactory.quest.db.86.title=The Second Tier One Circuits
-nomifactory.quest.db.86.desc=Much easier to mass produce than §6Primitive Circuits§r, and they fulfill the same function in nearly all cases.%n%nYou should be batch crafting these.
+nomifactory.quest.db.86.title=§2The Second Tier One Circuits
+nomifactory.quest.db.86.desc=Much easier to mass produce than §6Electronic Circuits§r, and they fulfill the same function in nearly all cases.%n%nYou should be batch crafting these.
 
 # db 87
-nomifactory.quest.db.87.title=The Second Tier Two Circuits
-nomifactory.quest.db.87.desc=Three §6Electronic Circuits§r and various other components will create an §6Electronic Processor§r.
+nomifactory.quest.db.87.title=§2The Second Tier Two Circuits
+nomifactory.quest.db.87.desc=§2Two Integrated Circuits§r and various other components will create a §2Good Integrated Circuit.
 
 # db 88
-nomifactory.quest.db.88.title=Lenses
-nomifactory.quest.db.88.desc=You'll need a variety of §alenses§r for use in §3Precision Laser Engravers§r, all of which are made in the §3Autoclave§r.%n%nInitially you'll need a §aRed Lens§r, a §aDiamond Lens§r, and a §aGlass Lens§r.%n%nRed Lenses can be made from §6Ruby§r, or alternately with Almandine, Red Garnet, Jasper or Rutile.%n%nThe other two lenses should be self-evident.%n%n
+nomifactory.quest.db.88.title=§2Lenses
+nomifactory.quest.db.88.desc=You'll need a variety of §alenses§r for use in §3Precision Laser Engravers§r, all of which are made in the §2Lathe§r.%n%nInitially you'll need a §a§3§2Ruby Lens§r. Soon you will need §2Diamond, Emerald, Topaz, and Sapphire Lenses§r. §2You can choose to use an MV Lathe to get a lens from a plate, or sift for an Exquisite Gem and use an LV Lathe.%n%n
 
 # db 89
-nomifactory.quest.db.89.title=The First Tier Three Circuits
-nomifactory.quest.db.89.desc=Your first tier three circuit, formed from four §6Electronic Processors§r and §6Transistors§r, among other ingredients.%n%nAs you'll realize is the pattern, it is expensive and unwieldy to make the first forms of each tier of circuits. Fortunately, you don't have to make many of them.%n%nPrioritize using these circuits to make things needed for unlocking the next theme of circuits, which require more infrastructure but are much cheaper to produce. Eventually each tier through six will have a circuit recipe instead of requiring processors, arrays, or mainframes.%n%n
+nomifactory.quest.db.89.title=§2The First Tier Three Circuits
+nomifactory.quest.db.89.desc=Your first tier three circuit, formed from §2two Good Integrated Circuits§r, §6RAM§r, and §6Transistors§r, among other ingredients.%n%nAs you'll realize is the pattern, it is expensive and unwieldy to make the first forms of each tier of circuits. Fortunately, you don't have to make many of them.%n%nPrioritize using these circuits to make things needed for unlocking the next theme of circuits, which require more infrastructure but are much cheaper to produce. Eventually each tier through six will have a circuit recipe instead of requiring processors, arrays, or mainframes.
 
 # db 90
-nomifactory.quest.db.90.title=MV Assembling Machine
-nomifactory.quest.db.90.desc=The §3Advanced Assembling Machine§r, or MV Assembler for short, allows you to craft recipes that require up to 128 EU/t instead of 32. Plus, any recipe that was at most 32 EU/t can §eoverclock§r, crafting up to 2.8 times faster for 4 times the original energy per tick.%n%nA host of new recipes are now achievable, including a new theme of Circuits!
+nomifactory.quest.db.90.title=§2MV Circuit Assembler
+nomifactory.quest.db.90.desc=With the §3Advanced Circuit Assembling Machine§r, a new theme of Circuits is available.
 
 # db 91
 nomifactory.quest.db.91.title=Chrome
@@ -403,12 +403,12 @@ nomifactory.quest.db.93.title=HV Machine Hulls
 nomifactory.quest.db.93.desc=With §6HV Machine Hulls§r made, you've made your first step towards §eHigh Voltage (HV)§r power machinery!%n%nWhile you can make these in a crafting table with §6Polyethylene Sheets§r, liquid §9Polyethylene§r can be used to craft these directly in an §3Assembling Machine§r.
 
 # db 94
-nomifactory.quest.db.94.title=Sulfuric Acid
-nomifactory.quest.db.94.desc=§9Sulfuric Acid§r is produced from §6Sulfur§r and §9Water§r, albeit very slowly. You'll need huge amounts of this for a whole range of chemical reactions, as it is a very common ingredient.%n%nIf you have excess §9Oxygen§r, you could instead look into making §9Sulfuric Acid§r with §9Sulfur Trioxide§r, as it is much quicker.%n%nSulfur can be electrolyzed from many things, but is also easily available via §bDeep Mob Learning§r's §aBlaze Model§r.
+nomifactory.quest.db.94.title=§2Sulfuric Acid
+nomifactory.quest.db.94.desc=§2Sulfuric Acid is mainly produced in a 3-step process:%n- Sulfur added to Oxygen to produce Sulfur Dioxide. SO₂ also can come from treating certain Sulfur-containing Dusts with Oxygen in the EBF, or by processing Nether Air.%n- Sulfur Dioxide added to more Oxygen, to produce Sulfur Trioxide.%n- Sulfur Trioxide added to Water, to produce Sulfuric Acid.%n%nThe shortcut Sulfur + Water reaction is locked behind the Large Chemical Reactor, unlocked at EV.%n%n§rYou'll need huge amounts of this for a whole range of chemical reactions, as it is a very common ingredient.%n%nSulfur can be electrolyzed from many things, but is also easily available via §bDeep Mob Learning§r's §aBlaze Model§r.
 
 # db 95
-nomifactory.quest.db.95.title=Ethylene and Polyethylene
-nomifactory.quest.db.95.desc=§9Ethylene§r is a hydrocarbon made from dehydrating §9Ethanol§r with §9Sulfuric Acid§r in a §3Chemical Reactor§r. It is an extremely important chemical in the production of plastics.%n%n§9Polyethylene§r is the most common category of plastic, made from polymers of §9Ethylene§r. Adding §9Oxygen§r in a §3Chemical Reactor§r recreates (with some artistic license) early accidental synthesis of Polyethylene.%n%nWhen you have large amounts of §6Rutile§r and §6Bauxite§r (probably after you visit the Moon) you can consider using §9Titanium Tetrachloride§r as a catalyst to improve your Polyethylene yields. For now it's not a great idea, as in addition to its Overworld rarity, you need it for §6Titanium§r.
+nomifactory.quest.db.95.title=§2Ethylene and Polyethylene
+nomifactory.quest.db.95.desc=§9Ethylene§r is a hydrocarbon made from §2either cracking and distilling Light Fuel, or§r dehydrating §9Ethanol§r with §9Sulfuric Acid§r in a §3Chemical Reactor§r. It is an extremely important chemical in the production of plastics.%n%n§9Polyethylene (PE)§r is the most common category of plastic, made from polymers of §9Ethylene§r. Adding §9Oxygen§r in a §3Chemical Reactor§r recreates (with some artistic license) early accidental synthesis of Polyethylene.%n%nWhen you have large amounts of §6Rutile§r and §6Bauxite§r (probably after you visit the Moon) you can consider using §9Titanium Tetrachloride§r as a catalyst to improve your Polyethylene yields. For now it's not a great idea, as in addition to its Overworld rarity, you need it for §6Titanium§r.
 
 # db 96
 nomifactory.quest.db.96.title=Plastic Sheets
@@ -423,8 +423,8 @@ nomifactory.quest.db.98.title=Stainless Steel
 nomifactory.quest.db.98.desc=§6Stainless Steel§r will be your primary material for HV, in the same way that §6Aluminium§r was for MV and §6Wrought Iron§r was for LV.%n%n§6Manganese§r comes from electrolyzing §6Tantalite§r, §6Pyrolusite§r, or §6Spessartine Dusts§r. You already have §6Chrome§r.%n%nMix up a bunch of the dust in a §3Mixer§r and begin processing it through the §3Electric Blast Furnace§r. This may be a good time to reevaluate your power generation and storage infrastructure.
 
 # db 99
-nomifactory.quest.db.99.title=Synthesizing Your First Omnium
-nomifactory.quest.db.99.desc=With the §6Stabilized Einsteinium§r you harvested from a microverse, you should now have access to everything you need to synthesize your first §dMote of Omnium§r.%n%nYou're gonna need to make a lot of these as you push into the End Game, so make sure your §eautomation is supplying you with a stock of all of the ingredients§r. That's what those quests in the End Game tab have been about all along!
+nomifactory.quest.db.99.title=§2Synthesizing Your First Omnium
+nomifactory.quest.db.99.desc=With the §6Stabilized Einsteinium§r you harvested from a microverse, you should now have access to everything you need to synthesize your first §dMote of Omnium§r. §2Compared to the original pack, this requires 20 new elements.§r%n%nYou're gonna need to make at least 487 of these as you push into the End Game, so make sure your §eautomation is supplying you with a stock of all of the ingredients§r. That's what those quests in the End Game tab have been about all along!
 
 # db 100
 nomifactory.quest.db.100.title=Engineering Processor
@@ -531,44 +531,44 @@ nomifactory.quest.db.125.title=GP Generation
 nomifactory.quest.db.125.desc=§6Stoneburnt§r is a key ingredient in crafting many things from Extra Utilities.%n%nBesides the Manual Mill, there are multiple ways to generate GP. Look up "Mill" in JEI for all possible mills.%n%nNote that the individual generators have been balanced differently than normal, so take that into account before building 16 Water Mills. It is a good idea to use several different kinds due to §bExtra Utilities§r implementing diminishing returns to prevent spamming one kind of Mill.%n%n
 
 # db 126
-nomifactory.quest.db.126.title=SMD Components
-nomifactory.quest.db.126.desc=§6Surface Mounted Devices§r, or §6SMD§rs for short, are one of the first endgame materials you'll be making. Even the mighty Tier Nine circuits require SMD components, and huge amounts of them at that.%n%nAll SMD components must be produced in at least an §3MV Assembling Machine§r, and they all will require liquid §9Polyethylene§r.%n%nStart off with the §6SMD Transistor§r. These are simply a §6Gallium Plate§r and §6Fine Annealed Copper Wire§r.%n%nNext up are §6SMD Resistors§r, which are also simple: §6Carbon Dust§r and §6Fine Electrum Wire§r.%n%nFinally, §6SMD Capacitors§r. You'll need sheets of §6Polyvinyl Chloride§r to make these, or they can also be made more slowly with §6Silicone Rubber§r.%n%nInvest in an extremely robust system of automation for SMD components and all of their ingredients, since you'll never stop needing them. They will also work in place of the non-SMD versions you've been using in all but the simplest of recipes.%n%n
+nomifactory.quest.db.126.title=§2SMD Components
+nomifactory.quest.db.126.desc=§6Surface Mounted Devices§r, or §6SMD§rs for short, are §2more efficient ways to produce the Circuit components you've been making. They will be used until the second-to-last theme of circuits.§r%n%nAll SMD components must be produced in at least a §2HV Assembling Machine§r, and they all will require liquid §9Polyethylene§r.%n%nStart off with the §6SMD Transistor§r. These are simply a §6Gallium §2Foil§r and §6Fine Annealed Copper Wire§r.%n%nNext up are §6SMD Resistors§r, which are also simple: §6Carbon Dust§r and §6Fine Electrum Wire§r.%n%nNext up are §6SMD Diodes§r, which are fairly simple. §2Gallium Arsenide Dust§r and §6Fine Platinum Wire§r net you half a stack. §2If you can't go to the End to mine Platinum there yet, buy some with Omnicoins.§r%n%nThen are §6SMD Capacitors§r. You'll need sheets of §6Polyvinyl Chloride§r to make these, or they can also be made more slowly with §6Silicone Rubber§r. §2Using Tantalum Foil in place of Aluminium doubles your yield.%n%nFinally, and new to CEu, SMD Inductors. Made with Nickel Zinc Ferrite and Fine Cupronickel Wire.§r%n%nInvest in a robust system of automation for SMD components and all of their ingredients, since you'll never stop needing them. They will also work in place of the non-SMD versions you've been using in all but the simplest of recipes.
 
 # db 129
-nomifactory.quest.db.129.title=SMD Diodes
-nomifactory.quest.db.129.desc=Next up are §6SMD Diodes§r, which are fairly simple.%n%nA §6Small Pile of Gallium Dust§r and four §6Fine Platinum Wire§r net you half a stack.
+nomifactory.quest.db.129.title=§2MV Emitter
+nomifactory.quest.db.129.desc=§2An expensive advanced component used in the construction of the MV Precision Laser Engraver and MV Circuit Assembler.%n%nProcess some Emerald Ore in the Sifter to get the Flawless Emerald required to craft this.
 
 # db 130
 nomifactory.quest.db.130.title=Annealed Copper
-nomifactory.quest.db.130.desc=§6Annealed Copper§r is made in the §3EBF§r by treating §6Copper§r with §9Oxygen§r. It has less power loss than regular Copper when used as a cable, and is also required for more advanced electronic components.
+nomifactory.quest.db.130.desc=§6Annealed Copper§r is made §2in an Arc Furnace§r by treating §6Copper§r with §9Oxygen§r. It has less power loss than regular Copper when used as a cable, and is also required for more advanced electronic components.
 
 # db 131
 nomifactory.quest.db.131.title=Polyvinyl Chloride
-nomifactory.quest.db.131.desc=§9Vinyl Chloride§r is an industrial chemical made from chlorinating §9Ethylene§r (adding §9Chlorine§r at high temperature) in a §3Chemical Reactor§r.%n%nIt is used to create the plastic §9Polyvinyl Chloride§r, most well known as PVC. While it deviates from reality, in GregTech you chemically react Vinyl Chloride and §9Oxygen§r to polymerize it into PVC.%n%nLater, you can use §9Titanium Tetrachloride§r to catalyze this reaction as well for greater yield.%n%n§6PVC Sheets§r are superior to §6Polyethylene Sheets§r for making plastic substrates, producing twice as many §6Plastic Boards§r per craft.%n%n
+nomifactory.quest.db.131.desc=§9Vinyl Chloride§r is an industrial chemical made from chlorinating §9Ethylene§r (adding §9Chlorine§r at high temperature) in a §3Chemical Reactor§r. §9Ethane§r can be used as an alternative reagent.%n%nIt is used to create the plastic §9Polyvinyl Chloride§r, most well known as PVC. While it deviates from reality, in GregTech you chemically react Vinyl Chloride and §9Oxygen§r to polymerize it into PVC.%n%nLater, you can use §9Titanium Tetrachloride§r to catalyze this reaction as well for greater yield.%n%n§6PVC Sheets§r are superior to §6Polyethylene Sheets§r for making plastic substrates, producing twice as many §6Plastic Boards§r per craft.%n%n
 
 # db 132
-nomifactory.quest.db.132.title=The First Tier Four Circuits
-nomifactory.quest.db.132.desc=This is the first Tier Four circuit, which is used for EV-tier machinery.%n%nThis is the first kind of mainframe you'll have made, and as you can see it's extraordinarily expensive. Fortunately, you don't have to make too many of these.%n%nInvest in the §3HV Assembling Machine§r to unlock the next theme of circuits, which use Epoxy substrates and span tiers two through five.
+nomifactory.quest.db.132.title=§2The First Tier Four Circuits
+nomifactory.quest.db.132.desc=This is the first Tier Four circuit, which is used for EV-tier machinery. Requires some Vibrant Alloy.%n%n§2The HV Circuit Assembler only unlocks one circuit type, the Mainframe. There is no circuit theme associated with the HV Circuit Assembler; instead, the HV (non-Circuit) Assembler unlocks easier Circuit components. The next circuit theme is not until EV.
 
 # db 133
-nomifactory.quest.db.133.title=The Third And Final Tier One Circuits
-nomifactory.quest.db.133.desc=With all the SMD components ready, you can start to churn out §6Refined Circuits§r. These are the best kind of Tier One circuits you can make, and you won't unlock the better recipes for quite a while.%n%nYou should absolutely automate the production of these circuits, and §ekeep a stockpile automatically crafted§r so you don't have to wait around for them or bloat your crafting orders making them on-demand through AE.
+nomifactory.quest.db.133.title=§2The Third And Final Tier One Circuits
+nomifactory.quest.db.133.desc=§2You can start to churn out Microprocessors§r. These are the best kind of Tier One circuits you can make, and you won't unlock the better recipes for quite a while.%n%nYou should absolutely automate the production of these circuits, and §ekeep a stockpile automatically crafted§r so you don't have to wait around for them or bloat your crafting orders making them on-demand through AE.
 
 # db 134
-nomifactory.quest.db.134.title=Plastic Substrate
-nomifactory.quest.db.134.desc=Better substrates. Using §6Polyvinyl Chloride§r (PVC) instead of §6Polyethylene§r (PE) doubles your yield.%n%nThe third material option is much more difficult to make and probably not worth considering for now.
+nomifactory.quest.db.134.title=§2Plastic Substrate
+nomifactory.quest.db.134.desc=Better substrates. Using §6Polyvinyl Chloride§r (PVC) instead of §6Polyethylene§r (PE) doubles your yield.%n%nThe third §2and fourth material options§r are§r much more difficult to make and probably not worth considering for now.
 
 # db 135
-nomifactory.quest.db.135.title=The Third Tier Two Circuits
-nomifactory.quest.db.135.desc=Using SMD components (or leftover non-SMD versions), you can combine §6Refined Circuits§r into the third type of Tier Two circuit: the §6Refined Processor§r.
+nomifactory.quest.db.135.title=§2The Third And Final Tier Two Circuits
+nomifactory.quest.db.135.desc=§2Unique to this tier of Circuit, this MV circuit doesn't require the previous tier to craft.§r These are the best kind of Tier Two circuits you can make, and you won't unlock the better recipes for quite a while.%n%nYou should absolutely automate the production of these circuits, and §ekeep a stockpile automatically crafted§r so you don't have to wait around for them or bloat your crafting orders making them on-demand through AE.
 
 # db 136
 nomifactory.quest.db.136.title=Small Coils
 nomifactory.quest.db.136.desc=Another electronic component.%n%nMaking it inside an §3Assembling Machine§r is much, much cheaper than by hand, and using §6Nickel Zinc Ferrite§r bolts gives even better returns.
 
 # db 138
-nomifactory.quest.db.138.title=LuV Machine Hulls
-nomifactory.quest.db.138.desc=With §6Lumium§r and §6Vanadium-Gallium§r, you can now make hulls for Ludicrous Voltage (LuV) §bGregTech§r machines.
+nomifactory.quest.db.138.title=§2LuV Machine Hulls
+nomifactory.quest.db.138.desc=With §6§2Rhodium Plated Lumium-Palladium§r,§6 Vanadium-Gallium§r, §2and Polyphenylene Sulfide§r, you can now make hulls for Ludicrous Voltage (LuV) §bGregTech§r machines.
 
 # db 139
 nomifactory.quest.db.139.title=Rare Earth
@@ -584,7 +584,7 @@ nomifactory.quest.db.141.desc=While there are no types of veins that are extreme
 
 # db 144
 nomifactory.quest.db.144.title=Yttrium
-nomifactory.quest.db.144.desc=Centrifuge §6Rare Earth§r, and among other useful materials, you'll get some §6Yttrium§r.%n%nBecause this recipe has chanced outputs, use an §3HV Centrifuge§r or better to guarantee all items, and §eensure the output slots don't fill up or excess items will be voided§r.
+nomifactory.quest.db.144.desc=Centrifuge §6Rare Earth§r, and among other useful materials, you'll get some §6Yttrium§r.%n%nBecause this recipe has chanced outputs, use a §2high tier Centrifuge to increase output chances§r, and §eensure the output slots don't fill up or excess items will be voided§r.
 
 # db 145
 nomifactory.quest.db.145.title=LV Pistons
@@ -595,8 +595,8 @@ nomifactory.quest.db.146.title=LV Pumps
 nomifactory.quest.db.146.desc=Another common component of any machine that uses fluids. Also usable as a cover for moving fluids between §bGregTech§r machines and adjacent tanks or machines.%n%nYou can use §6Paper Rings§r or §6Rubber Rings§r, but both will require a §aKnife§r to craft. A stick and a piece of flint will make a Knife with low durability, or check the recipe for metal ones.
 
 # db 147
-nomifactory.quest.db.147.title=Polarizer
-nomifactory.quest.db.147.desc=Note: this quest accepts both LV and MV Polarizer.%n%nAlthough you could §emagnetize§r §6Iron Ingots§r by hand using §6Redstone§r, doing that consumes considerable amounts of dust and that's not an option for more advanced materials. This machine will let you magnetize §6Steel Rods§r, as well as even more advanced materials later.%n%nThere are no recipes for the §3Polarizer§r that require more than 32 volts, which means you can get away with using an LV Polarizer for the entire pack. However, higher voltages will work faster, in exchange for consuming more power.%n%n
+nomifactory.quest.db.147.title=§2Polarizer
+nomifactory.quest.db.147.desc=Note: this quest accepts both LV and MV Polarizer.%n%nAlthough you could §emagnetize§r §6Iron Ingots§r by hand using §6Redstone§r, doing that consumes considerable amounts of dust and that's not an option for more advanced materials. This machine will let you magnetize §6Steel Rods§r, as well as even more advanced materials later.%n%n§2Polarizer recipes in GTCEu go up to HV.
 
 # db 148
 nomifactory.quest.db.148.title=Titanium
@@ -612,7 +612,7 @@ nomifactory.quest.db.150.desc=§3Vacuum Freezers§r are primarily used to cool d
 
 # db 151
 nomifactory.quest.db.151.title=Early Rutile
-nomifactory.quest.db.151.desc=§6Rutile§r is a §6Titanium§r precursor found in §6Ilmenite Ore§r and §6Bauxite Ore§r, which spawn uncommonly in the Overworld.%n%n§6Rutile Ore§r (the richest source), as well as larger quantities of Ilmenite and Bauxite, may be found on the Moon and other planets.%n%n
+nomifactory.quest.db.151.desc=§6Rutile§r is a §6Titanium§r precursor found in §6Ilmenite Ore§r and §6Bauxite Ore§r, which spawn uncommonly in the Overworld.%n%n§6§rLarger quantities of Ilmenite and Bauxite may be found on the Moon and other planets.%n%n
 
 # db 152
 nomifactory.quest.db.152.title=Titanium Tetrachloride
@@ -627,32 +627,32 @@ nomifactory.quest.db.154.title=Distillation Tower
 nomifactory.quest.db.154.desc=With tier three circuits in hand, it's time to make a §3Distillation Tower§r, which is the gatekeeper for more advanced plastics like §6Epoxy§r and doing petrochemistry.%n%nThe Distillation Tower is a highly flexible multiblock structure, able to be anywhere from §62 blocks high to up to 13 high§r (12 fluid outputs). The way that it works is that each level of the tower after the first will output an additional fluid from the recipe. §cAny output fluids in excess of available buses are voided§r. %n%nWhat you need the Distillation Tower for initially is to break down §9Biomass§r into §9Ethanol§r and §9Water§r. This recipe only has two outputs, so a §ethree-block-high Distillation Tower§r is just fine (the quest materials are for such a tower; if you want to build it bigger, you will need §ean additional 7 casings and 1 fluid output per floor§r).%n%nAny recipe with more than two fluids (like §9Oil§r) will need a larger tower. Make sure to increase the height of your tower to accommodate all of the outputs you want to keep. Also check the voltage requirements of the recipes, as many Distillation Tower recipes need higher voltages than MV. §eYou can swap out your Energy Input for a higher tier one when that time comes§r.%n%nThe tower we'll be building at first is 3x3x3, with a hollow center. §6Fluid Input Hatch§r §emust go in the very center of the bottom 3x3 layer§r. The §6controller§r goes in the middle of an outer edge of the bottom layer. The §6Output Bus§r and an §6Energy Input Hatch§r can go wherever you can fit them on the bottom layer. The rest of the 3x3 must be filled with §6Clean Stainless Steel Casings§r. Each level above that is a ring of 7 Clean Stainless Steel Casings, one §6Fluid Output§r and nothing in the center, except for the topmost layer which needs an eighth casing to fill in the center, capping off the top.
 
 # db 155
-nomifactory.quest.db.155.title=The Fourth and Final Tier Five Circuits
-nomifactory.quest.db.155.desc=With your §6Crystal CPUs§r and the §3LuV Assembling Machine§r crafted, you can make the final type of Tier Five Circuit: the §6Crystal Circuit§r.%n%nAs the best form of Tier Five circuit, these should be automated and stockpiled. The variant recipe requiring §6Crystal System-on-Chip§r won't be available until you can make a §3ZPM Assembling Machine§r.
+nomifactory.quest.db.155.title=§2The Fourth and Final Tier Five Circuits
+nomifactory.quest.db.155.desc=With your §6Crystal CPUs§r and the §3LuV Assembling Machine§r crafted, you can make the final type of Tier Five Circuit: the §6Crystal Circuit§r.%n%n§2This is the first Circuit which strictly requires Advanced SMD components. All of them will from now on.§r%n%nAs the best form of Tier Five circuit, these should be automated and stockpiled. The variant recipe requiring §6Crystal System-on-Chip§r won't be available until you can make a §3ZPM Assembling Machine§r.
 
 # db 156
 nomifactory.quest.db.156.title=Kanthal Ingots
 nomifactory.quest.db.156.desc=§6Kanthal§r is an alloy of §6Iron§r, §6Aluminium§r, and §6Chrome§r.%n%nThis alloy is cooked in an §3Electric Blast Furnace§r into a §6Hot Kanthal Ingot§r which will damage you if it is held. To prevent this damage and obtain the desired ingot, the Hot Ingot must be cooled in a §3Vacuum Freezer§r.%n%nIt is best to directly route this Hot Ingot from the §6Output Bus§r of your Blast Furnace to the §6Input Bus§r of your Vacuum Freezer via conduits or an §6Ore Dictionary Filter§r and then retrieve the cooled ingot.
 
 # db 157
-nomifactory.quest.db.157.title=Kanthal Coil Blocks
-nomifactory.quest.db.157.desc=§6Kanthal§r is the second coil material available, increasing your EBF's operating temperature to 2700K so it can process more advanced materials.
+nomifactory.quest.db.157.title=§2Kanthal Coil Blocks
+nomifactory.quest.db.157.desc=§6Kanthal§r is the second coil material available, increasing your EBF's operating temperature to 2700K so it can process more advanced materials.%n%n§2In CEu, using higher-tier coils provides some bonuses to their multiblocks.%n- Pyrolyse Oven: Cupronickel Coils are 25%% slower, every coil above Kanthal grants +50%% additive speed%n- Multi Smelter: Increases number of parallel operations and decreases energy usage%n- Cracking Unit: -5%% energy usage per coil above Cupronickel%n- Electric Blast Furnace: The temperature of the EBF is the coil's temperature, plus 100K for each voltage tier above MV.%nFor every 900K above the recipe temperature, the energy usage is multiplied by 0.95x.%nFor every 1800K above, one overclock becomes 100%% efficient - each overclock will 4x the speed instead of 2x.
 
 # db 158
 nomifactory.quest.db.158.title=Nichrome Ingots
 nomifactory.quest.db.158.desc=§6Nichrome§r is an alloy of §6Nickel§r and §6Chrome§r.%n%nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.%n
 
 # db 159
-nomifactory.quest.db.159.title=Nichrome Coil Blocks
-nomifactory.quest.db.159.desc=§6Nichrome§r is the third coil material available, increasing your EBF's operating temperature to 3600K so it can process more advanced materials.
+nomifactory.quest.db.159.title=§2Nichrome Coil Blocks
+nomifactory.quest.db.159.desc=§6Nichrome§r is the third coil material available, increasing your EBF's operating temperature to 3600K so it can process more advanced materials.%n%n§23600K is now also hot enough to grant a single 100%% efficient overclock to 1800K and below recipes. In effect, you will get an additional 2x speed boost by overclocking once. You may wish to use this well to make up for the slower recipes.
 
 # db 160
 nomifactory.quest.db.160.title=Sulfuric Heavy, Light, Naphtha and Gas
 nomifactory.quest.db.160.desc=First, you need some §9Oil§r. Pick your favorite method: you should engineer a renewable automated source, as you will need large quantities.%n%nStart off by running the Oil through the §3Distillation Tower§r. This will result in §9Sulfuric Heavy Fuel§r, §9Sulfuric Light Fuel§r, §9Sulfuric Naphtha§r, and §9Sulfuric Gas§r.%n%nThese will all need to be hydrodesulfurized using §9Hydrogen§r in a §3Chemical Reactor§r, which produces the non-Sulfuric versions.%n%nAll of these products are useful, so figure out how you want to store the variety and large quantities of fluids.
 
 # db 161
-nomifactory.quest.db.161.title=Refinery Gas
-nomifactory.quest.db.161.desc=Like other petroleum products, §9Sulfuric Gas§r is hydrodesulfurized into §9Refinery Gas§r using §9Hydrogen§r in a §3Chemical Reactor§r.%n%nRefinery Gas can be cracked and further distilled for its constituents, but it is also useful as fuel for §3Gas Turbines§r. While it can be burned directly, centrifuging Refinery Gas produces §9LPG§r (Liquefied Petroleum Gas), which is the ideal fuel for Gas Turbines, and §9Methane§r which is a potential suboptimal turbine fuel but is also useful for various chemical reactions.
+nomifactory.quest.db.161.title=§2Refinery Gas
+nomifactory.quest.db.161.desc=Like other petroleum products, §9Sulfuric Gas§r §2or Natural Gas§r is hydrodesulfurized into §9Refinery Gas§r using §9Hydrogen§r in a §3Chemical Reactor§r.%n%nRefinery Gas can be cracked and further distilled for its constituents, but it is also useful as fuel for §3Gas Turbines§r. While it can be burned directly, centrifuging Refinery Gas produces §9LPG§r (Liquefied Petroleum Gas), which is an ideal fuel for Gas Turbines, and §9Methane§r which is a potential suboptimal turbine fuel but is also useful for various chemical reactions.
 
 # db 162
 nomifactory.quest.db.162.title=Canola Press
@@ -667,20 +667,20 @@ nomifactory.quest.db.164.title=Heavy Fuel
 nomifactory.quest.db.164.desc=§9Heavy Fuel§r is mixed with §9Light Fuel§r to create §9Diesel§r.%n%nSince Diesel requires more Light than Heavy fuel, you should consider Steam-cracking and distilling the excess quantity of Heavy Fuel for its useful constituents.
 
 # db 165
-nomifactory.quest.db.165.title=Light Fuel
-nomifactory.quest.db.165.desc=Due to the ratios required, §9Light Fuel§r all goes into the production of §9Diesel§r.%n%nIt's inadvisable to crack and distill it or burn it directly as fuel.
+nomifactory.quest.db.165.title=§2Light Fuel
+nomifactory.quest.db.165.desc=§2Light Fuel's distillates are now more useful, and it is the only source of Octane for High-Octane Gasoline.%nBut if you choose to produce Diesel, a large proportion of the Light Fuel you produce still has to go into Diesel production.
 
 # db 166
 nomifactory.quest.db.166.title=Naphtha
-nomifactory.quest.db.166.desc=§9Naphtha§r is used in the simple (but highly inefficient) Naphtha route for making §9Epoxy§r, but is best utilized for Steam-Cracking and distilling for its constituents.%n%nNotably it contains §9Light Fuel§r and §9Heavy Fuel§r for making more §9Diesel§r, as well as many other useful chemicals for a variety of purposes.
+nomifactory.quest.db.166.desc=§9Naphtha§r is best utilized for Steam-Cracking and distilling for its constituents.%n%nNotably it contains §9Light Fuel§r and §9Heavy Fuel§r for making more §9Diesel§r, as well as many other useful chemicals for a variety of purposes.
 
 # db 167
-nomifactory.quest.db.167.title=Hydrogen Sulfide
-nomifactory.quest.db.167.desc=§9Hydrogen Sulfide§r is a byproduct of hydrodesulfurization.%n%nA simple chemical reaction with §9Water§r reprocesses it into the useful §9Sulfuric Acid§r, or it can be electrolyzed for recovering the §9Hydrogen§r.
+nomifactory.quest.db.167.title=§2Hydrogen Sulfide
+nomifactory.quest.db.167.desc=§9Hydrogen Sulfide§r is a byproduct of hydrodesulfurization. §2It also comes from distilling Liquid Nether Air.§r%n%nA simple chemical reaction with §9Water§r reprocesses it into the useful §9Sulfuric Acid§r, or it can be electrolyzed for recovering the §9Hydrogen§r.
 
 # db 168
 nomifactory.quest.db.168.title=Diesel
-nomifactory.quest.db.168.desc=§9Diesel§r is a mixture of §9Light Fuel§r and §9Heavy Fuel§r.%n%nWhile it can be used as a fuel, the performance of §3Diesel Generators§r is middling compared to the alternatives.%n%nThe primary use is for making §9Nitro Diesel§r, which you will want to stockpile in large quantities for the later production of §6Draconium§r.
+nomifactory.quest.db.168.desc=§9Diesel§r is a mixture of §9Light Fuel§r and §9Heavy Fuel§r.%n%nThe primary use is for making §9Nitro Diesel§r, which you will want to stockpile in large quantities for the later production of §6Draconium§r §2(unless you use Gasoline instead).%n%nThe performance of Combustion Generators is also improved, but you probably want to refine Diesel anyway.%n%n§2It's more power efficient to use singleblock Distilleries over a Distillation Tower for Oil, due to the overclocking mechanics being different. For Diesel, the correct ratio is 3 Distilleries for Light Oil and 2 Distilleries for Heavy Oil.
 
 # db 169
 nomifactory.quest.db.169.title=Palladium
@@ -688,11 +688,11 @@ nomifactory.quest.db.169.desc=§6Palladium§r is found in §6Palladium Ore§r, w
 
 # db 170
 nomifactory.quest.db.170.title=Sodium Hydroxide
-nomifactory.quest.db.170.desc=§6Sodium Hydroxide§r is an ingredient in §9Bio Diesel§r.%n%nThe primary sources are:%n%n- Combining §9Water§r and §6Sodium§r in a §3Chemical Reactor§r (also a good source of §9Hydrogen§r)%n- Splitting §9Salt Water§r in an §3Electrolyzer§r (also a good source of §9Chlorine§r).%n- Combining §6Sodium Bisulfate§r and §9Water§r in a §3Chemical Reactor§r (The production of §6Sodium Bisulfate§r also yields a little §9Hydrochloric Acid§r)
+nomifactory.quest.db.170.desc=§6Sodium Hydroxide§r is a strong base, and an ingredient in §9Bio Diesel§r, among other reactions.%n%n§2The only source§r is splitting §9Salt Water§r in an §3Electrolyzer§r - this is also a good source of §9Chlorine§r. You can get §9Salt Water§r from mixing §6Salt§r and §9Water§r (duh), §2dissolving Ghast Tears, or drilling it from Salt Water fluid veins, which only spawn over oceans.
 
 # db 171
-nomifactory.quest.db.171.title=Cryogenic Air Distillation
-nomifactory.quest.db.171.desc=§9Air§r can be sent into the §3Vacuum Freezer§r to turn it into §9Liquid Air§r.%n%nLiquid Air can be sent into a §3Cryogenic Distillation Tower§r to break it down into its components.%n%n§9Noble Gases§r can be broken further into other valuable products, so it's advised to have at least two Cryogenic Distillation Towers.%n%n§6Sneak-right click§r the controller to enable the in-world preview.
+nomifactory.quest.db.171.title=§2Cryogenic Air Distillation
+nomifactory.quest.db.171.desc=§9Air§r can be sent into the §3Vacuum Freezer§r to turn it into §9Liquid Air§r.%n%nLiquid Air can be sent into a §2normal Distillation Tower§r to break it down into its components.%n%n§2Liquid Nether Air and Liquid Ender Air give different useful components.%n
 
 # db 172
 nomifactory.quest.db.172.title=Bio Diesel and Glycerol
@@ -700,22 +700,22 @@ nomifactory.quest.db.172.desc=The reaction that produces §9Bio Diesel§r is als
 
 # db 173
 nomifactory.quest.db.173.title=Nitrogen
-nomifactory.quest.db.173.desc=§9Nitrogen§r comprises 78%% of the atmosphere. Because of this, after the first few processes of §9Liquid Air§r in a §3Cryogenic Distillation Tower§r, you'll probably have more Nitrogen than you know what to do with.%n%nIf you got here centrifuging air, then it's gonna take you longer to get to that point.%n%nEven so, don't void it unless you have secured a very large stockpile. Storage is cheap and Nitrogen is used in sizeable quantities for several notable things, one of which you'll be needing very soon.
+nomifactory.quest.db.173.desc=§9Nitrogen§r comprises 78%% of the atmosphere. Because of this, after the first few processes of §9Liquid Air§r, you'll probably have more Nitrogen than you know what to do with.%n%nIf you got here centrifuging air, then it's gonna take you longer to get to that point.%n%nEven so, don't void it unless you have secured a very large stockpile. Storage is cheap and Nitrogen is used in sizeable quantities for several notable things, one of which you'll be needing very soon.
 
 # db 174
-nomifactory.quest.db.174.title=Basic Air Collection
-nomifactory.quest.db.174.desc=Note: this quest accepts LV/MV/HV/EV §3Air Collectors§r.%n%nAn §3Air Collector§r will suck up air at a decent rate, provided the top side is unobstructed. The collected Air is automatically ejected into an adjacent tank via the output face.%n%nIV and LuV air collectors are not part of this quest, but for reference they exist and are called §3Atmosphere Collectors§r.%n%n
+nomifactory.quest.db.174.title=§2Basic Air Collection
+nomifactory.quest.db.174.desc=Note: this quest accepts LV/MV/HV/EV §3Gas Collectors§r.%n%nA §3Gas Collector§r will suck up air at a decent rate, provided the top side is unobstructed. The collected Air is automatically ejected into an adjacent tank via the output face.%n%n§2Gas Collectors in the Nether and End will collect Nether Air and Ender Air respectively, which yield different products.§r%n%nIV+ air collectors are not part of this quest, but for reference they exist and are called §3Atmosphere Collectors§r.%n%n
 
 # db 175
-nomifactory.quest.db.175.title=Noble Gasses
-nomifactory.quest.db.175.desc=Breaking down §9Noble Gasses§r into their components will require 53 iterations of distilling §9Liquid Air§r to acquire the buckets needed for one batch. Running multiple towers (if you can generate Liquid Air fast enough) is not a bad idea.%n%nYou'll be needing large quantities of the various Noble Gasses so you should get this automated and running continuously. %n%n§9Argon§r, for example, is important for production of advanced §6Silicon Boules§r.
+nomifactory.quest.db.175.title=§2Noble Gasses
+nomifactory.quest.db.175.desc=You'll be needing large quantities of the various Noble Gasses so you should get this automated and running continuously. %n%n§9Argon§r, for example, is important for production of advanced §6Silicon Boules§r.%n%n§2After liquefication, Overworld Air grants Helium and Argon; Nether Air grants Helium-3 and Neon; Ender Air grants Helium, Krypton, Xenon, and Radon.%n%n§2Certain Noble Gases can also boost the speed of EBF processes.
 
 # db 176
 nomifactory.quest.db.176.title=Nitrogen Dioxide
 nomifactory.quest.db.176.desc=A simple combination of §9Nitrogen§r and §9Oxygen§r, the two most common elements in the air, yet this substance is very toxic. Chemistry is weird.
 
 # db 177
-nomifactory.quest.db.177.title=Nitric Acid
+nomifactory.quest.db.177.title=§2Nitric Acid
 nomifactory.quest.db.177.desc=Don't let the EPA catch you making this stuff.%n%n§9Nitrogen Dioxide§r, §9Oxygen§r, and §9Water§r will create §9Nitric Acid§r, the next step in your chemical journey.
 
 # db 178
@@ -723,8 +723,8 @@ nomifactory.quest.db.178.title=Tetranitromethane
 nomifactory.quest.db.178.desc=This is the additive that will bring our diesel fuel to the next level.%n%nMix §9Nitric Acid§r and §9Ethenone§r in a §3Chemical Reactor§r to make §9Tetranitromethane§r.%n%nIn a newly added route, you can also mix §9Nitric Acid§r and §9Methyl Acetate§r in a §3Chemical Reactor§r.
 
 # db 179
-nomifactory.quest.db.179.title=NITRO DIESEL!!
-nomifactory.quest.db.179.desc=Mixing §9Diesel§r (or less efficiently, §9Bio Diesel§r) with §9Tetranitromethane§r in an §3HV Mixer§r produces §9Nitro Diesel§r, an extremely potent fuel needed later for §6Draconium§r production.%n%nIf you have a very robust petrochemical infrastructure and can afford to burn it, this fuel along with proper oxygenation maximizes the potential of multiblock §3Diesel Generators§r, producing 720 EU/mB of fuel.
+nomifactory.quest.db.179.title=§2NITRO DIESEL!!
+nomifactory.quest.db.179.desc=Mixing §9Diesel§r (or less efficiently, §9Bio Diesel§r) with §9Tetranitromethane§r in an §3HV Mixer§r produces §9Nitro Diesel§r, an extremely potent fuel needed later for §6Draconium§r production.%n%nIf you have a very robust petrochemical infrastructure and can afford to burn it, this fuel along with proper oxygenation §2is a potent fuel in the Large Combustion Engine and Extreme Combustion Engine, producing §2720 EU/mB of fuel.
 
 # db 180
 nomifactory.quest.db.180.title=Ethenone
@@ -735,32 +735,32 @@ nomifactory.quest.db.181.title=Acetic Acid
 nomifactory.quest.db.181.desc=There are several paths to §9Acetic Acid§r... probably the simplest is combining §9Oxygen§r, §9Hydrogen§r, and §6Carbon§r, but one of the several other methods may appeal to you more, especially if you have a §3Distillation Tower§r.%n%nLook through §bJEI§r for the various options.
 
 # db 182
-nomifactory.quest.db.182.title=Epichlorohydrin
-nomifactory.quest.db.182.desc=A colorless liquid with a pungent, garlic-like odor. It's needed in the production of §9Epoxy§r.
+nomifactory.quest.db.182.title=§2Epichlorohydrin
+nomifactory.quest.db.182.desc=A colorless liquid with a pungent, garlic-like odor. It's needed in the production of §9Epoxy§r.%n%n§2You can skip a step making this with the Large Chemical Reactor.
 
 # db 183
-nomifactory.quest.db.183.title=Fiber Reinforced Epoxy Substrate
-nomifactory.quest.db.183.desc=A §6Fiber-Reinforced Epoxy Resin Sheet§r is made in a §3Chemical Bath§r, not a §3Chemical Reactor§r. The board itself is made in a Chemical Reactor though.%n%nOther than that, it's very similar to the other substrates you've made so far. This board type unlocks §6Nanocircuits§r, which span tiers three through six.
+nomifactory.quest.db.183.title=§2Fiber Reinforced Epoxy Substrate
+nomifactory.quest.db.183.desc=A §6Fiber-Reinforced Epoxy Resin Sheet§r is made in a §3Chemical Bath§r, not a §3Chemical Reactor§r. The board itself is made in a Chemical Reactor though.%n%nOther than that, it's very similar to the other substrates you've made so far. This board type unlocks §2Quantum Circuits, which span tiers four through seven.
 
 # db 184
-nomifactory.quest.db.184.title=Navigating Petrochem
-nomifactory.quest.db.184.desc=Petrochemistry is the category of organic chemistry pertaining to petroleum, otherwise known as §9Oil§r.%n%n§bGregTech§r's petrochemistry may seem daunting at first, given the sheer number of chemicals and processing options, but it's actually easier to get into than you think.%n%nOil is the starting point, and can be found in several variants which you can pump from finite natural wells on the Overworld, as well as coming renewably from §6Oilsands Ore§r and directly in liquid form from an §3Oil Drilling Rig§r. The variant simply called "Oil" is the standard ratio of distillation products and is what you will always get from the latter two sources. §9Light Oil§r and §9Heavy Oil§r are effectively the same as Oil, but with different ratios of distillation products.%n%nThe upcoming quests will guide you through the basics of petrochemistry. Once you've mastered that, feel free to explore further.%n
+nomifactory.quest.db.184.title=§2Navigating Petrochem
+nomifactory.quest.db.184.desc=Petrochemistry is the category of organic chemistry pertaining to petroleum, otherwise known as §9Oil§r.%n%n§bGregTech§r's petrochemistry may seem daunting at first, given the sheer number of chemicals and processing options, but it's actually easier to get into than you think.%n%nOil is the starting point, and can be found in several variants which you can pump from finite natural wells on the Overworld, as well as coming renewably from §6Oilsands Ore§r and §6Soul Sand§r, and directly in liquid form from a §3Fluid Rig§r.%n%nStart off by distilling the Oil. This will result in §9Sulfuric Heavy Fuel§r, §9Sulfuric Light Fuel§r, §9Sulfuric Naphtha§r, and/or §9Sulfuric Gas§r.%n%nThese will all need to be hydrodesulfurized using §9Hydrogen§r in a §3Chemical Reactor§r or §2Oil Cracking Unit§r, which produces the non-Sulfuric versions.%n%nAll of these products are useful, so figure out how you want to store the variety and large quantities of fluids.%n%nThe upcoming quests will guide you through the basics of petrochemistry. Once you've mastered that, feel free to explore further.%n
 
 # db 185
 nomifactory.quest.db.185.title=Epoxy
 nomifactory.quest.db.185.desc=Finally, §6Epoxy Resin Sheets§r.%n%nThese can be made into circuit boards as a substrate for advanced circuits.
 
 # db 186
-nomifactory.quest.db.186.title=Carbon Fibers
-nomifactory.quest.db.186.desc=§6Carbon Fibers§r are useful for a variety of things.%n%nTo make them, you should use an §3HV Autoclave§r or better to ensure a 100%% chance of producing them, as they are a chanced output with a base success rate of 85%% at MV.
+nomifactory.quest.db.186.title=§2Carbon Fibers
+nomifactory.quest.db.186.desc=§6Carbon Fibers§r are useful for a variety of things.%n%n§2They are made with Carbon Dust and polymers. Higher tier polymers grant higher yields. It's also not a chanced output anymore.
 
 # db 187
-nomifactory.quest.db.187.title=MV Energy Input And MV CEF
-nomifactory.quest.db.187.desc=With §6Aluminium§r, you can replace the two §aLV Energy Input Hatches§r on your Electric Blast Furnace with a single MV one, if you want. When you're ready to move on to HV recipes in the EBF, you'll want to move up to HV Energy Input Hatches, and so on.%n%nHowever, remember to keep the MV area separate from your LV area. §eHooking up an LV machine to MV current will result in the machine being destroyed! Also LV cables will burn up if you put MV current through them§r. That's why it's probably best to keep the areas separate until you're comfortable and confident with voltages. Eventually you can use transformers to switch voltages within a single setup, but don't feel forced to try that until you've got a grasp on the basics.%n%nAll RF power is the same (it has no voltages), so you can use RF conduits to route power from wherever you're generating and storing it to §3CEFs§r for each voltage. You don't have to use this setup, but it's the most foolproof one for a beginner. And if you're an expert, well... you don't need my advice.%n%nFor your MV cables, you can use §6Copper§r to start with. §6Energetic Alloy cables§r are lossless though, so consider them if you're able to mass produce those ingots.
+nomifactory.quest.db.187.title=MV Energy Converter
+nomifactory.quest.db.187.desc=Remember to keep the MV area separate from your LV area. §eHooking up an LV machine to MV current will result in the machine being destroyed! Also LV cables will burn up if you put MV current through them§r. That's why it's probably best to keep the areas separate until you're comfortable and confident with voltages. Eventually you can use transformers to switch voltages within a single setup, but don't feel forced to try that until you've got a grasp on the basics.%n%nAll RF power is the same (it has no voltages), so you can use RF conduits to route power from wherever you're generating and converting to EU with §3Energy Converters§r for each voltage. You don't have to use this setup, but it's the most foolproof one for a beginner. And if you're an expert, well... you don't need my advice.%n%nFor your MV cables, you can use §6Copper§r to start with. §6Energetic Alloy cables§r are lossless though, so consider them if you're able to mass produce those ingots.
 
 # db 188
-nomifactory.quest.db.188.title=Epoxy Substrate
-nomifactory.quest.db.188.desc=§6Epoxy Circuit Boards§r are a more advanced substrate type that gives you access to §6Microcircuits§r, which span tiers two through five. 
+nomifactory.quest.db.188.title=§2Epoxy Substrate
+nomifactory.quest.db.188.desc=§6Epoxy Circuit Boards§r are a more advanced substrate type that gives you access to §2Nanocircuits, which span tiers three through six.
 
 # db 190
 nomifactory.quest.db.190.title=Nano CPUs
@@ -771,44 +771,44 @@ nomifactory.quest.db.191.title=The Fourth And Final Tier Two Circuits
 nomifactory.quest.db.191.desc=Using your new §6Epoxy Circuit Boards§r and some familiar components, you can now make the final form of Tier Two Circuit: the §6Microcircuit§r.%n%nYou craft four of these at once, and they're pretty cheap. Consider that you used to have to make §6Primitive Processors§r for this tier, and realize how far you've come.%n%nAs with the final form of any tier of circuits, be sure to set up automation to stockpile these. You won't get to the §6System-on-Chip§r variant recipe for a while yet.
 
 # db 192
-nomifactory.quest.db.192.title=The First Tier Five Circuit
-nomifactory.quest.db.192.desc=The second Mainframe you'll have to contend with.%n%nThis is the first Tier Five circuit available, and consequently the most expensive to make. as always, invest in the next circuit theme to get to cheaper recipes as soon as possible.
+nomifactory.quest.db.192.title=§2The First Tier Five Circuit
+nomifactory.quest.db.192.desc=The first Mainframe you'll have to contend with.%n%nThis is the first Tier Five circuit available, and consequently the most expensive to make. as always, invest in the next circuit theme to get to cheaper recipes as soon as possible.
 
 # db 194
-nomifactory.quest.db.194.title=Glowstone Doped Silicon Boule
-nomifactory.quest.db.194.desc=A more advanced type of §6Silicon Boule§r, formed by doping the §6Silicon§r crystal lattice with §6Glowstone§r.%n%nThese are made in an §3EBF§r with §6Nichrome§r or better coils, and need §9Argon§r for the process. It needs twice as much Silicon as the basic boules, but also results in twice as many doped Silicon Wafers when sliced.%n%nCircuit Wafers can be made far more efficiently with these doped Silicon Wafers, but they are also needed for some more advanced types of Circuit Wafers that can't be engraved onto the basic ones.
+nomifactory.quest.db.194.title=§2Glowstone Doped Silicon Boule
+nomifactory.quest.db.194.desc=A more advanced type of §6Silicon Boule§r, formed by doping the §6Silicon§r crystal lattice with §6Glowstone§r.%n%nThese are made in an §3EBF§r with §6Nichrome§r or better coils, and need §2Nitrogen§r for the process. It needs twice as much Silicon as the basic boules, but also results in twice as many doped Silicon Wafers when sliced.%n%nCircuit Wafers can be made far more efficiently with these doped Silicon Wafers, but they are also needed for some more advanced types of Circuit Wafers that can't be engraved onto the basic ones.
 
 # db 195
-nomifactory.quest.db.195.title=Fusion Reactor MK3
-nomifactory.quest.db.195.desc=FUSION!%n%nThis baby can do any fusion recipe, notably giving you access to §6Neutronium§r.%n%nThe multiblock layout is the same as the Mark 1 and Mark 2, with the same hatch and casing substitutions permitted.%n%nObviously though, this one uses §6Fusion Machine Casing Mk II§r and only works with §aUV Energy Input Hatches§r.%n%nThe §3Mark 3 Fusion Reactor§r has an energy buffer of §e640M EU§r.
+nomifactory.quest.db.195.title=§2Fusion Reactor MK3
+nomifactory.quest.db.195.desc=FUSION!%n%nThis baby can do any fusion recipe, notably giving you access to §6Neutronium§r.%n%nThe multiblock layout is the same as the Mark 1 and Mark 2, with the same hatch and casing substitutions permitted.%n%nObviously though, this one uses §6Fusion Machine Casing Mk §2III§r and only works with §aUV Energy Input Hatches§r.%n%nThe §3Mark 3 Fusion Reactor§r has an energy buffer of §e640M EU§r.
 
 # db 196
-nomifactory.quest.db.196.title=Tritanium Ingot
-nomifactory.quest.db.196.desc=Looks absolutely identical to Europium, but it's not the same thing, I promise.%n%nTo make §9Tritanium§r, you first need to make §9Duranium§r. This is done by fusing molten §9Gallium§r and §9Radon§r in a §3Fusion Reactor Mark 1§r or better.%n%nOnce you have Duranium, you can fuse Tritanium in a §3Fusion Reactor Mark 2§r using the Duranium and molten §9Titanium§r.%n%nIf you're having trouble figuring out the right item and fluid ratios for batching up these processes, consider plugging the relevant recipes into the §aCrafting Calculator§r.
+nomifactory.quest.db.196.title=§2Tritanium Ingot
+nomifactory.quest.db.196.desc=§2Doesn't look exactly like Europium anymore.§r%n%nTo make §9Tritanium§r, you first need to make §9Duranium§r. This is done by fusing molten §9Gallium§r and §9Radon§r in a §3Fusion Reactor Mark 1§r or better.%n%nOnce you have Duranium, you can fuse Tritanium in a §3Fusion Reactor Mark 2§r using the Duranium and molten §9Titanium§r.%n%nIf you're having trouble figuring out the right item and fluid ratios for batching up these processes, consider plugging the relevant recipes into the §aCrafting Calculator§r.
 
 # db 197
 nomifactory.quest.db.197.title=Tungstensteel
 nomifactory.quest.db.197.desc=§6Tungstensteel§r is an alloy of §6Tungsten§r and §6Steel§r.%n%nThis alloy is cooked in an §3Electric Blast Furnace§r and cooled in a §3Vacuum Freezer§r.%n
 
 # db 198
-nomifactory.quest.db.198.title=IV Machine Hulls
-nomifactory.quest.db.198.desc=With §6Tungstensteel§r achieved, you can now make hulls for Insane Voltage (IV) §bGregTech§r machines.
+nomifactory.quest.db.198.title=§2IV Machine Hulls
+nomifactory.quest.db.198.desc=With §6Tungstensteel§r achieved, you can now make hulls for Insane Voltage (IV) §bGregTech§r machines.%n%n§2Starting at IV, 16A Energy and Dynamo hatches are available at each tier.
 
 # db 199
 nomifactory.quest.db.199.title=Yttrium Barium Cuprate
 nomifactory.quest.db.199.desc=§6Yttrium Barium Cuprate§r (more accurately, Yttrium Barium Copper Oxide, or YBCO) is, among other things, a high-temperature superconductor material.%n%nThis is used as plates in §bNuclearCraft§r, and will become an important cable material for later tiers of §bGregTech§r components.
 
 # db 201
-nomifactory.quest.db.201.title=Tungsten
-nomifactory.quest.db.201.desc=§6Tungsten§r is a material that requires an §3EV Electrolyzer§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r.%n%nIt is only found from §6Tungstate§r, which is an abundant component of §6Tungstate Ore§r and §6Scheelite Ore§r sent through your ore processing. Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r or extremely small quantities from centrifuging §9Lava§r.%n%nTungstate needs to be electrolyzed with §9Hydrogen§r to get to the Tungsten, which then needs to be cooked in the EBF for Tungsten ingots.%n%n
+nomifactory.quest.db.201.title=§2Tungsten
+nomifactory.quest.db.201.desc=§6Tungsten§r is a material that requires an §3EV Electrolyzer §2and Chemical Bath§r and an §3Electric Blast Furnace§r with at least §6Nichrome Coils§r.%n%nIt is only found from §6Tungstate§r §2Dust and Scheelite Dust, obtained from their respective ores.§r Tungstate is also obtainable in small quantities from centrifuging §6Endstone Dust§r.%n%nScheelite and Tungstate needs to be §2bathed in Hydrochloric Acid to make Tungstic Acid, then electrolyzed§r to get to the Tungsten, which then needs to be cooked in the EBF for Tungsten ingots.
 
 # db 202
 nomifactory.quest.db.202.title=Apollo Program
 nomifactory.quest.db.202.desc=This is one of the simpler rockets you can build. The specifics of the shape don't really matter, as long as the rocket engines are on the bottom and all the parts are added. It also needs to be inside the edges of the Launch Pad and not taller than the Structure Tower.%n%n§aIn order to progress this quest chain further, you'll first need to complete the Interdimensional Transport (either Dislocators or Telepad) questline and the Rocket Fuel questline, both of which are nearby on this quest tab.
 
 # db 203
-nomifactory.quest.db.203.title=The Second Tier Three Circuits
-nomifactory.quest.db.203.desc=Marginally cheaper to make than §6Electronic Processor Arrays§r, and also the only way to make §6Refined Processor Mainframes§r, which is the first Tier Four circuit.
+nomifactory.quest.db.203.title=§2The Second Tier Three Circuits
+nomifactory.quest.db.203.desc=Marginally cheaper to make than §2Advanced Integrated Circuits§r, and also the only way to make the §2Workstation§r, which is the first Tier Four circuit.
 
 # db 204
 nomifactory.quest.db.204.title=Space Suit
@@ -835,8 +835,8 @@ nomifactory.quest.db.209.title=Advanced Extended Crafting Table
 nomifactory.quest.db.209.desc=With the Extended Crafting Table, you can now craft 5x5 recipes.
 
 # db 210
-nomifactory.quest.db.210.title=Steel Heavy Plates
-nomifactory.quest.db.210.desc=Even simple rockets demand §6Heavy Plates§r for their construction. In this case, made out of §6Steel§r. This plate requires at least an §6MV Compressor§r.
+nomifactory.quest.db.210.title=§2Steel Heavy Plates
+nomifactory.quest.db.210.desc=Even simple rockets demand §6Heavy Plates§r for their construction. In this case, made out of §6Steel§r. 
 
 # db 211
 nomifactory.quest.db.211.title=Flightplan To The Moon
@@ -851,20 +851,20 @@ nomifactory.quest.db.213.title=Staff of Traveling
 nomifactory.quest.db.213.desc=Holding one of these reveals §aTravel Anchors§r and §aTelepads§r in range.%n%nShift + right-click after aiming to warp to one, or point it anywhere to teleport forward a short distance (works through walls).%n%nThese are powered with RF, and can be further enchanted through §bEnderIO§r's enchanting mechanics.%n%nThe §6Vibrant Crystal§r will require an §3Autoclave§r.
 
 # db 214
-nomifactory.quest.db.214.title=Deuterium
-nomifactory.quest.db.214.desc=The Moon is a barren, lifeless rock... So why did you want to come here?%n%nOne major draw is that §6Moon Turf§r, which makes up the surface of the Moon, is an efficient means of obtaining §9Deuterium§r. It will be useful for producing §9Microversium§r, §9Tritium§r, plasmas from fusion, and crystallizing §6Dilithium§r.%n%nThere are also several ores that are rare on the Overworld but exist in abundance on the Moon. In particular, the Moon contains large quantities of §6Titanium§r (in the form of §6Rutile Ore§r and §6Ilmenite Ore§r) and §6Tungsten§r (in the form of §6Scheelite Ore§r and §6Tungstate Ore§r).%n%nMuch later you will also gain access to the §3Lunar Mining Station§r, which as the name suggests only works on the Moon.%n%n
+nomifactory.quest.db.214.title=§2Deuterium
+nomifactory.quest.db.214.desc=The Moon is a barren, lifeless rock... So why did you want to come here?%n%nOne major draw is that §6Moon Turf§r, which makes up the surface of the Moon, is an efficient means of obtaining §9Deuterium§r. It will be useful for producing §9Microversium§r, §9Tritium§r, plasmas from fusion, and crystallizing §6Dilithium§r.%n%nThere are also several ores that are rare on the Overworld but exist in abundance on the Moon. In particular, the Moon contains large quantities of §6Titanium§r (in the form of §6Rutile Ore§r and §6Ilmenite Ore§r) and §6Tungsten§r (in the form of §6Scheelite Ore§r and §6Tungstate Ore§r).%n%n§2The Moon also contains fluid deposits of Deuterium and Helium-3, which you can harvest with a Fluid Rig. However, you will want to use the second Fluid Rig tier to extract it, as the amount of Deuterium and Helium-3 is too low to be anything appreciable from a first tier Fluid Rig.%n
 
 # db 215
-nomifactory.quest.db.215.title=Ender Pump and Ender Tanks
-nomifactory.quest.db.215.desc=Great for gathering large amounts of §9lava§r and §9oil§r, at least until you have better ways to obtain them.%n%n§3Ender Pumps§r use RF to function.%n%n§aEnder Tanks§r do not require power, but rather simply store fluid. All Ender Tanks on the same 'channel' (denoted by the three colors on the top) have the same contents, essentially allowing for §einstant long range transfer of fluid§r.%n%nTry setting up one Ender Tank by an Ender Pump positioned over lava, and the other back up in your base. You'll have more lava than you know what to do with, without any boring bucketing.%n%nYou'll need a way to power the Ender Pump though... maybe a §aMagmatic Dynamo§r on site?
+nomifactory.quest.db.215.title=§2Pumps
+nomifactory.quest.db.215.desc=§2Pumps are now available in GT. Useful for gathering Oil or perhaps Lava from the Nether.
 
 # db 216
-nomifactory.quest.db.216.title=Small Microverse Projector
+nomifactory.quest.db.216.title=§2Small Microverse Projector
 nomifactory.quest.db.216.desc=This is your first §3Microverse Projector§r.%n%nThese structures are used to project §6Micro Miners§r into a §eMicroverse§r to obtain valuable loot such as §6ores§r, §6gems§r, and otherwise unobtainable items§r like §6Radium Salt§r and §6Naquadah Dust§r. §cKeep in mind that Micro Miners are single-use!§r%n%nMicroverse Projectors are §bGregTech§r multiblocks, which means that they're just as flexible as other machines in terms of the I/O block placement: §epositions of Buses and Hatches can be swapped with any Microverse Projector Casing§r.%n%nA single §6HV Energy Input§r supports missions up to 1024 EU/t. To process the rest, you'll need to upgrade the multiblock to at least §eEV power§r, which is either §6two HV Energy Inputs§r or §6one EV Energy Input§r. Missions will also overclock, increasing in speed each time the projector's energy tier increases and available power reaches the next multiple of four times the base mission power.%n%nHover your mouse over the Small Microverse Projector and press §bU§r to see all available missions.%n%n§6Sneak-right click§r the controller to enable the in-world preview.
 
 # db 217
-nomifactory.quest.db.217.title=First Foray Into The Microverse
-nomifactory.quest.db.217.desc=This is your first Micro Miner ever.%nYes, not the last: these things aren't reusable.%n%nThis one can get you:%n§6* Cassiterite Ore%n* Dense Iron Ore%n* Uraninite Ore%n* Redstone Ore%n* Nickel Ore%n* Rutile Ore%n* Galena Ore%n* Moon Turf%n* Dilithium%n* Salt Ore§r%n%nWhen equipped with a Gemstone Sensor (which may currently not be available to you yet):%n§6* Exquisite Diamond%n* Apatite Ore%n* Tricalcium Phosphate Ore%n* Quartzite Ore§r%n%nCan also be used to bring §bStellar Creation Data§r, but less efficiently than the Tier Two.%n%n
+nomifactory.quest.db.217.title=§2First Foray Into The Microverse
+nomifactory.quest.db.217.desc=This is your first Micro Miner ever.%nYes, not the last: these things aren't reusable.%n%nThis one can get you:%n§6* Cassiterite Ore%n* Dense Iron Ore%n* Uraninite Ore%n* Redstone Ore%n* Nickel Ore%n§2* Bauxite Ore%n§6* Galena Ore%n* Moon Turf%n* Dilithium%n* Salt Ore§r%n§2* Molybdenum Ore§r%n%nWhen equipped with a Gemstone Sensor (which may currently not be available to you yet):%n§2* Perfect Diamond%n§6* Apatite Ore%n* Tricalcium Phosphate Ore%n* Quartzite Ore§r%n%nCan also be used to bring §bStellar Creation Data§r, but less efficiently than the Tier Two.%n%n
 
 # db 219
 nomifactory.quest.db.219.title=Travel Anchors
@@ -895,8 +895,8 @@ nomifactory.quest.db.225.title=Methanol
 nomifactory.quest.db.225.desc=§9Oxygen§r, §9Hydrogen§r, and §6Carbon§r combine together in a §3Chemical Reactor§r to make §9Methanol§r.%n%nYou can also use a §3Distillation Tower§r to get Methanol from §9Wood Vinegar§r and §9Fermented Biomass§r.
 
 # db 226
-nomifactory.quest.db.226.title=Hypochlorous Acid
-nomifactory.quest.db.226.desc=§9Water§r and §9Chlorine§r can be combined to make §9Hypochlorous Acid§r. If you add §9Mercury§r to catalyze the reaction, the yield is much better.%n%n§ePlease note that Hypochlorous Acid and Hydrochloric Acid are different things.§r%n%nYou're already familiar with Chlorine production from your forays into Plastics, but a great source of Mercury is electrolyzing §6Redstone§r.
+nomifactory.quest.db.226.title=§2Hypochlorous Acid
+nomifactory.quest.db.226.desc=§9Water§r and §9Chlorine§r can be combined to make §9Hypochlorous Acid§r. If you add §9Mercury§r to catalyze the reaction, the yield is much better.%n%n§ePlease note that Hypochlorous Acid and Hydrochloric Acid are different things.§r%n%nYou're already familiar with Chlorine production from your forays into Plastics, but a great source of Mercury is §2centrifuging§4 §6Redstone§r.
 
 # db 227
 nomifactory.quest.db.227.title=MV Chemical Reactor
@@ -935,8 +935,8 @@ nomifactory.quest.db.235.title=Primal Mana
 nomifactory.quest.db.235.desc=Melting §6Mana Dust§r in a §3Fluid Extractor§r produces §9Primal Mana§r, which is needed for smelting various alloys from §bThermal Expansion§r.
 
 # db 236
-nomifactory.quest.db.236.title=Transistor
-nomifactory.quest.db.236.desc=§6Transistors§r are semiconductors that can amplify or switch electrical signals and power. They're probably one of the most important inventions of the 20th century.%n%nYou're going to use them as a component for better circuits. This one is a bit pricey, requiring §6Aluminium Foil§r and §6Fine Silver Wire§r.
+nomifactory.quest.db.236.title=§2Transistor
+nomifactory.quest.db.236.desc=§6Transistors§r are semiconductors that can amplify or switch electrical signals and power. They're probably one of the most important inventions of the 20th century.%n%nYou're going to use them as a component for better circuits. This one is a bit pricey, requiring §2PE, Silicon Plates and Fine Tin Wire.
 
 # db 237
 nomifactory.quest.db.237.title=Meteorite Hunter
@@ -955,28 +955,28 @@ nomifactory.quest.db.240.title=Tier Nine Micro Miner
 nomifactory.quest.db.240.desc=The Ninth Micro Miner.%n%nCombines §bStellar Creation Data§r into the §dUniverse Creation Data§r, which is a crucial component for the Tier Ten Micro Miner mission.%n%nThe alternate mission brings a decent quantity of §6Neutronium§r, but you have to bootstrap it with some Neutronium from the §3Fusion Reactor Mark 3§r anyway. It might be easier to just make all your Neutronium in the reactor, but it's up to you.
 
 # db 241
-nomifactory.quest.db.241.title=Crystal Matrix Heavy Plating
+nomifactory.quest.db.241.title=§2Crystal Matrix Heavy Plating
 nomifactory.quest.db.241.desc=Heavy plating used exclusively for the Tier Eight Micro Miner. 
 
 # db 242
-nomifactory.quest.db.242.title=Wetware Substrate
-nomifactory.quest.db.242.desc=The most advanced substrate available, crafted and grown with bleeding-edge bioengineering technology.%n%n§6Wetware Circuit Boards§r are the basis of §6Wetware§r circuits, the final theme that spans tiers six through nine.
+nomifactory.quest.db.242.title=§2Wetware Substrate
+nomifactory.quest.db.242.desc=The most advanced substrate available, prepared for bleeding-edge bioengineering technology.%n%n§6Wetware Circuit Boards§r are the basis of §6Wetware§r circuits, the final theme that spans tiers six through nine.
 
 # db 243
 nomifactory.quest.db.243.title=Superconducting Coil Block
-nomifactory.quest.db.243.desc=§6Superconductor coils§r are the eighth coil material available, increasing your EBF's operating temperature to 9001K so it can process more advanced materials.%n
+nomifactory.quest.db.243.desc=
 
 # db 244
 nomifactory.quest.db.244.title=Draconic Reactor Core
 nomifactory.quest.db.244.desc=§6Awakened Draconium§r, §6Chaos Shards§r, and §6Stabilized Einsteinium§r can be used in a Draconic Tier fusion crafting setup to create a §6Draconic Reactor Core§r.%n%nThis is an important component in the Tier Nine and Tier Ten Micro Miners, as well as some Endgame items.
 
 # db 245
-nomifactory.quest.db.245.title=Titanium Heavy Plating
+nomifactory.quest.db.245.title=§2Titanium Heavy Plating
 nomifactory.quest.db.245.desc=Heavy: avoid dropping it on your foot.%n%nThis special plating is used for two things-- §6Tier Two Micro Miners§r and the §3Space Station Assembler§r.
 
 # db 246
-nomifactory.quest.db.246.title=Tungsten Carbide Heavy Plating
-nomifactory.quest.db.246.desc=Heavy Plating for Micro Miners made from §6Tungsten Carbide§r.%n%nYou'll need an §3EV Compressor§r to make these.
+nomifactory.quest.db.246.title=§2Tungsten Carbide Heavy Plating
+nomifactory.quest.db.246.desc=Heavy Plating for Micro Miners made from §6Tungsten Carbide§r.%n%nYou §2no longer need high tier Compressors to make these.
 
 # db 248
 nomifactory.quest.db.248.title=Space Station Assembler
@@ -991,31 +991,31 @@ nomifactory.quest.db.250.title=Dilithium
 nomifactory.quest.db.250.desc=§6Dilithium Crystals§r are used to power Warp Cores, and are also a key component in several Micro Miner missions.%n%nThey are made by crystallizing §6Dilithium Dust§r with §9Deuterium§r in an §3Autoclave§r.
 
 # db 251
-nomifactory.quest.db.251.title=Tier Four Micro Miner
-nomifactory.quest.db.251.desc=The Fourth Micro Miner.%n%nAll of the Tier Four missions require §68 Quantum Flux§r and a stack of §6Petrotheum Dust§r.%n%nThis miner is the first convenient source of §6Osmium§r and §6Iridium§r, via a mission requiring §6Wither Realm Data§r.%n%nA §6Composition Sensor§r instead directs the miner to obtain §6Dense Oilsands Ore§r, equivalent to 32 stacks of §6Oilsands Ore§r.%n%nWhen equipped with a §6Gemstone Sensor§r:%n§6* Dense Redstone Ore%n* Dense Emerald Ore%n* Dense Diamond Ore%n* Dense Lapis Ore%n* Dense Coal Ore§r
+nomifactory.quest.db.251.title=§2Tier Four Micro Miner
+nomifactory.quest.db.251.desc=The Fourth Micro Miner.%n%nAll of the Tier Four missions require §68 Quantum Flux§r and a stack of §6Petrotheum Dust§r.%n%nThis miner is the first convenient source of §6Osmium§r and §6Iridium§r, via a mission requiring §6Wither Realm Data§r.%n%nA §6Composition Sensor§r instead directs the miner to obtain §6Dense Oilsands Ore§r, equivalent to §264§r stacks of §6Oilsands Ore§r.%n%nWhen equipped with a §6Gemstone Sensor§r:%n§6* Dense Redstone Ore%n* Dense Emerald Ore%n* Dense Diamond Ore%n* Dense Lapis Ore%n* Dense Coal Ore§r
 
 # db 252
-nomifactory.quest.db.252.title=Tier Five Micro Miner
-nomifactory.quest.db.252.desc=The Fifth Micro Miner.%n%nThe only source of §6Naquadah Dust§r.%n%nWhen provided with §6Stabilized Uranium§r, brings:%n§6* Uranium 238 Ore%n* Molybdenite Ore%n* Tennantite Ore%n* Bastnasite Ore%n* Sphalerite Ore%n* Palladium Ore%n* Beryllium Ore%n* Monazite Ore%n* Osmium Ore%n* Enderpearl §mOre§r§6 Blocks%n* Boron Dust§r
+nomifactory.quest.db.252.title=§2Tier Five Micro Miner
+nomifactory.quest.db.252.desc=The Fifth Micro Miner.%n%nThe only source of §6Naquadah §2Ore§r. Along with it, §2Sheldonite Ore§r (for §6PGS§r) and §2Kaemanite Ore§r (for §6Trinium§r).%n%nWhen provided with §6Stabilized Uranium§r, brings:%n§6§2* Uraninite Ore§6%n* Molybdenite Ore%n* Bastnasite Ore%n* Sphalerite Ore%n* Palladium Ore%n* Beryllium Ore%n* Monazite Ore%n§2* Osmiridium 80/20 Ore%n* Realgar Ore§6§r%n§6* Enderpearl Blocks%n* Boron Dust§r
 
 # db 253
 nomifactory.quest.db.253.title=Iridium
-nomifactory.quest.db.253.desc=§6Iridium§r is an advanced material used for Micro Miner plating, §6ZPM Machine Hulls§r, and for alloying with §6Osmium§r into §6Osmiridium§r.%n%n§6Iridium Ore§r is available renewably from the Tier Four and Tier Six micro miners.%n%nIt can also be reliably obtained from purifying §6Platinum§r or Osmium§r in a §3Chemical Bath§r, as well as from ore processing Osmium generally.
+nomifactory.quest.db.253.desc=§6Iridium§r is an advanced material used for Micro Miner plating, §6§rand for alloying with §6Osmium§r into §6Osmiridium§r.%n%n§6Iridium Ore§r is available renewably from the Tier Four and Tier Six micro miners.
 
 # db 254
-nomifactory.quest.db.254.title=Tier Six Micro Miner
-nomifactory.quest.db.254.desc=The Sixth Micro Miner.%n%nThe first decent source of §6Dragon Eggs§r and §6Stabilized Einsteinium§r.%n%nIs also useful for:%n§6* Uranium 238 Ore%n* Iridium Ore%n* Osmium Ore
+nomifactory.quest.db.254.title=§2Tier Six Micro Miner
+nomifactory.quest.db.254.desc=The Sixth Micro Miner.%n%nThe first decent source of §6Dragon Eggs§r and §6Stabilized Einsteinium§r.%n%nIs also useful for:%n§6§2* Uraninite Ore%n* Iridosmine 80/20 Ore%n* Osmiridium 80/20 Ore
 
 # db 255
 nomifactory.quest.db.255.title=Tungsten Carbide
 nomifactory.quest.db.255.desc=An alloy of equal parts §6Tungsten§r and §6Carbon Dust§r.%n%n§6Tungsten Carbide§r is a very dense, sturdy, and heat-resistant material useful for a variety of applications.
 
 # db 256
-nomifactory.quest.db.256.title=Tier Seven Micro Miner
-nomifactory.quest.db.256.desc=The Seventh Micro Miner.%n%nThe source of §6Dragon Hearts§r and the valuable §6Lair of The Chaos Guardian Data§r.%n%nAs a bonus, brings §6Dragon Eggs, Dragon's Breath, Ender Dragon Scales§r and a plenty of different precious metals and gems.
+nomifactory.quest.db.256.title=§2Tier Seven Micro Miner
+nomifactory.quest.db.256.desc=The Seventh Micro Miner.%n%nThe source of §6Dragon Hearts§r and the valuable §6Lair of The Chaos Guardian Data§r.%n%nAs a bonus, brings §6Dragon Eggs, Dragon's Breath, Ender Dragon Scales§r, §2Americium Blocks§r and a plenty of different precious metals and gems.
 
 # db 257
-nomifactory.quest.db.257.title=Draconium Heavy Plating
+nomifactory.quest.db.257.title=§2Draconium Heavy Plating
 nomifactory.quest.db.257.desc=Heavy plating used exclusively for the Tier Seven Micro Miner. 
 
 # db 258
@@ -1023,8 +1023,8 @@ nomifactory.quest.db.258.title=Awakened Draconium
 nomifactory.quest.db.258.desc=§6Awakened Draconium§r is a powerful material used for crafting high-grade components, items, and machines from §bDraconic Evolution§r.%n%nFive §6§6Draconium Blocks§r can be processed in a Wyvern Tier fusion crafting setup to create an equal output of five §6Awakened Draconium Blocks§r. At §e24 Billion RF per craft§r, you better have a handle on your power infrastructure.
 
 # db 259
-nomifactory.quest.db.259.title=MV Machine Hulls
-nomifactory.quest.db.259.desc=Your first MV hull is as good of a place as any to consider yourself graduated from LV.%n%nYou might notice that these hulls can be made more cheaply in an §3Assembling Machine§r, but you don't have that weird fluid. Don't worry, you'll be able to make that soon.
+nomifactory.quest.db.259.title=§2MV Machine Hulls
+nomifactory.quest.db.259.desc=Your first MV hull is as good of a place as any to consider yourself graduated from LV.%n%nYou might notice that these hulls can be made more cheaply in an §3Assembling Machine§r, but you don't have that weird fluid. Don't worry, you'll be able to make that soon.%n%n§2Overclocking mechanics have changed in CEu. All overclocks now multiply the speed by 2.0x (instead of the 2.0/2.8 split in CE). This means that to save energy, you should build more low-tier machines over overclocking a high-tier machine, especially for passive processes.%nAdditionally, ULV recipes will not overclock to LV. A ≤8 EU/t recipe won't overclock at all in an LV machine, will only overclock once in an MV machine, etc.
 
 # db 260
 nomifactory.quest.db.260.title=LV Electrolyzer
@@ -1040,35 +1040,35 @@ nomifactory.quest.db.262.desc=An advanced ingredient used for the §aUltimate Ex
 
 # db 263
 nomifactory.quest.db.263.title=Indium
-nomifactory.quest.db.263.desc=§6Indium§r is a rare material requiring specialized bulk ore processing to acquire. It is useful for making §6Indium Gallium Phosphide§r (InGaP).%n%nIf you were enterprising enough to discover and make §6Platinum Group Sludge Dust§r for early §6Osmium§r and §6Iridium§r, you'll be familiar with the general process.%n%nYou will need to purify (with a §3Washer§r or §3Chemical Bath§r) §6Galena§r and §6Sphalerite§r to get §6Crushed Purified§r dusts. These need to be placed together in a §3Chemical Reactor§r along with §9Sulfuric Acid§r, which will result in §9Indium Concentrate§r.%n%nThis in turn needs to be reacted with §6Aluminium§r in another Chemical Reactor, to create §6Tiny piles of Indium Dust§r and §9Lead-Zinc Solution§r. The latter can be centrifuged into various useful materials, and the Indium piles can be combined into full dusts.%n%n
+nomifactory.quest.db.263.desc=§6Indium§r is a rare material requiring specialized bulk ore processing to acquire. It is useful for making §6Indium Gallium Phosphide§r (InGaP).%n%nYou will need to purify (with a §3Washer§r or §3Chemical Bath§r) §6Galena§r and §6Sphalerite§r to get §6Crushed Purified§r dusts. These need to be placed together in a §3Chemical Reactor§r along with §9Sulfuric Acid§r, which will result in §9Indium Concentrate§r.%n%nThis in turn needs to be reacted with §6Aluminium§r in another Chemical Reactor, to create §2Small Piles of Indium Dust, Aluminium Sulfite and §9Lead-Zinc Solution§r. The latter two can be centrifuged into various useful materials, and the Indium piles can be combined into full dusts.%n%n§2Indium can also be obtained from the Naquadah processing chain in LuV.%n
 
 # db 264
-nomifactory.quest.db.264.title=The Fourth And Final Tier Four Circuits
-nomifactory.quest.db.264.desc=With your new §6Multi-Layer Fiber-Reinforced Epoxy Circuit Boards§r, §6QBit CPUs§r, and some standard components, you can make the final type of Tier Four Circuit: the §6Quantum Circuit§r.%n%nAs the best form of Tier Four circuit, these should be automated and stockpiled. The variant recipe requiring §6Advanced System-on-Chip§r won't be available until ZPM.
+nomifactory.quest.db.264.title=§2The Third And Final Tier Four Circuits
+nomifactory.quest.db.264.desc=With your new §6§6§ §6Epoxy Circuit Boards§r, §6QBit CPUs§r, and some standard components, you can make the final type of Tier Four Circuit: the §6Quantum Circuit§r.%n%nAs the best form of Tier Four circuit, these should be automated and stockpiled. The variant recipe requiring §6Advanced System-on-Chip§r won't be available until ZPM.
 
 # db 265
 nomifactory.quest.db.265.title=QBit Processing Unit
 nomifactory.quest.db.265.desc=§6QBit CPUs§r are an advanced Circuit Wafer crucial for §6Quantum Circuits§r.%n%nThere are two methods of creating them:%n%nThe simpler recipe uses two §6Quantum Eyes§r and two ingots worth of molten §9Gallium Arsenide§r to enhance a §6NanoCPU Wafer§r. This recipe is slow and requires substantially more §9Radon§r per craft.%n%nThe other route instead uses §6Indium Gallium Phosphide§r and a tiny amount of Radon. This skips the slow-crafting Quantum Eyes, using far less Radon in the process, but requires the infrastructure in place for obtaining §6Indium§r.%n%nThe second route is overall better, and you will need Indium processing to complete the pack so might as well do it.
 
 # db 266
-nomifactory.quest.db.266.title=Arsenic
-nomifactory.quest.db.266.desc=§6Arsenic§r can be obtained through the electrolysis of §6Cobaltite§r or §6Tennantite§r.%n%nThe latter comes renewably from a Tier Five Micro Miner mission, and Cobaltite can be found or purchased with §dOmnicoins§r.
+nomifactory.quest.db.266.title=§2GT Item Pipes
+nomifactory.quest.db.266.desc=§2Item Pipes are back in GTCEu! They will transport items instantly through them.%n%n§rTheir advantage over §5EnderIO §3Item Conduits§r is their far higher §6throughput§r. An unupgraded EIO Item Conduit transports §d8 items per second§r, and up to §d128§r when upgraded. In comparison, small low-tier Item Pipes can transfer §d64 items per second§r, and those made from later materials can transfer §dmultiple stacks per second§r.%n%nThey don't auto-extract by themselves, so you have to use §3Conveyor covers§r etc. with them.%n%nThe priority mechanics are more complicated, so skip ahead if you are not interested:%nA Destination will have a Routing Value calculated, which is the sum of all Routing Values of the individual Pipes to that Destination. Whichever Destination has the lowest Routing Value will be the one selected for Insertion.%nRestrictive Pipes typically have the lowest Priority for insertion due to their higher Routing Value.
 
 # db 267
-nomifactory.quest.db.267.title=Radon
-nomifactory.quest.db.267.desc=§9Radon§r will be needed in large quantities.%n%nFor now, you'll need to obtain it from Tier Two Micro Miner missions, in the form of §6Radium Salt§r. Electrolyze it for Radon and §6Rock Salt§r.%n%nLater it will be possible to make Radon using a §bGregTech§r §3Fusion Reactor§r.
+nomifactory.quest.db.267.title=§2Radon
+nomifactory.quest.db.267.desc=§9Radon§r will be needed in large quantities.%n%nFor now, you'll need to obtain it from Tier Two Micro Miner missions, in the form of §6Radium Salt§r. Electrolyze it for Radon and §6Rock Salt§r. §2You can also get it from distilling liquid Ender Air.§r%n%nLater it will be possible to make Radon using a §bGregTech§r §3Fusion Reactor§r.
 
 # db 268
-nomifactory.quest.db.268.title=The Third Tier Five Circuit
+nomifactory.quest.db.268.title=§2The Third Tier Five Circuit
 nomifactory.quest.db.268.desc=Nothing new here, just use more standard circuit stuff and you can upgrade several §6Quantum Circuits§r into a §6Quantum Processor§r.
 
 # db 269
-nomifactory.quest.db.269.title=The Second Tier Six Circuits
-nomifactory.quest.db.269.desc=§6Power IC Wafer§r may be new if you skipped some of the battery quests, but it is now relevant. %n%nUsing these wafers, some §6Chrome Plates§r, a §6Quantum Eye§r, and §6Signalum Wire§r, several §6Quantum Processors§r may be upgraded into a §6Quantum Processor Array§r.
+nomifactory.quest.db.269.title=§2The Second Tier Six Circuits
+nomifactory.quest.db.269.desc=§2Nothing special about this tier either.
 
 # db 270
-nomifactory.quest.db.270.title=LV Macerator
-nomifactory.quest.db.270.desc=§3Macerators§r are useful for grinding things down, replacing the §aMortars§r you've needed until now. This is an important machine you will be using for many things in the future.%n%nOne useful application for a Macerator in the near future is grinding down §6Clay§r or §6Terracotta§r into §6Clay Dust§f. You can also configure several of them to make a pipeline that grinds down §6Cobblestone§r into §6Gravel§r, then §6Sand§r, then §6Dust§r.%n%nBesides not having limited durability, a key advantage of Macerators over Mortars is the chance to get additional materials when grinding things down. These are called §ebyproducts§r, and HV or better Macerators have three slots instead of one so byproducts can appear.%n%nWhen reading Macerator recipes in §bJEI§r, you can tell which outputs are byproducts by seeing if §ethe tooltip tells you it has a chance to appear§r: guaranteed outputs do not list a chance. The chance displayed for Macerator recipes is always at MV, and the chance §edoubles each tier past MV§r your macerator is, up to a maximum of 100%%.%n%nFor example, the primary output from crushing ores scales as follows:%n• LV: §c0%%%n§r• MV: §c14%%§r (as listed in §bJEI§r)%n§r• HV: §a28%%%n§r• EV: §a56%%%n§r• IV and better: §a100%%§r%n%nFinally, a Macerator will only start processing if there is room for all possible outputs. Make sure you empty them so they can keep working.
+nomifactory.quest.db.270.title=§2LV Macerator
+nomifactory.quest.db.270.desc=§3Macerators§r are useful for grinding things down, replacing the §aMortars§r you've needed until now. This is an important machine you will be using for many things in the future.%n%nOne useful application for a Macerator in the near future is grinding down §6Clay§r or §6Terracotta§r into §6Clay Dust§f.%n%nBesides not having limited durability, a key advantage of Macerators over Mortars is the chance to get additional materials when grinding things down. These are called §ebyproducts§r, and HV or better Macerators have three slots instead of one so byproducts can appear.%n%nWhen reading Macerator recipes in §bJEI§r, you can tell which outputs are byproducts by seeing if §ethe tooltip tells you it has a chance to appear§r: guaranteed outputs do not list a chance. §2The chance increases by a certain amount for each tier of machine you have above the tier of recipe. This chance is also listed in the tooltip.§r%n%n§2Macerators can now also recycle your old Machines for some extra materials.§r%n%nFinally, a Macerator will only start processing if there is room for all possible outputs. Make sure you empty them so they can keep working.
 
 # db 271
 nomifactory.quest.db.271.title=Reactor Stabilizer
@@ -1080,7 +1080,7 @@ nomifactory.quest.db.272.desc=The first tier of §6capacitors§r. These (or stro
 
 # db 273
 nomifactory.quest.db.273.title=LV Mixer
-nomifactory.quest.db.273.desc=Mixes two dusts to make a third.%n%nFor now, you'll be using it to make §6Glowstone Dust§r and §6Energetic Blend§r.%n%nGlowstone Dust is made from §6Tricalcium Phosphate Dust§r and §6Gold Dust§r, or you could eventually gather it from the Nether.%n%nEnergetic Blend is made from Glowstone Dust and §6Redstone Dust§r.
+nomifactory.quest.db.273.desc=Mixes two dusts to make a third.%n%nFor now, you'll be using it to make §6Glowstone Dust§r.%n%nGlowstone Dust is made from §6Tricalcium Phosphate Dust§r and §6Gold Dust§r, or you could eventually gather it from the Nether.
 
 # db 274
 nomifactory.quest.db.274.title=Dragon Hearts
@@ -1111,35 +1111,35 @@ nomifactory.quest.db.282.title=Energy Acceptor
 nomifactory.quest.db.282.desc=Fluix is initially made via in-world crafting, by dropping §6Redstone Dust§r, §6Nether Quartz§r, and a §6Charged Certus Quartz Crystal§r in the same block of §9Water§r. You'll see some sparks then the items will merge into a §6Fluix Crystal§r. Be sure to turn off any nearby item magnets/collectors or they might interrupt this crafting process.%n%nThe §3Energy Acceptor§r converts RF power into AE power that Applied Energistics uses, in a 2 RF to 1 AE ratio. This power will be transmitted through adjacent full-block ME Network devices, as well as along all connected §6ME Cables§r, §6ME Conduits§r, and §6Quartz Fiber§r. %n%nQuartz Fiber are §emicroparts§r you can put between an ME Cable and any ME Network block or another ME Cable. This will allow transmission of AE power but not data, which is useful for having data-isolated ME Networks all sharing the same power source.
 
 # db 283
-nomifactory.quest.db.283.title=LuV Assembling Machine
-nomifactory.quest.db.283.desc=With your §6Lumium§r-based machine hulls, Assembling Machine built, and §6Quantum Processor Mainframes§r squared away, you can finally get on the path to making a Ludicrous Voltage §3Assembling Machine§r.%n%nThis tier of Assembling Machine unlocks §6Crystal Circuits§r, as well as handling crafting recipes up to 32768 EU/t. It can also optionally overclock recipes that consume up to 8192 EU/t for improved speed at the cost of relatively more power.
+nomifactory.quest.db.283.title=§2LuV Circuit Assembling Machine
+nomifactory.quest.db.283.desc=With your §6§2Rhodium Plated Lumium-Palladium§r-based machine hulls, Assembling Machine built, and §6Quantum Processor Mainframes§r squared away, you can finally get on the path to making a Ludicrous Voltage §3Circuit Assembling Machine§r.%n%nThis tier of Assembling Machine unlocks §6Crystal Circuits§r, as well as handling crafting recipes up to 32768 EU/t. It can also optionally overclock recipes that consume up to 8192 EU/t for improved speed at the cost of relatively more power.
 
 # db 285
 nomifactory.quest.db.285.title=Vanadium Gallium
-nomifactory.quest.db.285.desc=§6Vanadium-Gallium§r is an alloy made in the §3Electric Blast Furnace§r. It is a Ludicrous Voltage (LuV) cable material needed for certain recipes.%n%n§6Vanadium§r is an element acquired by processing §6Vanadium Magnetite Ore§r.
+nomifactory.quest.db.285.desc=§6Vanadium-Gallium§r is an alloy made in the §3Electric Blast Furnace§r. It is a Ludicrous Voltage (LuV) cable material needed for certain recipes.%n%n§6
 
 # db 286
-nomifactory.quest.db.286.title=Assembly Line
-nomifactory.quest.db.286.desc=The §3Assembly Line§r is a large multiblock structure that crafts complex materials, similar to an §3Assembling Machine§r. These will be crucial going forward for making a variety of components and machinery.%n%nMake sure your power generation and circuit production are up to the challenge. It is useful to make at least two of these to avoid recipe conflicts and for different programmed circuits.%n%nNotice that all numbers of required items are §emultiples of 12§r. This is to make an Assembly Line that's 12 units long, allowing for 11 inputs and one output. This is a large enough Assembly Line to make a §aFusion Reactor Controller Mk1§r, but you'll need to expand to more inputs for later projects.%n%n§aFluid Input Hatches§r can replace any of the §6Steel Casings§r along the bottom outside except for the Casings touching the §aOutput Bus§r. For the most part, ULV ones work fine, but a few recipes will need an LV one.%n%nThe §aEnergy Input Hatches§r along the top can be replaced by Steel Casings: you only need the one Energy Input Hatch (although you can add more if you want).%n%nThe §aInput Buses§r along the bottom §emust be ULV tier§r, nothing else. Make sure to spin them all so the hole is on the bottom.
+nomifactory.quest.db.286.title=§2Assembly Line
+nomifactory.quest.db.286.desc=The §3Assembly Line§r is a large multiblock structure that crafts complex materials, similar to an §3Assembling Machine§r. These will be crucial going forward for making a variety of components and machinery.%n%nMake sure your power generation and circuit production are up to the challenge. §2None of the Assembly Line recipes require programmed circuits anymore.§r%n%nNotice that all numbers of required items are §emultiples of 11.§r This is to make an Assembly Line that's 11 units long, allowing for 10 inputs and one output. This is a large enough Assembly Line to make a §aFusion Reactor Controller Mk1§r, but you'll need to expand to more inputs for later projects.%n%n§2You will also need a Maintenance Hatch.%n%n§aFluid Input Hatches§r can replace any of the §6Steel Casings§r along the bottom outside except for the Casings touching the §aOutput Bus§r. For the most part, ULV ones work fine, but a few recipes will need an LV one.%n%nThe §aEnergy Input Hatches§r along the top can be replaced by Steel Casings: you only need the one Energy Input Hatch (although you can add more if you want).%n%nThe §aInput Buses§r along the bottom §emust be ULV tier§r, nothing else. Make sure to spin them all so the hole is on the bottom.
 
 # db 287
-nomifactory.quest.db.287.title=Fusion Reactor MK1
-nomifactory.quest.db.287.desc=Time to get fusing!%n%nThe §3Fusion Reactor§r is a multiblock that uses enormous amounts of energy to fuse fluids into new elements. This one is less flexible than the previous GregTech multiblocks, as you can only put hatches where the preview shows. §6Sneak-right click§r the controller to enable the in-world preview.%n%nThe §bJEI§r preview shows §e§eall valid hatch locations§r, but you don't actually need that many fluid hatches. You can replace any of the hatch positions in the structure with §6LuV Machine Casings§r, as long as you have at least §atwo Fluid Input Hatches§r and §aone Fluid Output Hatch§r. It's possible to use input/output hatches in every valid location, if you prefer.%n%nBecause of this, the quest only asks for §a80 LuV Machine Casings§r. If you want to use the minimum number of fluid hatches, you'll need to craft an additional §a28 casings§r.%n%nEach §aEnergy Input Hatch§r increases the reactor's power buffer. §aAll 16 Energy Input Hatches§r are required to be able to process all Mark 1 recipes and give a power buffer of §e160M EU§r.%n%nIn addition to the recipe power drain, Fusion Reactors have a §eheat§r mechanic related to the recipe's §e"Eu to Start"§r. This amount of power is drained from the reactor's buffer before starting the recipe to heat up the reactor to the necessary temperature, and is independent of the recipe's EU/t cost. As such, this determines the minimum tier of reactor you need for a recipe.%n%nIf the reactor stops processing, it will §erapidly lose heat§r, even if you pause it with a soft hammer. On the other hand, if the reactor is already at the required temperature for a recipe, §eno additional power§r is required to heat up the reactor! This is true even if you switch between different recipes. This mechanic incentivizes continuous use of the reactor.%n%nIf you switch to a recipe that requires more heat, §eonly the difference§r in heat values is consumed as EU to reach the target heat (up to a maximum heat equal to the reactor's current buffer).%n%nFusion Reactors don't overclock, and they gate the next tier of materials, so you will eventually want to make more than one.
+nomifactory.quest.db.287.title=§2Fusion Reactor MK1
+nomifactory.quest.db.287.desc=Time to get fusing!%n%nThe §3Fusion Reactor§r is a multiblock that uses enormous amounts of energy to fuse fluids into new elements. This one is less flexible than the previous GregTech multiblocks, as you can only put hatches where the preview shows. §6Sneak-right click§r the controller to enable the in-world preview.%n%nThe §bJEI§r preview shows §e§eall valid hatch locations§r, but you don't actually need that many fluid hatches. You can replace any of the hatch positions in the structure with §2Fusion Glass or Fusion Machine Casings§r as long as you have at least §atwo Fluid Input Hatches§r and §aone Fluid Output Hatch§r. It's possible to use input/output hatches in every valid location, if you prefer.%n%nBecause of this, the quest only asks for §248 Fusion Machine Casings, 31 Fusion Glass§r. If you want to use the minimum number of fluid hatches, you'll need to craft an additional §231 Fusion Machine Casings§r.%n%nEach §aEnergy Input Hatch§r increases the reactor's power buffer. §aAll 16 Energy Input Hatches§r are required to be able to process all Mark 1 recipes and give a power buffer of §e160M EU§r.%n%nIn addition to the recipe power drain, Fusion Reactors have a §eheat§r mechanic related to the recipe's §e"Eu to Start"§r. This amount of power is drained from the reactor's buffer before starting the recipe to heat up the reactor to the necessary temperature, and is independent of the recipe's EU/t cost. As such, this determines the minimum tier of reactor you need for a recipe.%n%nIf the reactor stops processing, it will §erapidly lose heat§r, even if you pause it with a soft hammer. On the other hand, if the reactor is already at the required temperature for a recipe, §eno additional power§r is required to heat up the reactor! This is true even if you switch between different recipes. This mechanic incentivizes continuous use of the reactor.%n%nIf you switch to a recipe that requires more heat, §eonly the difference§r in heat values is consumed as EU to reach the target heat (up to a maximum heat equal to the reactor's current buffer).%n%nFusion Reactors §2now overclock§r, but they gate the next tier of materials, so you will eventually want to make more than one.
 
 # db 288
-nomifactory.quest.db.288.title=Draconium Ingots
-nomifactory.quest.db.288.desc=You'll need at least §6Naquadah Coil Blocks§r in your blast furnace to smelt §6Draconium§r, as well as a healthy supply of §9Nitro Diesel§r to reach the immense heat it takes to liquefy.%n%nDraconium gets so hot that it requires the potent coolant §9Gelid Cryotheum§r to aid your §3Vacuum Freezer§r in turning it into usable ingots.%n%nThere are several ways to make Draconium: dust can be smelted into ingots, but you can also turn §6Ender Dragon Scales§r, which contain Draconium, directly into ingots. It uses a lot of Nitro Diesel, but is the most efficient way to craft Draconium.%n%nYou've been stockpiling diesel, right?
+nomifactory.quest.db.288.title=§2Draconium Ingots
+nomifactory.quest.db.288.desc=You'll need at least §6Naquadah Coil Blocks§r in your blast furnace to smelt §6Draconium§r, as well as a healthy supply of §9Nitro Diesel §2or Gasoline§r to reach the immense heat it takes to liquefy.%n%nDraconium gets so hot that it requires the potent coolant §9Gelid Cryotheum§r to aid your §3Vacuum Freezer§r in turning it into usable ingots.%n%nThere are several ways to make Draconium: dust can be smelted into ingots, but you can also turn §6Ender Dragon Scales§r, which contain Draconium, directly into ingots. It uses a lot of§2 combustion fuel§r, but is the most efficient way to craft Draconium.%n%nYou've been stockpiling fuel, right?
 
 # db 289
-nomifactory.quest.db.289.title=Engraved Crystal Chip
-nomifactory.quest.db.289.desc=By baking an §6Exquisite Emerald§r and §6Emerald Plates§r with §9Helium§r in an §3Electric Blast Furnace§r, you can create an §6Engraved Crystal Chip§r.%n%nThis is a material needed for §6Crystal Circuits§r.
+nomifactory.quest.db.289.title=§2Engraved Crystal Chip
+nomifactory.quest.db.289.desc=By baking a §2Raw Crystal Chip §rand §6Emerald Plates§r with §9Helium§r in an §3Electric Blast Furnace§r, you can create an §6Engraved Crystal Chip§r.%n%nThis is a material needed for §6Crystal Circuits§r.
 
 # db 291
-nomifactory.quest.db.291.title=Crystal Processing Unit
-nomifactory.quest.db.291.desc=§6Crystal CPUs§r are the cores of §6Crystal Circuits§r.%n%nYou'll need an §3IV Precision Laser Engraver§r to craft this.
+nomifactory.quest.db.291.title=§2Crystal Processing Unit
+nomifactory.quest.db.291.desc=§6Crystal CPUs§r are the cores of §6Crystal Circuits§r.%n%nYou'll need an §2LuV Precision Laser Engraver§r to craft this.
 
 # db 292
-nomifactory.quest.db.292.title=The Third Tier Six Circuits
+nomifactory.quest.db.292.title=§2The Third Tier Six Circuits
 nomifactory.quest.db.292.desc=With some now-standard components you can upgrade a few §6Crystal Circuits§r into a §6Crystal Processor§r.
 
 # db 293
@@ -1227,15 +1227,15 @@ nomifactory.quest.db.313.title=HSS-G Coil Block
 nomifactory.quest.db.313.desc=§6HSS-G§r is the fifth coil material available, increasing your EBF's operating temperature to 5400K so it can process more advanced materials, such as §6Naquadah§r.
 
 # db 314
-nomifactory.quest.db.314.title=Iridium Heavy Plating
+nomifactory.quest.db.314.title=§2Iridium Heavy Plating
 nomifactory.quest.db.314.desc=Heavy plating made from §6Iridium§r for Tier Five and Tier Eight Micro Miners.
 
 # db 315
-nomifactory.quest.db.315.title=Signalum Heavy Plating
+nomifactory.quest.db.315.title=§2Signalum Heavy Plating
 nomifactory.quest.db.315.desc=A heavy plating material required for the next two tiers of Micro Miners.
 
 # db 316
-nomifactory.quest.db.316.title=Enderium Heavy Plating
+nomifactory.quest.db.316.title=§2Enderium Heavy Plating
 nomifactory.quest.db.316.desc=Heavy plating made from §6Enderium§r used for the Tier Six Micro Miner.
 
 # db 317
@@ -1243,8 +1243,8 @@ nomifactory.quest.db.317.title=Quantum Fluxed Eternium Heavy Plating
 nomifactory.quest.db.317.desc=A complex plating material used exclusively for the Tier Nine Micro Miner.
 
 # db 318
-nomifactory.quest.db.318.title=Epoxy Production
-nomifactory.quest.db.318.desc=There are two primary approaches to producing §9Epoxy§r: §9Bisphenol A§r (BPA) and §9Naphtha§r. Both approaches require §9Epichlorohydrin§r, which itself has a few possible approaches.%n%nNaphtha is the simplest approach, where it is mixed with §9Nitrogen Dioxide§r and Epichlorohydrin to yield Epoxy. This approach is easier but yields less Epoxy. You also forego making more diesel and getting distillation byproducts from Naphtha. If you have an extremely robust §9Oil§r drilling and petrochemistry infrastructure in place, this might be an acceptable choice.%n%nBPA can be produced using petrochemistry distillation products, or via distilling §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r into useful components. Alternatively, you can get §9Phenol§r from §6Coal§r pyrolysis. §9Fermented Biomass§r is also useful to distill as it provides many useful products. Epoxy made from BPA is more complex to set up initially, but also far more efficient.%n%nThe final decision is down to you to make. Check out recipes in §bJEI§r.
+nomifactory.quest.db.318.title=§2Epoxy Production
+nomifactory.quest.db.318.desc=§2The Naphtha route for Epoxy has been removed. You can only make Epoxy using the BPA route.%n%n§rBPA can be produced using petrochemistry distillation products, or via distilling §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r into useful components. Alternatively, you can get §9Phenol§r from §6Coal§r pyrolysis. §9Fermented Biomass§r is also useful to distill as it provides many useful products.%n%n§2Using the Large Chemical Reactor, you can skip two steps in the Epoxy production line.
 
 # db 319
 nomifactory.quest.db.319.title=Farming
@@ -1268,15 +1268,15 @@ nomifactory.quest.db.323.desc=An otherworldly material exclusive to Microverses,
 
 # db 324
 nomifactory.quest.db.324.title=Naquadah Coil Blocks
-nomifactory.quest.db.324.desc=§6Naquadah§r is the sixth coil material available, increasing your EBF's operating temperature to 7200K so it can process more advanced materials.%n%nWhile it's also possible to make §6Naquadah Alloy Coils§r, you can skip them and go directly to §6Superconducting Coils§r.
+nomifactory.quest.db.324.desc=§6Naquadah§r is the sixth coil material available, increasing your EBF's operating temperature to 7200K so it can process more advanced materials.%n%n§2You cannot skip a coil material anymore.
 
 # db 325
-nomifactory.quest.db.325.title=Europium Ingot
-nomifactory.quest.db.325.desc=With a §3Fusion Reactor§r, you can make Europium!%n%nThis element is needed for making things in §bDraconic Evolution§r§r, as well as the §6Fusion Reactor Computer Mark 2§r and §6Wetware Processor Arrays§r§r.%n%nYou make it by fusing molten §9§9Neodymium§r§r and §9Hydrogen§r.
+nomifactory.quest.db.325.title=§2Europium Ingot
+nomifactory.quest.db.325.desc=With a §3Fusion Reactor§r, you can make Europium!%n%nThis element is needed for making things in §bDraconic Evolution§r§r, as well as the §6Fusion Reactor Computer Mark 2§r, §2Crystal Chip growing§r, and §6Wetware Supercomputers§r§r.%n%nYou make it by fusing molten §9§9Neodymium§r§r and §9Hydrogen§r.
 
 # db 327
-nomifactory.quest.db.327.title=Draconic Stem Cells
-nomifactory.quest.db.327.desc=Just ignore the protesters outside your base.%n%nEach craft in an §3LuV Chemical Reactor§r takes five minutes, so it's probably a good idea to have more than one machine running this recipe. At least you get a whole stack from a single egg.
+nomifactory.quest.db.327.title=§2Stem Cells
+nomifactory.quest.db.327.desc=Just ignore the protesters outside your base.%n%nEach craft in an §3LuV Chemical Reactor§r takes five minutes, so it's probably a good idea to have more than one machine running this recipe. At least you get §2128 from a single craft.%n
 
 # db 328
 nomifactory.quest.db.328.title=Boron
@@ -1295,19 +1295,19 @@ nomifactory.quest.db.331.title=Chaotic Fusion Injectors
 nomifactory.quest.db.331.desc=The highest tier of fusion crafting injectors. You will need at least ten of these to reach the §dCreative Portable Tank§r.%n%nEach injector requires four ingots of §6Neutronium§r and four §6Chaos Shards§r, as well as two §6Crystal Matrix§r blocks.%n%nHope you've got those Tier Eight Micro Miners automated.
 
 # db 332
-nomifactory.quest.db.332.title=The Fourth And Final Tier Six Circuits
-nomifactory.quest.db.332.desc=The final form of Tier Six circuits, and the final circuit theme.%n%nUsing your §6Wetware Circuit Boards§r, §6Naquadah Alloy wire§r, §6ASoCs§r, and §9Sterilized Growth Medium§r, you can craft (grow?) these circuits in a ZPM or better §3Assembling Machine§r.%n%nThese are fairly slow to craft and you're going to need considerable quantities, so make sure you have a good parallelized infrastructure for keeping these stocked.
+nomifactory.quest.db.332.title=§2The Fourth And Final Tier Six Circuits
+nomifactory.quest.db.332.desc=The final form of Tier Six circuits, and the final circuit theme.%n%nUsing your §2Neuro Processing Units§r, you can craft (grow?) these circuits in a ZPM or better §3Assembling Machine§r.%n%nThese are fairly slow to craft and you're going to need considerable quantities, so make sure you have a good parallelized infrastructure for keeping these stocked.
 
 # db 333
-nomifactory.quest.db.333.title=The Third and Final Tier Seven Circuits
-nomifactory.quest.db.333.desc=§6Wetware Processors§r are made in an §3Assembly Line§r on ZPM power.%n%nAmong the usual kinds of parts, these require §6Frank'N'Zombies§r from a §3Soul Binder§r and §6Silicone Rubber Foils§r.
+nomifactory.quest.db.333.title=§2The Third and Final Tier Seven Circuits
+nomifactory.quest.db.333.desc=§6Wetware Processors§r are made in §2the ZPM+ Circuit Assembler still.
 
 # db 334
-nomifactory.quest.db.334.title=The Second And Final Tier Eight Circuits
-nomifactory.quest.db.334.desc=§6Wetware Processor Arrays§r are made in an §3Assembly Line§r at ZPM or better power.%n%nYou'll need §6Sentient Ender§r from §3Soul Binders§r and §6Europium§r from the §3Fusion Reactor§r to craft these.
+nomifactory.quest.db.334.title=§2The Second And Final Tier Eight Circuits
+nomifactory.quest.db.334.desc=§6Wetware Supercomputers§r are made in an §3Assembly Line§r at ZPM or better power.%n%nYou'll need §6Europium§r from the §3Fusion Reactor§r to craft these.
 
 # db 335
-nomifactory.quest.db.335.title=The First And Only Tier Nine Circuit
+nomifactory.quest.db.335.title=§2The First And Only Tier Nine Circuit
 nomifactory.quest.db.335.desc=The final circuit!%n%nThe only novel ingredient is §6Tritanium Frames§r.%n%n§6Wetware Processor Mainframes§r are unique in that there are no subsquent circuit themes, and thus no other kinds of Tier Nine circuits. Unlike past mainframes, you will need to craft more than just a few of them. They're mostly used in the Endgame though, so you don't have to worry too much yet.%n%nDefinitely consider parallelizing your §3Assembly Lines§r if you haven't already. Even just having two or three lines will vastly improve your production speeds and help avoid bottlenecks as you push towards the Endgame.%n
 
 # db 336
@@ -1319,24 +1319,24 @@ nomifactory.quest.db.337.title=Draconic Cores
 nomifactory.quest.db.337.desc=§6Draconic Cores§r are the first crafting step into §bDraconic Evolution§r.%n%nThese serve as the basis for crafting many items and can be upgraded into different tiers of cores via §eFusion Crafting§r.
 
 # db 338
-nomifactory.quest.db.338.title=HV Power Storage
-nomifactory.quest.db.338.desc=HV Batteries function the same as LV and MV, only requiring more resources to craft.
+nomifactory.quest.db.338.title=§2HV Power Storage
+nomifactory.quest.db.338.desc=§2You can make HV Batteries like LV and MV ones, but there is a better option.%n%nEnergium Crystals can store 6,400,000 EU, at the cost of some crafting complexity. They need an HV Autoclave.
 
 # db 339
-nomifactory.quest.db.339.title=EV Machine Hulls
-nomifactory.quest.db.339.desc=With §6Titanium§r smelting automated, you can now build Machine Hulls for Extreme Voltage machines.
+nomifactory.quest.db.339.title=§2EV Machine Hulls
+nomifactory.quest.db.339.desc=With §6Titanium§r smelting automated, you can now build Machine Hulls for Extreme Voltage machines.%n%n§2Starting at EV, 4A Energy and Dynamo hatches are available at each tier.
 
 # db 340
-nomifactory.quest.db.340.title=EV Power Storage
-nomifactory.quest.db.340.desc=The Extreme Voltage tier §bGregTech§r battery. These are upgrades to the High Voltage tier battery, augmenting the §aEnergy Crystal§r with circuits and plates made of §6Lapis§r, §6Lazurite§r, or §6Sodalite§r.%n%nChances are by now you're not really using anything that needs GregTech batteries. You can safely ignore this quest until much later in the pack if you don't specifically need them.
+nomifactory.quest.db.340.title=§2EV Power Storage
+nomifactory.quest.db.340.desc=An Extreme Voltage tier §bGregTech§r battery.%n%n§3§2Higher tier GT Batteries have been buffed to be quite strong - this one holds 25 MEU, or 100 MRF. You may want to consider using them over RF storage.
 
 # db 341
-nomifactory.quest.db.341.title=IV Power Storage
-nomifactory.quest.db.341.desc=An Insane Voltage tier §bGregTech§r battery.%n%nYou're unlikely to be using EU batteries so it's safe to skip this for now and do it later, though some of the infrastructure used for these batteries is also used for other things.
+nomifactory.quest.db.341.title=§2IV Power Storage
+nomifactory.quest.db.341.desc=An Insane Voltage tier §bGregTech§r battery. §2Equivalent to 40 Vibrant Capacitor Banks!
 
 # db 342
-nomifactory.quest.db.342.title=LuV Power Storage
-nomifactory.quest.db.342.desc=A Ludicrous Voltage tier §bGregTech§r battery.%n%nYou're unlikely to be using EU batteries so it's safe to skip this for now and do it later, though some of the infrastructure used for these batteries is also used for other things.
+nomifactory.quest.db.342.title=§2LuV Power Storage
+nomifactory.quest.db.342.desc=A Ludicrous Voltage tier §bGregTech§r battery.
 
 # db 344
 nomifactory.quest.db.344.title=Empowerer
@@ -1415,12 +1415,12 @@ nomifactory.quest.db.365.title=Ultimate Leggings
 nomifactory.quest.db.365.desc=An ultimate pair of leggings, forged from all manner of materials across dimensions and microverses.
 
 # db 366
-nomifactory.quest.db.366.title=Creative Vending Upgrade
+nomifactory.quest.db.366.title=§2Creative Vending Upgrade
 nomifactory.quest.db.366.desc=You win.%n%nCongratulations.%n%nI hope you enjoyed playing §5Nomifactory§r.
 
 # db 367
-nomifactory.quest.db.367.title=Creative Tank
-nomifactory.quest.db.367.desc=§oNow this is not the end. It is not even the beginning of the end. But it is, perhaps, the end of the beginning.§r%n%nThe §d§dCreative Portable Tank§r is a major milestone. Great work!%n%nThis tank is your first proper creative item, which can be set to a fluid and then provides an infinite quantity of that fluid. The first fluid you should do this with is §dMolten Creative Portable Tank§r, so you can make as many more tanks as you want! You get exactly enough from a §6Heart of a Universe§r to do this.%n%nFrom there you can set up tanks with infinite quantities of every fluid you can think of.  §3Fluid Solidifiers§r can be used to make infinite of every element you can melt and solidify.%n%nThis is quite a game-changer as far as infrastructure goes. You'll find that many machines won't need to be used for their original purpose anymore. Some major base redesign is in order. Have you considered moving to space?%n%nAll that said, §ethe pack will still be challenging to complete§r. Infinite resources and power is nice, but it's not everything. There are plenty of materials you can't melt, and creative items will push your factory automation engineering skills to their limits.%n%nOnward to the final challenge: the §dCreative Vending Upgrade§r!%n%n
+nomifactory.quest.db.367.title=§2Creative Tank
+nomifactory.quest.db.367.desc=§oNow this is not the end. It is not even the beginning of the end. But it is, perhaps, the end of the beginning.§r%n%nThe §d§dCreative Tank§r is a major milestone. Great work!%n%nThis tank is your first proper creative item, which can be set to a fluid and then provides an infinite quantity of that fluid. §2Use the Creative Tank Provider to supply you with Creative Tanks.%n%nThe GT Creative Tank has been enhanced. You can turn it on and off, configure exactly how much fluid you want it to push and how often, and change which direction the fluid is pushed out. You can even configure the fluid you want directly from JEI!§r%n%nFrom there you can set up tanks with infinite quantities of every fluid you can think of. §3Fluid Solidifiers§r §2or the much more powerful Large Solidification Arrays§r can be used to make infinite of every element you can melt and solidify.%n%nThis is quite a game-changer as far as infrastructure goes. You'll find that many machines won't need to be used for their original purpose anymore. Some major base redesign is in order. Have you considered moving to space?%n%nAll that said, §ethe pack will still be challenging to complete§r. Infinite resources and power is nice, but it's not everything. There are plenty of materials you can't melt, and creative items will push your factory automation engineering skills to their limits.%n%nOnward to the final challenge: the §dCreative Vending Upgrade§r!%n%n
 
 # db 368
 nomifactory.quest.db.368.title=Grappling Hook
@@ -1431,8 +1431,8 @@ nomifactory.quest.db.370.title=Charcoal
 nomifactory.quest.db.370.desc=No hoops to jump through here. Smelt §6Wood Logs§f to get §6Charcoal§f. It will serve you well as a fuel source until you locate a vein of §6Coal§f.%n%nYou might want to craft Charcoal into §6Tiny Charcoal§f pieces to save some fuel. One tiny piece is enough to smelt exactly one item. Just put charcoal into the crafting grid to make some!
 
 # db 371
-nomifactory.quest.db.371.title=Rubber Soft Hammer
-nomifactory.quest.db.371.desc=A §aRubber Soft Hammer§f can be used to temporarily stop a machine from functioning. This is useful when you have two machines running and both are unable to keep going because of a lack of power... let one finish then turn the other one back on with a second hit from the hammer.
+nomifactory.quest.db.371.title=Soft Hammer
+nomifactory.quest.db.371.desc=A §aSoft Hammer§f can be used to temporarily stop a machine from functioning. This is useful when you have two machines running and both are unable to keep going because of a lack of power... let one finish then turn the other one back on with a second hit from the hammer.
 
 # db 384
 nomifactory.quest.db.384.title=Elite Component
@@ -1460,7 +1460,7 @@ nomifactory.quest.db.389.desc=This is the largest Extended Crafting Table, capab
 
 # db 390
 nomifactory.quest.db.390.title=Energetic Infuser
-nomifactory.quest.db.390.desc=Infuses things with Redstone Flux.%n%nThis is useful for charging RF-powered devices, but it also can also charge §6Rich Phyto-Gro§r into §6Fluxed Phyto-Gro§r, and charge §6Certus Quartz Crystals§r into §6Charged Certus Quartz Crystals§r.
+nomifactory.quest.db.390.desc=Infuses things with Redstone Flux.%n%nThis is useful for charging RF-powered devices, but it also can also charge §6Rich Phyto-Gro§r into §6Fluxed Phyto-Gro§r, and charge §6Activated Certus Quartz Crystals§r into §6Charged Certus Quartz Crystals§r.
 
 # db 391
 nomifactory.quest.db.391.title=Craftable Nether Stars
@@ -1476,7 +1476,7 @@ nomifactory.quest.db.393.desc=You might be wondering what chunkloading options t
 
 # db 394
 nomifactory.quest.db.394.title=Flux Capacitors
-nomifactory.quest.db.394.desc=Basic §aFlux Capacitors§r hold a whopping lot of energy - §a10 million RF§r - and are useful for keeping your §aRF-powered§r equipment and tools charged.%n%nPut one into your newly crafted §3CEF§r to charge it. You can then put it in your inventory to charge your items with §aRF§r, or you can leave it in the CEF to act as a §a2.5 million EU§r battery!%n%nFlux Capacitor is a §bBauble§r, open your inventory and look for the Baubles button, click it to reveal the additional bauble slots menu and put it into any slot you wish.%n%nFinally you can charge up all those depleted §6Dark Boots§r and §6The Ender§r swords you've looted.
+nomifactory.quest.db.394.desc=Basic §aFlux Capacitors§r hold a whopping lot of energy - §a10 million RF§r - and are useful for keeping your §aRF-powered§r equipment and tools charged.%n%nPut one into your newly crafted §3Battery Buffer§r to charge it. You can then put it in your inventory to charge your items with §aRF§r. %n§cRF batteries such as Flux Capacitors cannot be drained by Battery Buffers!§r%n%nFlux Capacitor is a §bBauble§r, open your inventory and look for the Baubles button, click it to reveal the additional bauble slots menu and put it into any slot you wish.%n%nFinally you can charge up all those depleted §6Dark Boots§r and §6The Ender§r swords you've looted.
 
 # db 395
 nomifactory.quest.db.395.title=Quantum Flux
@@ -1488,23 +1488,23 @@ nomifactory.quest.db.397.desc=A single-block solution to all your power needs.%n
 
 # db 398
 nomifactory.quest.db.398.title=Multi Smelter
-nomifactory.quest.db.398.desc=The §3Multi Smelter§r is an absolute smelting unit, and is most likely the best furnace added by a mod.%n%nIt's a 3x3x3 multiblock machine capable of §esmelting huge amounts of items per second§r. By upgrading its coils and power tier, it can become capable of smelting up to literal thousands of items per second.%n%nHover over different coil blocks: the higher the §elevel§r, the more items a Multi Smelter can smelt per operation: §e32 items per level§r. The most basic Multi Smelter essentially does 32 items in the same time as a furnace does one. With a set of level 4 coil blocks, that jumps to 128 items per operation.%n%nThis quest doesn't ask for coils, hatches or buses: feel free to choose whatever combination you want. You'll need §a8 coil blocks§r, §a1 input bus§r, §a1 output bus§r and at least §a1 energy hatch§r of any tier.%n%n
+nomifactory.quest.db.398.desc=The §3Multi Smelter§r is an absolute smelting unit, and is most likely the best furnace added by a mod.%n%nIt's a 3x3x3 multiblock machine capable of §esmelting huge amounts of items per second§r. By upgrading its coils and power tier, it can become capable of smelting up to literal thousands of items per second.%n%nShift and hover over different coil blocks: they tell you the number of items a Multi Smelter can smelt per operation: §e32 items per level§r. The most basic Multi Smelter essentially does 32 items in the same time as a furnace does one. With a set of §6Tungstensteel§r coil blocks, that jumps to 128 items per operation.%n%nThis quest doesn't ask for coils, hatches or buses: feel free to choose whatever combination you want. You'll need §a8 coil blocks§r, §a1 input bus§r, §a1 output bus§r, and §21 maintenance hatch§r, §21 muffler hatch§r, and at least §a1 energy hatch§r, all of any tier.%n%n
 
 # db 399
-nomifactory.quest.db.399.title=Plasma Turbine
-nomifactory.quest.db.399.desc=§3Large Plasma Turbines§r are a powerful late game method of generating power. One Large Plasma Turbine can produce nearly 41800 EU/t when using an §aLuV Rotor Holder§r and equipped with §a100%% efficiency§r rotor.%n%nOne §3Mark 1 Fusion Reactor§r dedicated to producing §bOxygen Plasma§r can provide sufficient fuel for continuously operating 16 Large Plasma Turbines, resulting in a combined production of roughly 670000 EU/t. Granted, this is a decent amount of infrastructure.%n%nDon't rely on §bJEI§r too much when looking for the best plasma: fuels are displayed in a very misleading manner. A Large Plasma Turbine consumes up to nearly 16 buckets of plasma to run a cycle for the duration specified in JEI, and takes some time to spin up to full power.
+nomifactory.quest.db.399.title=§2Plasma Turbine
+nomifactory.quest.db.399.desc=§3Large Plasma Turbines§r are a powerful late game method of generating power. One Large Plasma Turbine produces §2a base of 16384 EU/t when using an IV Rotor Holder§r.
 
 # db 400
-nomifactory.quest.db.400.title=I Don't Like Space
-nomifactory.quest.db.400.desc=Space exploration isn't mandatory in this pack, so if you don't feel like exploring space with §bAdvanced Rocketry§r, then you can centrifuge §9Hydrogen§r for §eDeuterium§r instead.%n%nJust keep in mind that it's much less rewarding to skip this and you'll need lots of Hydrogen to compensate, although you won't need too much for the first §3Microverse Projector§r.
+nomifactory.quest.db.400.title=§2I Don't Like Space
+nomifactory.quest.db.400.desc=Space exploration isn't mandatory in this pack, so if you don't feel like exploring space with §bAdvanced Rocketry§r, then you can centrifuge §9Hydrogen§r for §eDeuterium§r instead.%n%nJust keep in mind that it's much less rewarding to skip this and you'll need lots of Hydrogen to compensate, although you won't need too much for the first §3Microverse Projector§r.%n%n§2In HV Age and more effectively in IV Age, you can get this from processing Ender Air.
 
 # db 401
 nomifactory.quest.db.401.title=Proper Tool Care
 nomifactory.quest.db.401.desc=§3Anvils§f can be used to repair almost all §bGregTech tools§f!%n%nYou might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils§f spawn abundantly in §bLost Cities§f buildings, so go and snatch one!%n%nPut a damaged tool inside and put some material it's made of. For example, you'll need to put §6Wrought Iron Ingots§f to repair tools made of §6Wrought Iron§f. The only tools unable to be repaired are the mortar and the plunger.
 
 # db 402
-nomifactory.quest.db.402.title=Machine Covers
-nomifactory.quest.db.402.desc=§bGregTech§r adds a very versatile way of augmenting machines with §aMachine Covers§r. Covers are "upgrades" that you can put on any GregTech machine, chest, or drum to expand its functionality. To work with covers, you'll need to make yourself a §aScrewdriver§r to configure covers, and a §aCrowbar§r to remove covers without having to break the machine.%n%nHere's a list of some covers there are in the game, and what they do:%n%n- §a§lConveyor§r: transfers items continuously to or from an adjacent inventory.%n%n- §a§lPump§r: is much like a §aConveyor§f, but for fluids.%n%n- §a§lRobotic Arm§r: is much like §aConveyor§r, but has two additional modes:%n    * §eKeep Exact§r: moves items to keep a stock of at most the specified number of items%n    * §eSupply Exact§r: transfers precisely the specified number of items per operation.%nThis cover is very useful for crafting automation.%n%n- §a§lFluid Regulator§r: is like a §aRobotic Arm§r, but works with fluids instead of items.%n%n- §a§lShutter§r: prevents automation from interacting with a specific side of a machine.%n%nCovers that move items or fluids can have a §aFilter§r placed inside them. These modify the functionality of covers in ways explained in their own quests.%n
+nomifactory.quest.db.402.title=§2Machine Covers
+nomifactory.quest.db.402.desc=§bGregTech§r adds a very versatile way of augmenting machines with §aMachine Covers§r. Covers are "upgrades" that you can put on any GregTech machine, chest, or drum to expand its functionality. To work with covers, you'll need to make yourself a §aScrewdriver§r to configure covers, and a §aCrowbar§r to remove covers without having to break the machine.%n%nHere's a list of some covers there are in the game, and what they do:%n%n- §a§lConveyor§r: transfers items continuously to or from an adjacent inventory.%n%n- §a§lPump§r: is much like a §aConveyor§f, but for fluids.%n%n- §a§lRobotic Arm§r: is much like §aConveyor§r, but has two additional modes:%n    * §eKeep Exact§r: moves items to keep a stock of at most the specified number of items%n    * §eSupply Exact§r: transfers precisely the specified number of items per operation.%nThis cover is very useful for crafting automation.%n%n- §a§lFluid Regulator§r: is like a §aRobotic Arm§r, but works with fluids instead of items.%n%n- §a§lShutter§r: prevents automation from interacting with a specific side of a machine.%n%n- §2§lDetector§r: Available in Item, Fluid, Energy, Activity, and Advanced Activity flavours. Emits a Redstone signal depending on the status of whatever it's detecting.%n%n- §2§lDigital Interface§r: A graphical display for the machine's current status. Can display things like contained fluids, energy levels, etc.%n%nCovers that move items or fluids can have a §aFilter§r placed inside them. These modify the functionality of covers in ways explained in their own quests.%n
 
 # db 403
 nomifactory.quest.db.403.title=Screwdrive Output Sides!
@@ -1516,7 +1516,7 @@ nomifactory.quest.db.404.desc=You can easily automate most §bGregTech§r machin
 
 # db 405
 nomifactory.quest.db.405.title=Crafting Calculator
-nomifactory.quest.db.405.desc=This modpack has §aCrafting Calculators§r. It has a steep learning curve, but once you manage to learn how to use it, it's going to be your trusty companion in calculating recipe costs.%n%nCraft yourself one and hit the book button in the top-left corner for a quick overview of how it works.
+nomifactory.quest.db.405.desc=This modpack has §aCrafting Calculators§r. It has a steep learning curve, but once you manage to learn how to use it, it's going to be your trusty companion in calculating recipe costs.%n%nCraft yourself one and hit the book button in the top-left corner for a quick overview of how it works.%n%n§2The GTCEu Terminal also has an in-built equivalent to the Crafting Calculator, which you may use instead if you prefer.
 
 # db 406
 nomifactory.quest.db.406.title=Automating Extended Crafting
@@ -1531,11 +1531,11 @@ nomifactory.quest.db.408.title=PackagedAuto
 nomifactory.quest.db.408.desc=§bPackagedAuto§r is an addon for §bApplied Energistics 2§r. Its main purpose in §5Nomifactory§r is to allow you to automate extended crafting recipes.%n%nApplied Energistics 2 stores recipes in §aPatterns§r, but they are limited to at most 9 stacks of items (a standard 3x3 crafting grid). PackagedAuto stores recipes in §aPackage Recipe Holders§r, which don't have this limitation. Additionally, each Holder can store up to §e20 different recipes§r. Holders must be encoded in the §3Package Recipe Encoder§r.%n%nIn the vast majority of situations you'll need two identically-encoded Holders, as the following machines work together.%n%nThe §3Packager§r is a machine that compresses ingredients for a specific recipe into a set of §6Recipe Packages§r. Each package in a set can hold up to 9 stacks of ingredient items. A simple recipe might consist of one package, but a complex recipe can have up to 9 packages in its set (for 81 total item stacks).%n%nThe §3Unpackager§r is a machine that extracts ingredient items from complete sets of Recipe Packages made in a Packager, ejecting the items into an adjacent inventory. It will only extract the items if §eall packages in a set are present§r.%n%nWhen both a Packager and Unpackager are connected to an ME Network and have the same recipe, the resulting item will appear as craftable in your §aTerminal§r.%n%nUp to 8 §3Packager Extensions§r can optionally be added to the Packager to speed up package creation. Place the Packager Extensions in a plane surrounding the Packager, creating a 3 by 3 structure with the Packager in the center when all 8 Packager Extensions are placed.
 
 # db 409
-nomifactory.quest.db.409.title=A Primer on Power
-nomifactory.quest.db.409.desc=Unlike §aRF power§r, which is safe to transport in any §6conduit§r, §aEU power §r§erequires caution§r. The key is to always §amatch or exceed§r the §eVoltage §rand §eAmperage§r of your power source with your §6cables§r and machines.%n%n§o§4§cNEVER §rhook up your CEF§r to a cable that has fewer §eAmps§r than your CEF or Battery Buffer§r generates. For example, you must use §64x cable§r for a 4x CEF§r, and §616x cable§r for a filled 16-slot Battery Buffer§r. Cables with insufficient amperage rating will §cburn and be destroyed§r. Similarly, your cable must match or exceed the §eVoltage§r of your machines, or they will §cburn and be destroyed§r.%n%n§cNEVER§r connect a machine to excessive §eVoltage§r or it will §cvaporize§r. Touching a §6wire§r with connected §aEU power§r will §cinjure or kill you§r, so for your safety, §euse §6cables§e instead§r!
+nomifactory.quest.db.409.title=§2A Primer on Power
+nomifactory.quest.db.409.desc=Unlike §aRF power§r, which is safe to transport in any §6conduit§r, §aEU power §r§erequires caution§r. The key is to always §amatch or exceed§r the §eVoltage §rand §eAmperage§r of your power source with your §6cables§r and machines.%n%n§o§4§cNEVER §rhook up your Energy Converter§r to a cable that has fewer §eAmps§r than your Energy Converter or Battery Buffer§r generates. For example, you must use §64x cable§r for a 4A Converter§r, and §616x cable§r for a filled 16-slot Battery Buffer§r. Cables with insufficient amperage rating will §cburn and be destroyed§r. §2Both the multiple-amp-source and multiple-face-input bugs from CE have been fixed - the Energy network now works as intended.§r%n%nSimilarly, your cable must match or exceed the §eVoltage§r of your machines, or they will §cburn and be destroyed§r.%n%n§cNEVER§r connect a machine to excessive §eVoltage§r or it will §cvaporize§r. Touching a §6wire§r with connected §aEU power§r will §cinjure or kill you§r, so for your safety, §euse §6cables§e instead§r!%n%n§2Superconductor-type wires do not damage you in CEu. The 0-loss cables in CE (Conductive Iron, Energetic Alloy, etc.) are considered Superconductors.
 
 # db 411
-nomifactory.quest.db.411.title=Large Microverse Projector
+nomifactory.quest.db.411.title=§2Large Microverse Projector
 nomifactory.quest.db.411.desc=The §3Large Microverse Projector§r is a more powerful projector required for sending §6Tier Seven§r through §6Tier Ten Micro Miners§r into microverses.%n%nTier Seven missions will operate on §eLuV power§r, but higher energy tiers will be required for later missions. As with the prior projector, this structure supports overclocking and the position of buses and hatches can be swapped with any §6Microverse Projector Casing§r.%n%n§6Sneak-right click§r the controller to enable the in-world preview.
 
 # db 412
@@ -1543,8 +1543,8 @@ nomifactory.quest.db.412.title=Lunar Mining Station
 nomifactory.quest.db.412.desc=The §3Lunar Mining Station§r is a large multiblock structure used for mining gases from the moon. It is an excellent (though not the only) source of §9Deuterium§r or §9Helium-3§r, depending on what kind of §6Rover§r you use. %n%nRovers only have a 10%% chance to break while mining, so a stack of them will last quite a while.%n%nWhile both available recipes require §eMV power§r, you can overclock it with higher tiers of power. The positions of hatches and buses can be swapped with any §6LuV Machine Casing§r.%n%n§6Sneak-right click§r the controller to enable the in-world preview.%n%nBecause this structure must be placed on the Moon, it is a good idea to use mechanisms like §aEnder Tanks§r or a §6Quantum Link Chamber§r for teleporting the fluids back to your base.%n%nMake sure to keep it chunk-loaded!%n
 
 # db 413
-nomifactory.quest.db.413.title=LV Fluid Extractor
-nomifactory.quest.db.413.desc=§3Fluid Extractors§r are useful for melting things into liquids. For example, you can melt down ingots into molten metals, or §6Rubber Sheets§r into liquid §9Rubber§r.%n%nWhen you have access to §6Steel§r, you can make molds and use §3Fluid Solidifiers§r to form various components more efficiently from fluids, like §6Gears§r.%n%nThis quest will take the LV, MV, or HV version of the §3Fluid Extractor§r.
+nomifactory.quest.db.413.title=§2LV Extractor
+nomifactory.quest.db.413.desc=§2The functions of the Extractor and Fluid Extractor have been combined into a single machine!%n%n§3Extractors§r are useful for melting things into liquids. For example, you can melt down ingots into molten metals, or §6Rubber Sheets§r into liquid §9Rubber§r.%n%nWhen you have access to §6Steel§r, you can make molds and use §3Fluid Solidifiers§r to form various components more efficiently from fluids, like §6Gears§r.
 
 # db 415
 nomifactory.quest.db.415.title=Fluxomagnet
@@ -1552,7 +1552,7 @@ nomifactory.quest.db.415.desc=Now that you have a §aFlux Capacitor§r to keep t
 
 # db 416
 nomifactory.quest.db.416.title=Fish Oil
-nomifactory.quest.db.416.desc=§9Fish Oil§r comes from, surprisingly, fish.%n%nAeügh.
+nomifactory.quest.db.416.desc=Fish Oil, surprisingly, comes from fish.
 
 # db 417
 nomifactory.quest.db.417.title=Combination Package Crafter
@@ -1563,16 +1563,16 @@ nomifactory.quest.db.488.title=Basic Satchel
 nomifactory.quest.db.488.desc=Useful to carry more stuff.%n%nWhat more explanation are you expecting?
 
 # db 489
-nomifactory.quest.db.489.title=LV Compressor
-nomifactory.quest.db.489.desc=You'll need a §3Compressor§r for a variety of things, but probably most importantly is the ability to make many kinds of plates from a single ingot.
+nomifactory.quest.db.489.title=§2LV Compressor
+nomifactory.quest.db.489.desc=§2Most plates are made in the Bending Machine instead of here. (Technically this was the case in CE, but this modpack transferred its recipes to the Compressor.)%n%nHowever, this machine will still see use for compressing Nuggets into Ingots, Ingots into Blocks, and gem Dusts into Plates (such as Certus).
 
 # db 490
 nomifactory.quest.db.490.title=LV Autoclave
-nomifactory.quest.db.490.desc=An §3Autoclave§r is a machine that uses liquids (usually water) to polish stones, carve gems into lenses, infuse gems with special liquids, and crystallize various dusts.%n%nYou'll need an Autoclave for many recipes, but right now you want it to make §6Certus Quartz Crystals§r for §bApplied Energistics§r out of the §bGregTech§r §6Certus Quartz§r and its dust you get from mining and ore processing.
+nomifactory.quest.db.490.desc=An §3Autoclave§r is a machine that uses liquids (usually water) to polish stones, carve gems into lenses, infuse gems with special liquids, and crystallize various dusts.%n%nYou'll need an Autoclave for many recipes, but right now you want it to make §6Activated Certus Quartz Crystals§r for §bApplied Energistics§r out of the §bGregTech§r §6Certus Quartz§r and its dust you get from mining and ore processing.
 
 # db 491
 nomifactory.quest.db.491.title=Veinmining Trees?
-nomifactory.quest.db.491.desc=§aLumberaxes§f are tools that cut all connected blocks of the same kind (usually referred to as "§eveinmining§f") that require an axe. These are primarily intended to §echop down entire trees§f, but you can use them to veinmine other wooden blocks too.%n%n§l§c§lKeep in mind that the veinmining feature doesn't get disabled when sneaking!§r%n%nPlease be careful to not veinmine your entire Storage Drawers network; this WILL end in tears.
+nomifactory.quest.db.491.desc=No need for Lumberaxes anymore, §dGregTech Axes§r will cut down entire trees for you. They won't destroy your Storage Drawer networks, too.
 
 # db 492
 nomifactory.quest.db.492.title=Drill Baby Drill
@@ -1595,16 +1595,16 @@ nomifactory.quest.db.497.title=Compacting Drawers
 nomifactory.quest.db.497.desc=Great for automatically converting between Nuggets, Ingots, and Blocks of metals, or simply storing massive amounts of things. Also works with §dOmnicoins§r.%n%nThe appearance can be customized by crafting the drawer into §aFramed Compacting Drawer§r and putting it into a §aFraming Table§r.
 
 # db 498
-nomifactory.quest.db.498.title=Soldering Alloy
-nomifactory.quest.db.498.desc=When making circuits, you'll need either molten §9Tin§r, or molten §9Soldering Alloy§r§r§r in the §3Assembling Machine§r. Soldering Alloy is made in the §3Alloy Smelter§r with a 9:1 ratio of §6Tin Ingots§r to §6Antimony Dust§r. You then process it in a §3Fluid Extractor §rfor the usual 144mB of fluid per ingot.%n%nThe Assembling Machine will only consume half as much Soldering Alloy as it would have consumed molten Tin per craft (72mB vs 144mB), so it's very efficient to use this stuff.%n%nPut your §3Centrifuge§r to work for the §6Antimony§r you'll need, which comes in tiny piles from processing §6Tetrahedrite Ore§r and §6Stibnite Ore§r.%n
+nomifactory.quest.db.498.title=§2Soldering Alloy
+nomifactory.quest.db.498.desc=When making circuits, you'll need either molten §9Tin§r, or molten §9Soldering Alloy§r§r§r. §2Soldering Alloy is made in the Mixer with 6 parts Tin Dust, 3 parts Lead Dust and 1 part Antimony Dust.§r You then process it in an §3Extractor §rfor the usual 144mB of fluid per unit.%n%nThe §2Circuit Assembler§r will only consume half as much Soldering Alloy as it would have consumed molten Tin per craft (72mB vs 144mB), so it's very efficient to use this stuff.%n%n§2Antimony can be directly smelted from Stibnite Ore, allowing you to skip ore processing for this.
 
 # db 499
 nomifactory.quest.db.499.title=Fine Copper Wire
 nomifactory.quest.db.499.desc=Now that you have a §3Wiremill§r, you can turn one §6Copper Wire§r into four §6Fine Copper Wire§r. The recipes for §6Resistors§r, §6LV Motors§r and §6Vacuum Tubes§r all accept either type, so doing this extra processing step will make your §6Copper Ingots§r go §efour times further§r when making circuits.%n%nYou'll be making a lot more circuits from here on out, so it's definitely worthwhile to save your copper!
 
 # db 500
-nomifactory.quest.db.500.title=The Fourth And Final Tier Three Circuits
-nomifactory.quest.db.500.desc=With your new §6Fiber-Reinforced Epoxy Circuit Boards§r, §6Nano CPUs§r, and some standard components, you can make the final type of Tier Three Circuit: the §6Nanocircuit§r.%n%nAs the best form of Tier Three circuit, these should be automated and stockpiled. As with the Final Tier Two circuits, the §6System-on-Chip§r variant recipes won't be available for a while.
+nomifactory.quest.db.500.title=§2The Third And Final Tier Three Circuits
+nomifactory.quest.db.500.desc=With your new§2 Epoxy Circuit Boards§r, §6Nano CPUs§r, and some standard components, you can make the final type of Tier Three Circuit: the §6Nanocircuit§r.%n%nAs the best form of Tier Three circuit, these should be automated and stockpiled. As with the Final Tier Two circuits, the §6Advanced System-on-Chip§r variant recipes won't be available for a while.
 
 # db 501
 nomifactory.quest.db.501.title=Exotic Materials Catalyst
@@ -1620,23 +1620,23 @@ nomifactory.quest.db.503.desc=
 
 # db 504
 nomifactory.quest.db.504.title=Brewery
-nomifactory.quest.db.504.desc=Note: this quest accepts both LV and MV Brewery.%n%nYou can turn §6Plant Balls§r and other various §6sugary crops§r into §9Biomass§r with a §3Brewery§r. Biomass is the first step towards making Plastic in the form of §9Polyethylene§r.%n%nThe Brewery is a very very slow machine, but it requires almost no power. Building higher tier Breweries, or many LV ones, is necessary to brew enough Biomass for plastics.
+nomifactory.quest.db.504.desc=Note: this quest accepts both LV and MV Brewery.%n%nYou can turn §6Plant Balls§r and other various §6sugary crops§r into §9Biomass§r with a §3Brewery§r. Biomass is the first step towards making Plastic in the form of §9Polyethylene§r.%n%nThe Brewery is a very very slow machine, but it requires almost no power. Building §2many Breweries§r is necessary to brew enough Biomass for plastics.
 
 # db 505
 nomifactory.quest.db.505.title=Ethanol
 nomifactory.quest.db.505.desc=§9Ethanol§r is alcohol, which you can first produce from distilling §9Biomass§r.%n%nBoiling §6Sugar Cane§r in a §3Brewery§r is a great way to get Biomass, but you can also get it from other crops and saplings if you want.%n%nOnce you have a hefty starting stock of Ethanol, consider making and distilling §9Fermented Biomass§r in a §3Distillation Tower§r for extra chemicals.
 
 # db 507
-nomifactory.quest.db.507.title=Chlorine
-nomifactory.quest.db.507.desc=You'll need §9Chlorine§r at this point. It is an important ingredient in many chemical processes, and you primarily get it from electrolyzing either §6Salt§r or §6Rock Salt§r.
+nomifactory.quest.db.507.title=§2Chlorine
+nomifactory.quest.db.507.desc=You'll need §9Chlorine§r at this point. It is an important ingredient in many chemical processes, and you can currently get it from electrolyzing either §6Salt§r or §6Rock Salt§r.%n%n§2Later, you can use Fluid Rigs or break down Ghast Tears to obtain Salt Water, and electrolyze it to Chlorine.
 
 # db 508
-nomifactory.quest.db.508.title=Knightslime Ingots
+nomifactory.quest.db.508.title=§2Ruridit Ingots
 nomifactory.quest.db.508.desc= 
 
 # db 509
-nomifactory.quest.db.509.title=MV Lossless Cables
-nomifactory.quest.db.509.desc=§bEnderIO§r and §bThermal§r alloys are a bit more expensive than the normal wires, but they come with the huge advantage of being §elossless§r. Lossy cables like §6Tin§r and §6Copper§r will bleed out energy for every block they travel, but lossless ones do not.%n%nThe lossless cables for each tier are:%n%nLV - Conductive Iron Cables%nMV - Energetic Alloy Cables%nHV - Vibrant Alloy Cables%nEV - End Steel Cables%nIV - Lumium Cables%nLuV   - Signalum Cables%nZPMV - Enderium Cables%nUV     - Draconium Cables%nMaxV - Omnium Cables%n%nMV and higher cables are made in an §3Assembling Machine§r. They're made with liquid §9Rubber§r and §6Wires§r, plus a reusable §6Programmed Circuit§r that tells it what thickness of wire to make.%n%nYou can use Wires, and for these materials they'll conduct just as well as if they were covered. But they'll §ckill you if you touch them while power is passing through§r, so... yeah. Your call.
+nomifactory.quest.db.509.title=§2Lossless Cables
+nomifactory.quest.db.509.desc=§bEnderIO§r and §bThermal§r alloys are a bit more expensive than the normal wires, but they come with the huge advantage of being §e§2superconductors§r. Lossy cables like §6Tin§r and §6Copper§r will bleed out energy for every block they travel, but §2superconductors§r do not.%n%nThe §2cheap superconductors§r for each tier are:%n%nLV - Conductive Iron%nMV - Energetic Alloy%nHV - Vibrant Alloy%nEV - End Steel%nIV - Lumium %nLuV   - Signalum %nZPM - Enderium %nUV     - Draconium %nMAX - §2Draconic Superconductor§r, Omnium%n%n§2There are an additional set of superconductors, one for each tier, which are the CEu default superconductors. Their advantage is their higher amperage rating, reaching the hundreds of amps for higher tier 16x wires. They are also used in crafting Field Generators.§,§r%n%nMV and higher cables are made in an §3Assembling Machine§r. They're made with liquid §9Rubber§r and §6Wires§r, plus a reusable §6Programmed Circuit§r that tells it what thickness of wire to make.%n%nYou can use Wires, and for these materials they'll conduct just as well as if they were covered. §2Superconductor wires also won't kill you when touched now. In fact, you have to use Wires for Superconductors, because they don't even have cables!
 
 # db 510
 nomifactory.quest.db.510.title=Dew Of The Void
@@ -1664,11 +1664,11 @@ nomifactory.quest.db.517.desc=§6Robot Arms§r are components of several powerfu
 
 # db 519
 nomifactory.quest.db.519.title=Naquadah Reactor Mk1
-nomifactory.quest.db.519.desc=The §3Naquadah Reactor Mk1§r is a structure used to generate considerable amounts of EU power from decaying §6Enriched Naquadah§r or §6Naquadria§r into §6Lead§r.%n%nYou'll have to use a §6CEU§r if you want to convert EU to RF.%n%n§6Sneak-right click§r the controller to enable the in-world preview.
+nomifactory.quest.db.519.desc=The §3Naquadah Reactor Mk1§r is a structure used to generate considerable amounts of EU power from decaying §6Enriched Naquadah§r or §6Naquadria§r into §6Lead§r.%n%n§6Sneak-right click§r the controller to enable the in-world preview.
 
 # db 520
 nomifactory.quest.db.520.title=The Second Tier Four Circuits
-nomifactory.quest.db.520.desc=Four §6Microprocessors§r combined with §6Titanium Plates§r and a few other standard components will make a §6Microprocessor Array§r.
+nomifactory.quest.db.520.desc=Four §6Microprocessors§r combined with §6Titanium Plates§r and a few other standard components will make a §6MicroSupercomputer§r.
 
 # db 521
 nomifactory.quest.db.521.title=Resonant Upgrade Kit
@@ -1679,76 +1679,76 @@ nomifactory.quest.db.522.title=LuV Compressor
 nomifactory.quest.db.522.desc=This compressor is needed for making §6Iridium Heavy Plating§r and §6Enderium Heavy Plating§r.
 
 # db 523
-nomifactory.quest.db.523.title=The Second Tier Five Circuits
-nomifactory.quest.db.523.desc=Upgrading to the §6Nanoprocessor Array§r requires some standard circuit components, but also some §6Lumium Wire§r and §6Tungstensteel Plates§r.
+nomifactory.quest.db.523.title=§2The Second Tier Five Circuits
+nomifactory.quest.db.523.desc=Upgrading to the §6Nano Supercomputer§r requires some standard circuit components, but also some §6Lumium Wire§r and §2Fine Tungstensteel Wire.
 
 # db 524
-nomifactory.quest.db.524.title=The First Tier Six Circuits
-nomifactory.quest.db.524.desc=The first and most expensive Tier Six Circuit, needed for crafting the §3IV Assembling Machine§r.%n%nRequires a bunch of standard circuit components, as well as multiple §6Lumium Wire§r and §6Tungstensteel Frames§r.
+nomifactory.quest.db.524.title=§2The First Tier Six Circuits
+nomifactory.quest.db.524.desc=The first and most expensive Tier Six Circuit, needed for crafting the §3IV Assembling Machine§r.%n%nRequires a bunch of standard circuit components.
 
 # db 525
-nomifactory.quest.db.525.title=The Third Tier Four Circuits
+nomifactory.quest.db.525.title=§2The Second Tier Four Circuits
 nomifactory.quest.db.525.desc=Nothing you haven't seen here: just combine some standard circuit components and §6Nanocircuits§r to make a §6Nanoprocessor§r.
 
 # db 526
-nomifactory.quest.db.526.title=EV Assembling Machine
-nomifactory.quest.db.526.desc=With your §6Titanium§r-based machine hulls and §6Microprocessor Mainframes§r squared away, you can finally get on the path to making an Extreme Voltage §3Assembling Machine§r.%n%nThis tier of Assembling Machine unlocks §6Nanocircuits§r, as well as handling crafting recipes up to 2048 EU/t. It can also optionally overclock recipes that consume up to 512 EU/t for improved speed at the cost of relatively more power.
+nomifactory.quest.db.526.title=§2EV Circuit Assembling Machine
+nomifactory.quest.db.526.desc=With your §6Titanium§r-based machine hulls and §6Mainframes§r squared away, you can finally get on the path to making an Extreme Voltage §3Circuit Assembling Machine§r.%n%nThis tier of Assembling Machine unlocks §6Nanocircuits§r, as well as handling crafting recipes up to 2048 EU/t. It can also optionally overclock recipes that consume up to 512 EU/t for improved speed at the cost of relatively more power.
 
 # db 527
 nomifactory.quest.db.527.title=Lumium
-nomifactory.quest.db.527.desc=Glowing!%n%nThis one takes a significant amount of time to cook, so make sure to have it going constantly.%n%nWires made from §6Lumium§r transmit IV power losslessly, and it forms the basis for §6LuV Machine Hulls§r.
+nomifactory.quest.db.527.desc=Glowing! §2But all the GTCEu machines glow already, so...§r%n%nThis one takes a significant amount of time to cook, so make sure to have it going constantly.%n%nWires made from §6Lumium§r transmit IV power losslessly, and it forms part of the basis for §6LuV Machine Hulls§r.
 
 # db 528
 nomifactory.quest.db.528.title=Hardened Upgrade Kit
 nomifactory.quest.db.528.desc=What?!%n§6STEAM DYNAMO§r is evolving!%n%nUpgrade kits can be applied to Thermal Expansion Dynamos, machines, and even Portable Tanks. Machines and dynamos get additional augment slots.%n%nWhen applied to a dynamo, it increases the §apower generation and fuel burn rate to 150%%§r.%n%nIncreases the base capacity of Portable Tanks to §a200 buckets§r.%n%nAllows machines operate at §a150%% of base power per tick§r. The more power a machine can use, the faster it works.%n
 
 # db 529
-nomifactory.quest.db.529.title=IV Assembling Machine
-nomifactory.quest.db.529.desc=With your §6Tungstensteel§r-based machine hulls and §6Nanoprocessor Mainframes§r squared away, you can finally get on the path to making an Insane Voltage §3Assembling Machine§r.%n%nThis tier of Assembling Machine unlocks §6Quantum Circuits§r, as well as handling crafting recipes up to 8192 EU/t. It can also optionally overclock recipes that consume up to 2048 EU/t for improved speed at the cost of relatively more power.
+nomifactory.quest.db.529.title=§2IV Circuit Assembling Machine
+nomifactory.quest.db.529.desc=With your §6Tungstensteel§r-based machine hulls and §6Nanoprocessor Mainframes§r squared away, you can finally get on the path to making an Insane Voltage §3Circuit Assembling Machine§r.%n%nThis tier of Assembling Machine unlocks §6Quantum Circuits§r, as well as handling crafting recipes up to 8192 EU/t. It can also optionally overclock recipes that consume up to 2048 EU/t for improved speed at the cost of relatively more power.
 
 # db 530
-nomifactory.quest.db.530.title=Your First Circuit
-nomifactory.quest.db.530.desc=With all of the components made, it's time to craft a §6Primitive Circuit§r.%n%nThis is where your §3Crafting Station§f setups will really shine! With the patterns encoded into a Crafting Stations (well, really over §omany§r Crafting Stations), you'll be able to §ebatch craft circuits quickly§f.%n%nYou'll be making a LOT§r of circuits, so take advantage of the improved crafting efficiency.
+nomifactory.quest.db.530.title=§2Your First Circuit
+nomifactory.quest.db.530.desc=With all of the components made, it's time to craft an §2Electronic Circuit§r.%n%nThis is where your §3Crafting Station§f setups will really shine! With the patterns encoded into a Crafting Stations (well, really over §omany§r Crafting Stations), you'll be able to §ebatch craft circuits quickly§f.%n%nYou'll be making a LOT§r of circuits, so take advantage of the improved crafting efficiency.
 
 # db 531
-nomifactory.quest.db.531.title=The First Tier Seven Circuits
-nomifactory.quest.db.531.desc=Now that you have an §3Assembly Line§r you can craft the §6Quantum Processor Mainframe§r, the first Tier Seven circuit.%n%nThese are required for crafting the Ludicrous Voltage (LuV) §3Assembling Machine§r.%n%nThis recipe requires some §6Quantum Stars§r, which are made in a §3Chemical Bath§r with a §6Nether Star§r and §9Radon§r. It also needs some §6HSS-G Frames§r and significant quantities of §6SMD Components§r.
+nomifactory.quest.db.531.title=§2The First Tier Seven Circuits
+nomifactory.quest.db.531.desc=Now you can craft the §6Quantum Processor Mainframe§r, the first Tier Seven circuit.%n%nThese are required for crafting the Ludicrous Voltage (LuV) §3Assembling Machine§r.
 
 # db 532
-nomifactory.quest.db.532.title=HV Assembling Machine
-nomifactory.quest.db.532.desc=The §3HV Assembling Machine§r unlocks §6Microcircuits§r, as well as handling crafting recipes that consume up to 512 EU/t.%n%nIt can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.
+nomifactory.quest.db.532.title=§2HV Circuit Assembling Machine
+nomifactory.quest.db.532.desc=The §3HV Circuit Assembling Machine§r unlocks §2the Mainframe§r, as well as handling crafting recipes that consume up to 512 EU/t.%n%nIt can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.
 
 # db 533
-nomifactory.quest.db.533.title=ZPM Assembling Machine
-nomifactory.quest.db.533.desc=With your §6Iridium§r-based machine hulls and §6Crystal Processor Mainframes§r squared away, you can finally get on the path to making a ZPM §3Assembling Machine§r.%n%nThis tier of Assembling Machine unlocks §6Wetware Circuits§r, as well as handling crafting recipes up to 131072 EU/t. It can also optionally overclock recipes that consume up to 32768 EU/t for improved speed at the cost of relatively more power.
+nomifactory.quest.db.533.title=§2ZPM Circuit Assembling Machine
+nomifactory.quest.db.533.desc=With your §2Naquadah Alloy§r-based machine hulls and §6Crystal Processor Mainframes§r squared away, you can finally get on the path to making a ZPM §3Circuit Assembling Machine§r.%n%nThis tier of Assembling Machine unlocks §6Wetware Circuits§r, as well as handling crafting recipes up to 131072 EU/t. It can also optionally overclock recipes that consume up to 32768 EU/t for improved speed at the cost of relatively more power.
 
 # db 534
-nomifactory.quest.db.534.title=The Second Tier Seven Circuits
-nomifactory.quest.db.534.desc=With §6Draconium§r, §6Enderium§r, and some §6HPICs§r, you can assemble a §6Crystal Processor Array§r.
+nomifactory.quest.db.534.title=§2The Second Tier Seven Circuits
+nomifactory.quest.db.534.desc=With §6Enderium§r, you can assemble a §6Crystal Supercomputer§r.
 
 # db 535
-nomifactory.quest.db.535.title=The First Tier Eight Circuits
+nomifactory.quest.db.535.title=§2The First Tier Eight Circuits
 nomifactory.quest.db.535.desc=The §6Crystal Processor Mainframe§r is the first Tier Eight circuit.%n%nAlong with things you already know how to make, this needs §6HSS-E Frames§r.%n%nThese are required for crafting the §3ZPM Assembling Machine§r. As usual, these are extremely expensive: invest in the next theme of circuits instead of trying to mass-produce these.%n
 
 # db 536
-nomifactory.quest.db.536.title=ZPM Machine Hulls
-nomifactory.quest.db.536.desc=§6ZPM Machine Hulls§r are made with §6Iridium Plates§r, but you'll notice they also need §9Polytetrafluoroethylene§r (more commonly known as Teflon™), a special plastic which will be required for all machine hulls going forward.%n%nZPM stands for Zero Point Module.%n%nThis is the last tier of machine that's sensible to produce before you reach the §dCreative Portable Tank§r. Multiblock hatches are a different matter: feel free to upgrade your §3EBF§rs to Ultimate Voltage, if you can handle the power drain.%n
+nomifactory.quest.db.536.title=§2ZPM Machine Hulls
+nomifactory.quest.db.536.desc=§6ZPM Machine Hulls§r are made with §2Naquadah Alloy Plates,§r but you'll notice they also need §2Polybenzimidazole§r.%n%nZPM stands for Zero Point Module.%n%nThis is the last tier of machine that's sensible to produce before you reach the §dCreative Tank§r. Multiblock hatches are a different matter: feel free to upgrade your §3EBF§rs to Ultimate Voltage, if you can handle the power drain.%n
 
 # db 537
-nomifactory.quest.db.537.title=Sterilized Growth Medium
-nomifactory.quest.db.537.desc=§9Sterilized Growth Medium§r is needed for §6Wetware Circuits§r.%n%nYou'll need to mix §6Mincemeat§r, §6Sugar§r, and §6Tiny piles of Salt§r with water in a mixer to make §9Raw Growth Medium§r, then use a §3Fluid Heater§r to sterilize it.%n%nMincemeat comes from pulverizing any kind of animal meat. A §aPowered Spawner§r might be useful for this endeavor.
+nomifactory.quest.db.537.title=§2Sterilized Growth Medium
+nomifactory.quest.db.537.desc=§9Sterilized Growth Medium§r is needed for §6Wetware Circuits§r.%n%nYou'll need to mix §6Mincemeat§r, §2Calcium, Salt, Agar, and Mutagen§r with water in a mixer to make §9Raw Growth Medium§r, then use a §3Fluid Heater§r to sterilize it. §2This is a significantly more involved process than before.§r%n%nMincemeat comes from pulverizing any kind of animal meat. A §aPowered Spawner§r might be useful for this endeavor. §2Agar is produced from Mincemeat through multiple steps.
 
 # db 539
 nomifactory.quest.db.539.title=Phosphorus
 nomifactory.quest.db.539.desc=§6Phosphorus§r can be obtained by processing §6Tricalcium Phosphate Ore§r into dust and electrolyzing several times. This ore is found in §6Apatite§r veins.
 
 # db 540
-nomifactory.quest.db.540.title=MV Extruder
-nomifactory.quest.db.540.desc=The §3Extruder§r is an alternative way to form shapes from metal. §aExtruder Shapes§r are used for telling an Extruder which shape to make.%n%nExtruders are the only way to make certain things, like §6Large Pipes§r. Extruders use ingots, but are as efficient for making §6Gears§r as melting and solidifying.%n%nYou can also use Extruders to make things from other machines like plates and wires, but they are less efficient than using the dedicated machines for these purposes.
+nomifactory.quest.db.540.title=§2MV Extruder
+nomifactory.quest.db.540.desc=The §3Extruder§r is a universal metalworking machine. §aExtruder Shapes§r are used for telling an Extruder which shape to make.%n%nExtruders are §2no longer strictly needed for Large Pipes.§r Extruders use ingots, but are as efficient for making §6Gears§r as melting and solidifying. They are also the most efficient way to make §6Bolts§r, §6Small Gears§r, and §6Rings§r.%n%nYou can also use Extruders to make things from other machines like plates and wires, but they are less efficient than using the dedicated machines for these purposes.
 
 # db 541
-nomifactory.quest.db.541.title=More Blast Furnaces
-nomifactory.quest.db.541.desc=Overclocking aside, as you continue to progress in §5Nomifactory§f, materials made in the §3Electric Blast Furnace§f will take longer to complete. §eMore advanced coils do not give speed bonuses§f, only allowing for the furnace to §eget hot enough to process more advanced materials§f.%n%nConsequently, you'll need to continually expand your smelting and power generation infrastructure.%n%nYou don't have to get all four of these Electric Blast Furnaces completed and running just yet, but be prepared to make many of them over the course of the pack.
+nomifactory.quest.db.541.title=§2More Blast Furnaces
+nomifactory.quest.db.541.desc=Overclocking aside, as you continue to progress in §5Nomifactory§f, materials made in the §3Electric Blast Furnace§f will take longer to complete. §eMore advanced coils do not give speed bonuses§f §2directly§r; they mainly allow for the furnace to §eget hot enough to process more advanced materials§f, §2and they also granting energy efficiency bonuses and speed bonuses to overclocking.§r%n%nConsequently, you'll need to continually expand your smelting and power generation infrastructure.%n%nYou don't have to get all four of these Electric Blast Furnaces completed and running just yet, but be prepared to make many of them over the course of the pack.%n%n§2As a reminder, all blocks and hatches can be shared across EBFs, except Maintenance!
 
 # db 542
 nomifactory.quest.db.542.title=Soul Binder
@@ -1767,20 +1767,20 @@ nomifactory.quest.db.545.title=Reinforced Satchel
 nomifactory.quest.db.545.desc=Carry §oeven more§r stuff.
 
 # db 546
-nomifactory.quest.db.546.title=I Don't Need No Stinkin' Tower
-nomifactory.quest.db.546.desc=Note: this quest accepts both LV and MV Distillery.%n%nIf you don't feel up to making a §3Distillation Tower§r just yet, you can get §9Ethanol§r via a single block §3Distillery§r, a machine that gets one fluid output per §6Integrated Circuit§r configuration, while the §3Distillation Tower§r gives all possible outputs for the input fluid. This defers the tower for a little while longer.%n%nHowever, the Distillation Tower is mandatory for advanced chemistry, as most things have more than one important output: §9Fermented Biomass§r, §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r, and the entire line of petrochemicals from §9Oil§r, to name a few.%n%nCan't avoid it forever!%n%n
+nomifactory.quest.db.546.title=§2Distillery
+nomifactory.quest.db.546.desc=Note: this quest accepts both LV and MV Distillery. §2If you are distilling Ethanol, you now need an MV Distillery.%n%n§rThe §3Distillery§r is a single-block machine which only outputs one distillate out of several and §cdiscards§r the rest. You can use this now to get §9Ethanol§r from §9Biomass§r, or to selectively distill §9Oil§r in multiple steps to §9Ethylene§r. Its advantage over the full Tower, apart from cost, is its §denergy efficiency§r.§r %n%nHowever, the Distillation Tower is mandatory for advanced chemistry, as most things have more than one important output: §9Fermented Biomass§r, §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r, and the entire line of petrochemicals from §9Oil§r, to name a few.%n%nCan't avoid it forever!%n%n
 
 # db 547
 nomifactory.quest.db.547.title=Scanner Module: Block
-nomifactory.quest.db.547.desc=A good way to find a specific ore you're missing is the §6Scanner Module: Block§r for your Scanner. §6Sneak-right click§f a piece of ore you want to search for with a Module in your hand, then §6sneak-right click§f the §aScanner§f, put the module inside, and go wander around scanning. %n%nThe range is significantly longer than it is when using the modules which detect all ores, and you even have room for a second §6Range Module§f if you've got an §6Ender Pearl§f to craft one.%n%nYou can combo this with ores bought from §dOmnicoins§f to act as a "sample" to easily find a full vein with the Block Module.
+nomifactory.quest.db.547.desc=
 
 # db 548
 nomifactory.quest.db.548.title=Molds
-nomifactory.quest.db.548.desc=§aMolds§r are used in a §3Fluid Solidifier§r or §3Alloy Smelter§r to form materials into specific shapes. These are not consumed or damaged during crafting, so you can leave them in a machine to dedicate it to that shape.%n%nThe Fluid Solidifier tends to be the more efficient option: for example, you can use §e8 ingots§r to make one §6Gear§r in an Alloy Smelter, but with a Fluid Extractor and Solidifier you can accomplish the same result with §e4 ingots§r.%n%nBe careful not to accidentally make §aExtruder Shapes§r. Those are for a machine you will get access to later. The three molds in this quest are ones you will find useful right away.
+nomifactory.quest.db.548.desc=§aMolds§r are used in a §3Fluid Solidifier§r or §3Alloy Smelter§r to form materials into specific shapes. These are not consumed or damaged during crafting, so you can leave them in a machine to dedicate it to that shape.%n%nThe Fluid Solidifier tends to be the more efficient option: for example, you can use §e8 ingots§r to make one §6Gear§r in an Alloy Smelter, but with an Extractor and Solidifier you can accomplish the same result with §e4 ingots§r.%n%nBe careful not to accidentally make §aExtruder Shapes§r. Those are for a machine you will get access to later. The three molds in this quest are ones you will find useful right away.
 
 # db 549
-nomifactory.quest.db.549.title=Oil Drilling Rig
-nomifactory.quest.db.549.desc=If you don't like the idea of mining out Oilsands veins, you can build an §3Oil Drilling Rig§r.%n%nYou'll need to provide it with power, §9Drilling Fluid§r, and a steady supply of §6Pipes§r. The Pipes only have a 1%% chance to break per bucket of §9Oil§r drilled.%n%nYou'll need to supply at least §eHV power§r to your rig, and it will overclock with higher energy tiers. Positions of hatches and buses can be swapped with any §6Solid Steel Machine Casing§r.%n%nIf the multiblock preview in §bJEI§r is confusing, note that you can §ehold shift and drag-right-click§r to scale the preview to fit the window. Place then §6sneak-right click§r the controller block with an empty hand to enable the in-world preview.%n%nKeep in mind when placing the structure that there are 12 pipes that extend downward from the level of the controller.%n
+nomifactory.quest.db.549.title=§2Fluid Rig
+nomifactory.quest.db.549.desc=§2Fluid Rigs will harvest fluids from underground fluid veins. Note that the fluid veins are simply simulated and don't exist in the world. §r%n%nUse your §3Prospector's Scanner§r to see the type and amount of fluid underground and to check the depletion state of the vein. The first number represents the base amount of fluid extracted per second. %n%nIn the §eOverworld§r, it can harvest: §9Oil, Light Oil, Heavy Oil, Raw Oil, Natural Gas, Salt Water§r%n%nIn the §eNether§r: §eLava, Natural Gas§r%n%nOn the §eMoon§r: §9Deuterium, Helium-3§r%n%nThe first tier of Fluid Rig is good for §d100,000 operations§r. Higher tier Fluid Rigs harvest fluids far faster and deplete veins slower.
 
 # db 550
 nomifactory.quest.db.550.title=Vertical Digger
@@ -1788,7 +1788,7 @@ nomifactory.quest.db.550.desc=Place the §3Vertical Digger§r over an ore vein, 
 
 # db 551
 nomifactory.quest.db.551.title=Phantom Booster
-nomifactory.quest.db.551.desc=Up to three §aPhantom Boosters§r can be placed atop the §3Vertical Digger§r to increase its area of effect.%n%nThese are also useful for extending the range of other "Phantom" machines and devices from §bActually Additions§r.
+nomifactory.quest.db.551.desc=These are useful for extending the range of other "Phantom" machines and devices from §bActually Additions§r.
 
 # db 552
 nomifactory.quest.db.552.title=Leadstone Jetpack
@@ -1823,8 +1823,8 @@ nomifactory.quest.db.564.title=Neutronium Solar Panel
 nomifactory.quest.db.564.desc=How much do you think these solar panels weigh? %n%nThese are quite expensive and two of them are required for each Tier Ten Micro Miner.%n%n§6Neutronium Solar Panels§r generate an enormous amount of RF power in sunlight, so once you get your tank it's also a good choice for compact power generation.%n%nProtip: it's always daytime in space.
 
 # db 580
-nomifactory.quest.db.580.title=Blast Furnaces Galore
-nomifactory.quest.db.580.desc=As you continue to progress, crafting times for more advanced §3Electric Blast Furnace§r recipes will continue to increase. More advanced coils do not give speed bonuses, they just increase the operating temperature so you can smelt more advanced materials.%n%nTo compensate, you'll need to get your infrastructure for smelting, as well as for power generation, up to snuff.%n%nYou don't need to get all eight of these completed and running just yet, but plan to at some point in the future. Instead of upgrading existing EBFs, have them passively automating a stock of materials and build new EBFs with higher specifications for new materials.%n%n
+nomifactory.quest.db.580.title=§2Blast Furnaces Galore
+nomifactory.quest.db.580.desc=As you continue to progress, crafting times for more advanced §3Electric Blast Furnace§r recipes will continue to increase. More advanced coils do not give speed bonuses, they just increase the operating temperature so you can smelt more advanced materials, §2and they also grant energy efficiency bonuses and speed bonuses to overclocking.§r%n%nTo compensate, you'll need to get your infrastructure for smelting, as well as for power generation, up to snuff.%n%nYou don't need to get all eight of these completed and running just yet, but plan to at some point in the future. Instead of upgrading existing EBFs, have them passively automating a stock of materials and build new EBFs with higher specifications for new materials.%n%n
 
 # db 582
 nomifactory.quest.db.582.title=Fluxed Electrum Ingots
@@ -1912,19 +1912,19 @@ nomifactory.quest.db.603.desc=
 
 # db 604
 nomifactory.quest.db.604.title=Heart Of A Universe
-nomifactory.quest.db.604.desc=No hypothetical aliens were harmed in the harvesting of this item.%n%nProbably.%n%nMelting the heart of a universe provides a rather useful liquid: §dMolten Creative Portable Tank§r.
+nomifactory.quest.db.604.desc=No hypothetical aliens were harmed in the harvesting of this item.%n%nProbably.
 
 # db 605
 nomifactory.quest.db.605.title=Tier Ten Micro Miner
 nomifactory.quest.db.605.desc=You are become Death, destroyer of Universes.%n%nMight probably be obvious, but this miner gathers §6Heart of a Universe§r.
 
 # db 606
-nomifactory.quest.db.606.title=Neutronium Heavy Plating
+nomifactory.quest.db.606.title=§2Neutronium Heavy Plating
 nomifactory.quest.db.606.desc=Kind of redundant, really.%n%nThis plating is used exclusively for the Tier Ten Micro Miner. You need some serious protection from forces when harvesting a whole microverse.
 
 # db 607
 nomifactory.quest.db.607.title=Neutronium Ingot
-nomifactory.quest.db.607.desc=§6Neutronium§r is a hyper-dense material normally found in the hearts of neutron stars: the collapsed cores of stars between ten and thirty times the size of the sun.%n%nFun fact: a single neutronium block is approximately 2884 million metric tons and somewhere around 600000K, yet you're somehow capable of holding one with your bare hands. Don't think about it too much.%n%nNeutronium is made from fusing molten §9Naquadria§r, a super-enriched form of §6Naquadah§r, with molten §9Americium§r. These bad boys require a LOT of time to fuse.%n%nParallelizing fluid crafting is tricky business (and Mark 3 reactors are expensive), but several could be used to speed up the processing. Try to minimize your reactor's downtime and be very careful about supplying your reactors with stable power.%n%nAfter getting §6Chaotic Fusion Injectors§r, you might consider using Tier Nine Micro Miners to supplement the fusion, as it is net-positive for Neutronium. These miners are expensive though, so it's up to you.%n
+nomifactory.quest.db.607.desc=§6Neutronium§r is a hyper-dense material normally found in the hearts of neutron stars: the collapsed cores of stars between ten and thirty times the size of the sun.%n%nFun fact: a single neutronium block is approximately 2884 million metric tons and somewhere around 600000K, yet you're somehow capable of holding one with your bare hands. Don't think about it too much.%n%nNeutronium is made from fusing molten §9Naquadria§r, a super-enriched form of §6Naquadah§r, with molten §9Americium§r. %n%nAfter getting §6Chaotic Fusion Injectors§r, you might consider using Tier Nine Micro Miners to supplement the fusion, as it is net-positive for Neutronium. These miners are expensive though, so it's up to you.%n
 
 # db 608
 nomifactory.quest.db.608.title=Superconductor Wire
@@ -1967,7 +1967,7 @@ nomifactory.quest.db.617.title=Element 005: Boron
 nomifactory.quest.db.617.desc= 
 
 # db 618
-nomifactory.quest.db.618.title=Element 006: Carbon
+nomifactory.quest.db.618.title=§2Element 006: Carbon
 nomifactory.quest.db.618.desc= 
 
 # db 619
@@ -1987,11 +1987,11 @@ nomifactory.quest.db.622.title=Element 010: Neon
 nomifactory.quest.db.622.desc= 
 
 # db 623
-nomifactory.quest.db.623.title=Element 011: Sodium
+nomifactory.quest.db.623.title=§2Element 011: Sodium
 nomifactory.quest.db.623.desc= 
 
 # db 624
-nomifactory.quest.db.624.title=Element 012: Magnesium
+nomifactory.quest.db.624.title=§2Element 012: Magnesium
 nomifactory.quest.db.624.desc= 
 
 # db 625
@@ -2019,7 +2019,7 @@ nomifactory.quest.db.630.title=Element 018: Argon
 nomifactory.quest.db.630.desc= 
 
 # db 631
-nomifactory.quest.db.631.title=Element 019: Potassium
+nomifactory.quest.db.631.title=§2Element 019: Potassium
 nomifactory.quest.db.631.desc= 
 
 # db 632
@@ -2151,7 +2151,7 @@ nomifactory.quest.db.663.title=Element 094: Plutonium
 nomifactory.quest.db.663.desc= 
 
 # db 664
-nomifactory.quest.db.664.title=Element 095: Americium
+nomifactory.quest.db.664.title=§2Element 095: Americium
 nomifactory.quest.db.664.desc= 
 
 # db 665
@@ -2179,12 +2179,12 @@ nomifactory.quest.db.670.title=End Game Tab
 nomifactory.quest.db.670.desc=Take a peek at The §eEnd Game quest book tab§f. This might seem a bit premature to suggest, but it has a reason.%n%nThese are quests for a full stack of many of the materials in the game. Those are the materials you'll need to synthesize §5Omnium§r, the basic end game resource. It's the pack's way of letting you know what materials you should be prepared to mass produce as you approach the end.%n%nOf course, it's not necessary or even advisable to try to finish up all of these quests the moment they become available. Some will be incredibly easy (like §6Iron§f and §6Copper§f), others will be brutally grindy at early tech levels. The rewards are all the same: §d25 Omnicoins each§f, so use your best judgement on which ones to complete and which to ignore for later.
 
 # db 671
-nomifactory.quest.db.671.title=Thorium Fission
-nomifactory.quest.db.671.desc=Thorium is another basic fissile material that can be used to get into the fissile chain. Thorium comes from §6Pitchblende Ore§r, §6Thorium Ore§r, and even §6Granite§r (with a few processing steps).%n%nThorium-Bred Uranium, or §6TBU§r for short, is made from nine clumps of §6Thorium 232§r enriched in a §3Thermal Centrifuge§r.%n%nThe depleted fuel provides tiny clumps of §6Uranium 233§r, §6Uranium 235§r, §6§6Neptunium 236§r, and §6Neptunium 237§r.
+nomifactory.quest.db.671.title=§2Thorium Fission
+nomifactory.quest.db.671.desc=Thorium is another basic fissile material that can be used to get into the fissile chain. Thorium comes from §6Pitchblende Ore§r, §6Thorium Ore§r, and even §2Black Granite§r (with a few processing steps).%n%nThorium-Bred Uranium, or §6TBU§r for short, is made from nine clumps of §6Thorium 232§r enriched in a §3Thermal Centrifuge§r.%n%nThe depleted fuel provides tiny clumps of §6Uranium 233§r, §6Uranium 235§r, §6§6Neptunium 236§r, and §6Neptunium 237§r.
 
 # db 672
-nomifactory.quest.db.672.title=Nuclear Fuel Infrastructure
-nomifactory.quest.db.672.desc=Climbing the ladder of fissile materials will require some specific raw materials and machinery.%n%n§6Uranium 238§r is an important fissile material, and can be obtained from ores like §6Uranium Ore§r and §6Pitchblende Ore§r. Uranium 238 ingots or dusts need to be processed in a §3Thermal Centrifuge§r into clumps required for Enriched Fuels. §6Uranium 235§r dust is a byproduct of processing Uranium 238 Ore or §6Uraninite Ore§r, and must also be turned into clumps with a Thermal Centrifuge.%n%nThermal Centrifuges are very slow machines so you should parallelize this processing as much as possible, using the highest tier ones you can afford for overclocking.%n%n
+nomifactory.quest.db.672.title=§2Nuclear Fuel Infrastructure
+nomifactory.quest.db.672.desc=Climbing the ladder of fissile materials will require some specific raw materials and machinery.%n%n§2Uraninite is the base resource you will need, which comes from Uraninite and Pitchblende Ore. You will need to react it with Fluorine and Hydrofluoric Acid in a Chemical Reactor to form Uranium Hexafluoride.%n%nThe Uranium Hexafluoride must then be separated into Depleted and Enriched Uranium Hexafluoride in a Centrifuge. The Depleted UF₆ will grant Uranium-238, while the Enriched UF₆ will grant Uranium-235.%n%n
 
 # db 673
 nomifactory.quest.db.673.title=Neptunium Fission
@@ -2219,8 +2219,8 @@ nomifactory.quest.db.680.title=Further Adventures In Fission
 nomifactory.quest.db.680.desc=Now that you have all the basic building blocks of nuclear fission, you'll need to start creating breeding chains to mass produced stabilized versions of each element, for the synthesis of §dOmnium§r.%n%nExperiment around with larger breeder reactors that can handle highly enriched fuels.%n%nYou'll probably want to build multiple reactors to make all the fissile elements in any reasonable amount of time.
 
 # db 681
-nomifactory.quest.db.681.title=Implosion Compressor
-nomifactory.quest.db.681.desc=The §aImplosion Compressor§f is like an autoclave that uses explosions instead of water. It is the only way to turn most gem dusts into gemstones.%n%nIt will also be vital for processing §5Motes of Omnium§f.%n%nIn addition to the controller and casings, you will need one §eLV or better§r §6Item Input Bus§r, §6Item Output Bus§r, and §6Energy Input Hatch§r.
+nomifactory.quest.db.681.title=§2Implosion Compressor
+nomifactory.quest.db.681.desc=The §aImplosion Compressor§f is like an autoclave that uses explosions instead of water. It is the only way to turn most gem dusts into gemstones.%n%nIt will also be vital for processing §5Motes of Omnium§f.%n%nIn addition to the controller and casings, you will need one §eLV or better§r §6Item Input Bus§r, §6Item Output Bus§r, and §6Energy Input Hatch§r.%n%n§2If desired, you may upgrade this directly to an Electric Implosion Compressor, which can accept Parallel Control hatches.
 
 # db 682
 nomifactory.quest.db.682.title=Simulating Mobs
@@ -2243,8 +2243,8 @@ nomifactory.quest.db.686.title=Overworldian Mobs
 nomifactory.quest.db.686.desc=There's no rush to get these all done and leveled up, but they do provide a good source of some of the basic resources in exchange for RF.%n%nLook at what the §6Pristine Matter§r for each mob provides, and set up simulators for all the ones you're interested in. If your power can handle it, it can even be advantageous to run several of the same model.
 
 # db 687
-nomifactory.quest.db.687.title=Infinite Water
-nomifactory.quest.db.687.desc=Feeding a §3Steam Dynamo§f with water by hand is a pretty silly idea.%n%nAn §6Infinite Water Source§f will take care of that for you, albeit slowly.
+nomifactory.quest.db.687.title=§2Infinite Water
+nomifactory.quest.db.687.desc=Feeding a §3Steam Dynamo§f with water by hand is a pretty silly idea.%n%nAn §6Infinite Water Source§f will take care of that for you, albeit slowly.%n%n§2GTCEu has a Primitive Water Pump, which can do it faster. However, it requires Treated Wood, which requires Creosote from a Coke Oven.
 
 # db 688
 nomifactory.quest.db.688.title=Hellish Matter
@@ -2263,8 +2263,8 @@ nomifactory.quest.db.691.title=Extraterrestrial Mobs
 nomifactory.quest.db.691.desc=Some of these simulations will start to consume tremendous amounts of power at this point, so if you're finding it a struggle, don't be afraid to hold off on progressing through these data models until a later time.
 
 # db 692
-nomifactory.quest.db.692.title=Wrenches Galore
-nomifactory.quest.db.692.desc=Confused about all the Wrenches yet?%n%nThe §aCrescent Hammer§r is for use on machines from §bThermal Expansion§f, but can be used for basic wrench interactions with blocks from almost every mod.%n%nThe §aYeta Wrench§r is used with machines and conduits from §bEnderIO§f, and has several special display modes (§6sneak-mouse wheel§f to switch between them).%n%nThe §aGregTech Wrench§r is used to rotate GregTech machines and redefine their output sides.%n%nYou can see which mod a machine is from with the §9blue text§f at the bottom of its tooltip.
+nomifactory.quest.db.692.title=§2Wrenches Galore
+nomifactory.quest.db.692.desc=Confused about all the Wrenches yet?%n%nThe §aCrescent Hammer§r is for use on machines from §bThermal Expansion§f, but can be used for basic wrench interactions with blocks from almost every mod.%n%nThe §aYeta Wrench§r is used with machines and conduits from §bEnderIO§f, and has several special display modes (§6sneak-mouse wheel§f to switch between them).%n%nThe §aGregTech Wrench§r is used to rotate GregTech machines and redefine their output sides. §2It also has some of the capabilities of the other Wrenches now.§r%n%nYou can see which mod a machine is from with the §9blue text§f at the bottom of its tooltip.
 
 # db 693
 nomifactory.quest.db.693.title=Infinity War
@@ -2280,11 +2280,11 @@ nomifactory.quest.db.695.desc=This is the flight of our lives.
 
 # db 696
 nomifactory.quest.db.696.title=Naquadah Reactor Mk2
-nomifactory.quest.db.696.desc=The §3Naquadah Reactor Mk2§r is an upgraded reactor that can generate immense amounts of EU energy from the same types of fuels as the Mk1. The materials it requires are similar to the Mk1, and you can almost reuse the same structure. Make sure you are prepared for the UV power output by adding a §6UV Energy Output Hatch§r.%n%nThis is a pretty expensive structure though, as it needs blocks of §dOmnium§r. Maybe wait until after you get the §dCreative Portable Tank§r?%n%n§6Sneak-right click§r the controller to enable the in-world preview.
+nomifactory.quest.db.696.desc=The §3Naquadah Reactor Mk2§r is an upgraded reactor that can generate immense amounts of EU energy from the same types of fuels as the Mk1. The materials it requires are similar to the Mk1, and you can almost reuse the same structure. Make sure you are prepared for the UV power output by adding a §6UV Energy Output Hatch§r.%n%nThis is a pretty expensive structure though, as it needs blocks of §dOmnium§r. Maybe wait until after you get the §dCreative Tank§r?%n%n§6Sneak-right click§r the controller to enable the in-world preview.
 
 # db 727
-nomifactory.quest.db.727.title=Ore Processing for Byproducts
-nomifactory.quest.db.727.desc=When you first started the pack, we told you that ore doubling can wait, and that's true... But you will need to start doing some rudimentary ore processing for §ebyproducts§r.%n%nByproducts are additional materials that can only be obtained from processing ores in certain machines. For example, there is no "Gallium Ore". You get §6Gallium§r as a byproduct from processing other ores.%n%nOres have various means of processing, and eventually you'll use machine pipelines to process ores in specific ways to optimize what byproducts you gain. You can look at the §b§b§6Ore Byproduct Page§6§r of an ore in §bJEI§r, accessed by pressing 'U' on an ore and navigating to the byproduct tab, to see the required route to obtain desired byproducts. The tooltips on a byproduct will specify what processing method is needed to obtain it.%n%nThe relevant machines are as follows:%n %n- §3Macerator§r: turns ores into §6Crushed Ores§r, Crushed Ores into §6Impure Dusts§r, and §6Purified Crushed Ores§r into §6Pure Dusts§r. Higher tiers of macerators have byproduct slots and gain a chance to get a full pile of byproduct from ores and both types of crushed ores.%n%n- §3Washer§r: cleans Crushed Ores with §9Water§r, making Purified Crushed Ores§r, and a guaranteed 3 tiny piles of byproduct. Using §9Distilled Water§r makes them go faster. This is an improved alternative to dropping dusts in a Cauldron.%n%n- §3Chemical Bath§r: similar to a washer, but uses chemicals to purify the crushed ores. Has a chance to give a full pile of byproducts, often different than what the Washer would give.%n%n- §3§3Centrifuge§r: separates Pure or Impure dusts into the final material, producing a guaranteed 3 tiny piles of byproduct.%n%n- §3Electrolyzer§r: uses power to split compounds into individual elements, sometimes gaining useful byproducts in the process.%n%nThe §3Thermal Centrifuge§r, not to be confused with the regular Centrifuge, can be used for alternative ore processing but is §edreadfully slow and power-hungry§r. No LV form exists, and its primary use is for §bNuclearCraft§r fission fuels.%n%nYour first forays into ore processing for byproducts will be the Electrolyzer and the Centrifuge.%n
+nomifactory.quest.db.727.title=§2Ore Processing for Byproducts
+nomifactory.quest.db.727.desc=When you first started the pack, we told you that ore doubling can wait, and that's true... But you will need to start doing some rudimentary ore processing for §ebyproducts§r.%n%nByproducts are additional materials that can only be obtained from processing ores in certain machines. For example, there is no "Gallium Ore" or "Arsenic Ore". You get §6Gallium§r and §6Arsenic §ras a byproduct from processing other ores.%n%nOres have various means of processing, and eventually you'll use machine pipelines to process ores in specific ways to optimize what byproducts you gain. You can look at the §b§b§6Ore Byproduct Page§6§r of an ore in §bJEI§r, accessed by pressing 'U' on an ore and navigating to the byproduct tab, to see the required route to obtain desired byproducts. %n%nThe relevant machines are as follows:%n %n- §3Macerator§r: turns ores into §6Crushed Ores§r, Crushed Ores into §6Impure Dusts§r, and §6Purified Crushed Ores§r into §6Pure Dusts§r. Higher tiers of macerators have byproduct slots and gain a chance to get a full pile of byproduct from ores and both types of crushed ores.%n%n- §3Ore Washer§r: cleans Crushed Ores with §9Water§r, making Purified Crushed Ores§r, and a guaranteed 3 tiny piles of byproduct. Using §9Distilled Water§r makes them go faster. §2You can also perform a simple wash with this similar to Cauldron washing, which is extremely fast, but grants no byproducts.§r%n%n- §3Chemical Bath§r: §2uses Sodium Persulfate or Mercury to purify certain ores, granting a chance to yield a full pile of a byproduct.%n%n§r- §3§3Centrifuge§r: separates Pure or Impure dusts into the final material, producing a guaranteed §21 (nerfed from 3) tiny pile of byproduct§r.%n%n- §3Electrolyzer§r: uses power to split compounds into individual elements, sometimes gaining useful byproducts in the process. §2Be warned that certain dusts may be better to directly smelt instead of electrolyze!§r%n%n- §3Thermal Centrifuge§r: not to be confused with the regular Centrifuge. §2Less slow and power-hungry now, but still so. However, it yields 3 additional tiny piles of byproduct, and macerating the Centrifuged Ore can grant a special third byproduct.%n%n§2- Sifter: filters high-quality Gems from Purified Crushed gem Ores for an overall higher yield.%n%n- Electromagnetic Separator: filters magnetic metals from certain ores, increasing their yields.§r%n%nYour first forays into ore processing for byproducts will be the Electrolyzer and the Centrifuge.%n
 
 # db 728
 nomifactory.quest.db.728.title=Resonant Clathrate
@@ -2303,8 +2303,8 @@ nomifactory.quest.db.731.title=Fluid Logistics
 nomifactory.quest.db.731.desc=Your §3Chemical Reactors§r will be making a lot of different fluids. You'll need to manage the logistics of routing and storing all the different fluids you're automating.%n%nWherever possible, having one Chemical Reactor output directly into another machine that needs its output chemical saves you from having to figure out additional storage and routing. §aFluid Filters§r and §aPump covers§r are very useful for moving fluids around a compact processing pipeline.%n%nBut what about the final output fluids that you need elsewhere?%n%nOne option is to use the output tanks of the Chemical Reactors as a small storage buffer, letting it back up and stop crafting automatically. A §aFluid Storage Bus§r on the machine will expose the fluid to your ME Network. Whenever you need some of this fluid, your AE2 system will pull the needed fluid out and the machine will resume processing.%n%nThere's some catches with this approach though. First is that the inaccessible input tanks will also show up in AE but you won't be able to access them. You will want to set the Storage Bus to §eExport Only§r so AE doesn't try to store random fluids in the Chemical Reactor, and you may want to §ereduce the priority§r of the Storage Bus as well: this will signal to AE that you want it to remove fluids from that location first. Also, if multiple fluids are produced, §ethe machine will not resume processing if it doesn't have room for all fluid outputs§r.%n%nWhen you get access to them, it's probably just better to use single-fluid-formatted §aFluid Storage Cells§r and dump outputs into AE via Fluid Interfaces. You can fill up the cells, then pull the fluids out wherever else you need them.%n%n
 
 # db 732
-nomifactory.quest.db.732.title=Hard Carbon Alloy
-nomifactory.quest.db.732.desc=§6Hard Carbon Alloy§r is an alloy made from §6Graphite§r and §6Diamonds§r.%n%nGraphite is an important ingredient for §bNuclearCraft§r and is found principally as a byproduct of processing §6Diamond Ore§r. §6Graphite Ore§r spawns alongside Diamond Ore, but unlike Diamond Ore it is not renewable through automation (though it can be purchased using §dOmnicoins§r).
+nomifactory.quest.db.732.title=§2Hard Carbon Alloy
+nomifactory.quest.db.732.desc=§6Hard Carbon Alloy§r is an alloy made from §2Steel§r and §6Diamonds§r.
 
 # db 733
 nomifactory.quest.db.733.title=Draconic Evolution Information Tablet
@@ -2315,8 +2315,8 @@ nomifactory.quest.db.743.title=Use JEI! Use JEI! USE. JEI.
 nomifactory.quest.db.743.desc=§eUSE JEI!!!§r%n%n§bJEI§r stands for §bJust Enough Items§r. It's the list of all items that you see every time you open your inventory. It's the better(tm) recipe book that shows you all available items and recipes in the modpack.%n%nTo see it in action, pull up a quest that requires an item of some sort and just click the item!%n%nIf you want to know how to craft an item, just hover your mouse over it and press §6R§r. JEI will list all available recipes.%n%nIf you instead want to know what recipes use an item, hover over it and press §6U§r.%n%nHover over an item and press §6A§r to bookmark it. To remove a bookmarked item from the list, press A on the bookmark.%n%nOne of the remarkable features of JEI is that it's also capable of helping you with recipes. Right-click a crafting table, look up the recipe you need and press the §a[+]§r button: if you have all required items for the recipe, this will put them all into the crafting table for you.
 
 # db 744
-nomifactory.quest.db.744.title=Multi-Layer Fiber-Reinforced Epoxy Substrate
-nomifactory.quest.db.744.desc=That's a lot of foil.%n%nThese boards are required for §6Quantum§r and §6Crystal Circuits§r, as well as the future basis of §6Wetware Lifesupport Circuit Boards§r. These will get you from tier four to tier eight.
+nomifactory.quest.db.744.title=§2Multi-Layer Fiber-Reinforced Epoxy Substrate
+nomifactory.quest.db.744.desc=That's a lot of foil. §2These use Platinum Foil instead of Electrum now.§r%n%nThese boards are required for §6Crystal Circuits§r, as well as the future basis of §6Wetware Lifesupport Circuit Boards§r. These will get you from tier five to tier eight.
 
 # db 745
 nomifactory.quest.db.745.title=Signalum
@@ -2324,7 +2324,7 @@ nomifactory.quest.db.745.desc=Not glowing.%n%nThis one takes a significant amoun
 
 # db 746
 nomifactory.quest.db.746.title=Compactor
-nomifactory.quest.db.746.desc=A very power-efficient, if slow before upgrades, means of creating plates. Also the only way to directly make plates from single gems.%n%nUpgrading the machine tier with §aUpgrade Kits§r and applying §aAugments§r to boost its crafting speed is a good idea.%n%nPlates and Platings that are gated specifically by later §bGregTech§r voltage tiers are not craftable in these (instead requiring a §3Compressor§r), but almost every single-ingredient recipe made in a Compressor is available.
+nomifactory.quest.db.746.desc=A very power-efficient, if slow before upgrades, means of creating plates. Also the only way to directly make plates from single gems.%n%nUpgrading the machine tier with §aUpgrade Kits§r and applying §aAugments§r to boost its crafting speed is a good idea.
 
 # db 747
 nomifactory.quest.db.747.title=Dark Steel Enchanter
@@ -2335,12 +2335,12 @@ nomifactory.quest.db.748.title=Gearworking Die
 nomifactory.quest.db.748.desc=A §3Compactor§r§r§r specialized to a §aGear Press§r is a very power efficient way to make gears. It is slower than its overclocking GTCE counterparts, but is required for some gears, most notably the crystal and gemstone ones.%n%nLike all §aAugments§r, the Gear Press specialization takes up an upgrade slot, but you can still use the rest of the slots for other ones like speed upgrades.
 
 # db 749
-nomifactory.quest.db.749.title=Fusion Reactor MK2
+nomifactory.quest.db.749.title=§2Fusion Reactor MK2
 nomifactory.quest.db.749.desc=Upgrade time! %n...or building a new one, which is probably better.%n%nYet again this quest asks for the minimal number of casings. Make an extra 28 if you don't want more than §a2 Fluid Inputs§r§r and §a1 Fluid Output§r.%n%nIf you insist on upgrading instead of making a new one, don't dismantle the current one before you're sure you've got everything you need to upgrade it, or you might end up having to rebuild the §3Mark 1 Fusion Reactor§r again.%n%nThe §3Mark 2 Fusion Reactor§r has an energy buffer of §e320M EU§r.
 
 # db 750
-nomifactory.quest.db.750.title=Enderium Ingot
-nomifactory.quest.db.750.desc=A complex material from §bThermal Expansion§r cooked in an §3Electric Blast Furnace§r.%n%n§6Enderium§r doesn't require much power (running on as little as MV) but it does need a lot of heat and is incredibly slow without overclocking.%n%nAs with all later blast furnace materials, dedicate a furnace to keeping these in stock and have it running constantly to ensure a stable supply (turning it off when you have an acceptably vast stockpile).%n%nIn addition to its other uses, Enderium gets you access to §aResonant Upgrade Kits§r for machines and the §6Resonant Satchel§r. These quests can be found on the §eProgression§r tab.%n%n
+nomifactory.quest.db.750.title=§2Enderium Ingot
+nomifactory.quest.db.750.desc=A complex material from §bThermal Expansion§r cooked in an §3Electric Blast Furnace§r.%n%n§6Enderium§r doesn't require much power (running on as little as MV) but it does need a lot of heat and is incredibly slow without overclocking. §2You can use small amounts of Krypton from Liquid Ender Air distillation to significantly decrease the smelting time.§r%n%nAs with all later blast furnace materials, dedicate a furnace to keeping these in stock and have it running constantly to ensure a stable supply (turning it off when you have an acceptably vast stockpile).%n%nIn addition to its other uses, Enderium gets you access to §aResonant Upgrade Kits§r for machines and the §6Resonant Satchel§r. These quests can be found on the §eProgression§r tab.%n%n
 
 # db 751
 nomifactory.quest.db.751.title=Infinitest Water
@@ -2396,7 +2396,7 @@ nomifactory.quest.db.763.desc=A good, but slightly gated way of teleporting back
 
 # db 764
 nomifactory.quest.db.764.title=LV Circuits
-nomifactory.quest.db.764.desc=Circuits along this line are LV, and can all be substituted in recipes.%n%n§7Primitive Circuits§r are the worst in terms of cost and effort required to produce, but you have to start with something.%n%n§2Electronic Circuits§r are the middle layer between Primitive Circuits and Refined Circuits.%n%nAnd finally, §aRefined Circuits§r, which take the lowest effort and come in batches of four, but require polyethylene.%n
+nomifactory.quest.db.764.desc=Circuits along this line are LV, and can all be substituted in recipes.%n%n§7§2Electronic Circuits§r are the worst in terms of cost and effort required to produce, but you have to start with something.%n%n§2§2Integrated Circuits§r are the middle layer between §2Electronic Circuits and Microprocessors.§r%n%nAnd finally, §2Microprocessors§r, which take the lowest effort.
 
 # db 765
 nomifactory.quest.db.765.title=What is This?
@@ -2440,7 +2440,7 @@ nomifactory.quest.db.774.desc=The §3Lathe§r is an important machine that makes
 
 # db 775
 nomifactory.quest.db.775.title=Multiblock Machine Previews
-nomifactory.quest.db.775.desc=§bMultiblock Tweaker§r adds an §einteractive in-world preview§r for all §bGregTech§r multiblocks! §6Shift-right-click§r a placed controller to activate a hologram depicting the default layout of the structure to help you with building. As you place blocks, the structure will be validated and the §efirst incorrect block§r it detects will be highlighted in red.%n%n§6Sneak-right-click§r to cycle from the full view through each layer. When on the final layer of the preview, this will remove the preview.%n%n§6Sneak-left-click§r to go back to the previous layer, or close the preview from the full view.%n%nIn the §eJEI previews§r for multiblocks, §6left-click§r and drag the mouse to rotate the preview horizontally. §6Shift-left-click§r to rotate it vertically.%n%nAdditionally, you can §6right-click§r and drag the mouse to pan the preview or §6shift-right-click§r and drag to zoom in or out.%n%nSome blocks in the multiblock preview have additional tooltips to provide more information on how the multiblock can form.
+nomifactory.quest.db.775.desc=§2GregTechCEu§r adds an §einteractive in-world preview§r for all §bGregTech§r multiblocks! §6Shift-right-click§r a placed controller §2with an empty hand§r to activate a hologram depicting the default layout of the structure to help you with building. As you place blocks, the structure will be validated and the §efirst incorrect block§r it detects will be highlighted in red.%n%n§6Sneak-right-click§r to cycle from the full view through each layer. When on the final layer of the preview, this will remove the preview.%n%n§6Sneak-left-click§r to go back to the previous layer, or close the preview from the full view.%n%nIn the §eJEI previews§r for multiblocks, §6left-click§r and drag the mouse to rotate the preview.%n%nAdditionally, you can §6right-click§r and drag the mouse to pan the preview or §6shift-right-click§r and drag to zoom in or out.%n%nSome blocks in the multiblock preview have additional tooltips to provide more information on how the multiblock can form.
 
 # db 776
 nomifactory.quest.db.776.title=Awakened Core
@@ -2451,16 +2451,16 @@ nomifactory.quest.db.777.title=Empowered Diamantine Gear
 nomifactory.quest.db.777.desc=A gear forged from §6Empowered Diamantine Crystal§6§r.%n%nMade from fluid solidification.
 
 # db 778
-nomifactory.quest.db.778.title=Power Storage on a Massive Level
-nomifactory.quest.db.778.desc=Now that you have §6Awakened Cores§r, you can make the §eEnergy Storage Core§r from §bDraconic Evolution§r. It's a great way to store all the energy required to craft power-hungry late game items.%n%nThe §eEnergy Storage Core§r is a multiblock structure that can be upgraded to store increasingly immense amounts of RF energy. See the §bDraconic Evolution§r manual for more information on the material requirements for each tier.%n%n§6Energy Pylons§r are required to input and output energy from the core. Each pylon allows movement in a single direction, so you need at least two.%n%nOnce you have the materials together for your desired tier, § the structure can build itself: simply access the GUI of the §6Energy Core§r, set the tier, and click Assemble. Items will be automatically used from your inventory. Once the structure is built, you can access the core's GUI again through §6Energy Core Stabilizers§r to activate it.%n%nIt is recommended to postpone Tier 8 until after you reach the §dCreative Portable Tank§r, as it requires large amounts of §6Awakened Draconium§r.%n%n
+nomifactory.quest.db.778.title=§2Power Storage on a Massive Level
+nomifactory.quest.db.778.desc=Now that you have §6Awakened Cores§r, you can make the §eEnergy Storage Core§r from §bDraconic Evolution§r. It's a great way to store all the energy required to craft power-hungry late game items.%n%nThe §eEnergy Storage Core§r is a multiblock structure that can be upgraded to store increasingly immense amounts of RF energy. See the §bDraconic Evolution§r manual for more information on the material requirements for each tier.%n%n§2You cannot use regular Draconium Blocks to build this structure. You must treat it with Enriched Naquadah to make Activated Draconium before it can be used in the Energy Storage Core.%n%n§6Energy Pylons§r are required to input and output energy from the core. Each pylon allows movement in a single direction, so you need at least two.%n%nOnce you have the materials together for your desired tier, § the structure can build itself: simply access the GUI of the §6Energy Core§r, set the tier, and click Assemble. Items will be automatically used from your inventory. Once the structure is built, you can access the core's GUI again through §6Energy Core Stabilizers§r to activate it.%n%nIt is recommended to postpone Tier 8 until after you reach the §dCreative Portable Tank§r, as it requires large amounts of §2Activated §6Awakened Draconium§r.%n%n
 
 # db 779
-nomifactory.quest.db.779.title=Infinite Cobblestone
-nomifactory.quest.db.779.desc=Now that you have acquired §6Steel§6§r, your path to infinite cobblestone awaits! The §6Cobblestone Generator§r continuously outputs cobblestone into adjacent inventories, and can be upgraded to produce it even faster.%n%nCobblestone can be processed into many useful materials:%n%n§6Gravel§r is useful for making conduits and §9Concrete§r.%n%n§6Sand§r is useful for §6Glass§r, which can be turned into §6Nether Quartz§r.%n%nFinally, §6Dust§r can be turned into §6Clay§r which is both a reliable source of §6Aluminium§r and very important for automating §bDeep Mob Learning§r.%n%nSet up a §ecobbleworks§r soon, so you can stockpile all these useful materials.%n
+nomifactory.quest.db.779.title=§2Infinite Cobblestone
+nomifactory.quest.db.779.desc=Now that you have acquired §6Steel§6§r, your path to infinite cobblestone awaits! The §6Cobblestone Generator§r continuously outputs cobblestone into adjacent inventories, and can be upgraded to produce it even faster.%n%nCobblestone can be processed into many useful materials:%n%n§6Stone Dust§r is useful for small amounts of a whole host of useful materials.%n%n§6Gravel§r is useful for making conduits and §9Concrete§r.%n%n§6Sand§r is useful for §6Glass§r, which can be turned into §6Nether Quartz§r or §6Silicon Dioxide§r for §6Oxygen§r.%n%nFinally, §6Dust§r can be turned into §6Clay§r which is both a reliable source of §6Aluminium§r and very important for automating §bDeep Mob Learning§r.%n%nSet up a §ecobbleworks§r soon, so you can stockpile all these useful materials.%n
 
 # db 780
-nomifactory.quest.db.780.title=To the Nether
-nomifactory.quest.db.780.desc=Once you have obtained your§e §rfi§rrst §rpiece of §6Hellish Matter§6§r, travel to the §r§eNether§r becomes available.%n%nIt is not required to travel to the nether for any reason in this pack, although you may find it an easy source of §6Glowstone§r, §6Soul Sand§r, and your initial pieces of §6Sulfur§r before you make a §eBlaze Model§r from §c§bDeep Mob Learning§r.
+nomifactory.quest.db.780.title=§2To the Nether
+nomifactory.quest.db.780.desc=Once you have obtained your§e §rfi§rrst §rpiece of §6Hellish Matter§6§r, travel to the §r§eNether§r becomes available.%n%nThe §eNether§r contains quite a few useful resources:%n- Some initial pieces of §6Sulfur§r%n- §6Glowstone§r and §6Soul Sand§r%n- §6Fluorine§r, §6Certus Quartz§r, §6Molybdenum§r, §6Antimony§r, and §6Gold§r-bearing ores%n- §9§2Nether Air§r, which can be distilled for useful gases%n- §eLava§r and §eNatural Gas§r from §2Fluid Rigs§r%n%nDespite all this, §eNether§r travel is still strictly optional in the pack.
 
 # db 781
 nomifactory.quest.db.781.title=Numismatic Power
@@ -2471,16 +2471,16 @@ nomifactory.quest.db.782.title="Deuterium" or "I Don't Like Space"
 nomifactory.quest.db.782.desc=Hidden gathering quest for SMP
 
 # db 783
-nomifactory.quest.db.783.title="Arsenic" and "Quantum Eyes"
-nomifactory.quest.db.783.desc=⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⢀⣶⣶⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣄⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀%n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⢀⣿⣿⣿⣿⣿⣿⠿⠿⠟⠟⠛⠛⠻⠻⣿⣿⠆⠆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀%n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⢸⣿⣿⣿⣿⣿⣿⣆⣆⣀⣀⣀⣀⠀⠀⣿⣿⠂⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀%n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⢸⠻⠻⣿⣿⣿⣿⣿⣿⠅⠅⠛⠛⠋⠋⠈⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀%n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⠘⢼⢼⣿⣿⣿⣿⣿⣿⣃⣃⠠⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀%n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣿⣿⣿⣟⣟⡿⡿⠃⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀%n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣛⣛⣛⣛⣫⣫⡄⡄⠀⠀⢸⢸⣦⣦⣀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀%n⠀⠀⠀⠀⠀⠀⠀⠀⢀⢀⣠⣠⣴⣴⣾⣾⡆⡆⠸⠸⣿⣿⣿⣿⣿⣿⡷⡷⠂⠂⠨⠨⣿⣿⣿⣿⣿⣿⣿⣿⣶⣶⣦⣦⣤⣤⣀⣀⠀⠀⠀⠀⠀⠀%n⠀⠀⠀⠀⣤⣤⣾⣾⣿⣿⣿⣿⣿⣿⣿⣿⡇⡇⢀⢀⣿⣿⡿⡿⠋⠋⠁⠁⢀⢀⡶⡶⠪⠪⣉⣉⢸⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣇⣇⠀⠀⠀⠀%n⠀⠀⢀⢀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡏⡏⢸⢸⣿⣿⣷⣷⣿⣿⣿⣿⣷⣷⣦⣦⡙⡙⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡏⡏⠀⠀⠀⠀%n⠀⠀⠈⠈⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣇⣇⢸⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣷⣦⣦⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⡇⠀⠀⠀⠀%n⠀⠀⢠⢠⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⡇⠀⠀⠀⠀%n⠀⠀⢸⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣄⣄⠀⠀%n⠀⠀⠸⠸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀⠀%n⠀⠀⣠⣠⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⡿⠀⠀%n⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃⠃⠀⠀%n⠀⠀⢹⢹⣿⣿⣵⣵⣾⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⣯⡁⡁⠀⠀⠀⠀%n%nWe're no strangers to love,%nYou know the rules, and so do I!
+nomifactory.quest.db.783.title=§2Large Turbines
+nomifactory.quest.db.783.desc=§2Large Turbines have been improved in CEu. They are quite complex to run, but can generate lots of power when done well and scale very well.§r%n%nRight now, you can make the §6Large Steam Turbine§r and §6Large Gas Turbine§r. Once you get a §3Fusion Reactor§r going, you can make the §6Large Plasma Turbine§r.%n%nEach Large Turbine will need a §3Rotor Holder§r of the same or higher tier than the Large Turbine itself, and a §3Dynamo Hatch§r capable of handling the energy output. Each §3Rotor Holder§r tier above the Large Turbine §ddoubles§r the energy production and adds 10%% to fuel efficiency.%n%nYou will need a §aRotor§r to go into each §3Rotor Holder§r§r. The Rotor will grant multiplicative Power and Efficiency bonuses depending on its material. Each Rotor also has a Durability, which is the number of seconds it will last.%n%n§aExample: §r§6Large Gas Turbine§r, with §3HSS-E Rotor§r and §3IV Rotor Holder§r:%n§aProduction:§r 4096 * 2.80 * 2=22938 EU/t (91752 RF/t)%n§aEfficiency:§r 1.40 * 1.10=154.0%%%n§aDurability:§r 205,600 s (57.1 h)%n%nYou can run the §6Large Gas Turbine§r off §9LPG§r and §9Methane§r from §3Fluid Rigs§r, or §9Nitrobenzene§r from §6Wood§r.%nThe best §6Large Steam Turbine§r fuel is a closely-guarded government secret.
 
 # db 784
 nomifactory.quest.db.784.title=ME Cables
 nomifactory.quest.db.784.desc=These are the basic cables used by §3Applied Energistics§r to transport network connectivity. Due to the fact that channels are disabled, these cables will be your main method of transporting network connectivity, rather than the dense cables.%n%nThese cables do not share blockspace with conduits or cables for other mods, so they can be somewhat unweildy to build with, but they do accept §3Applied Energistics§r§6§r §6Facades§r, so they can be hidden very easily.%n%nLater you can make a variant of the cable that can share blockspace with §3Ender IO§r conduits.
 
 # db 785
-nomifactory.quest.db.785.title=New Cable Coverings
-nomifactory.quest.db.785.desc=§9Rubber§r has been sufficient for making cables so far, but you will soon discover that this basic type of rubber won't withstand more than §eHigh Voltage§r. Higher quality rubber is necessary to properly insulate your wires.%n%nThere are two better types of rubber, and you will eventually need to make both of them. §eThese can also be used for insulating lower voltage wires more efficiently, requiring less fluid§r!%n%n§9Styrene-Butadiene Rubber§r is capable of withstanding up to §eLuV§r. However, this requires petrochemistry infrastructure you may not have yet, and is not mandatory until you are making late-game components.%n%n§9Silicone Rubber§r is the highest quality of rubber and can be used §efor all voltages§r. It can also conveniently be made from chemicals you are already familiar with. By setting this up now, you won't have to change your wire coating material later!%n%nTo make Silicone Rubber, you will need to create §6Polydimethylsiloxane Dust§r in one of several ways, then mix it with §6Sulfur§r in a §3Chemical Reactor§r. You can then coat wires with it in an §3Assembling Machine§r.%n%n
+nomifactory.quest.db.785.title=§2New Cable Coverings
+nomifactory.quest.db.785.desc=§9Rubber§r has been sufficient for making cables so far, but you will soon discover that this basic type of rubber won't withstand more than §2Extreme Voltage§r. Higher quality rubber is necessary to properly insulate your wires.%n%nThere are two better types of rubber, and you will eventually need to make both of them. §eThese can also be used for insulating lower voltage wires more efficiently, requiring less fluid§r!%n%n§9§2Both Styrene-Butadiene Rubber (SBR) and Silicone Rubber (SiR) can wrap any Cable tier.§r However, SBR requires petrochemistry infrastructure you may not have yet, and is not mandatory until you are making late-game components. On the other hand, SiR can conveniently be made from chemicals you are already familiar with. By setting this up now, you won't have to change your wire coating material later!%n%nTo make Silicone Rubber, you will need to create §6Polydimethylsiloxane Dust§r in one of several ways, then mix it with §6Sulfur§r in a §3Chemical Reactor§r. You can then coat wires with it in an §3Assembling Machine§r.%n%n
 
 # db 786
 nomifactory.quest.db.786.title=Effortless Building
@@ -2492,11 +2492,11 @@ nomifactory.quest.db.787.desc=The §3Farming Station§r is a machine that automa
 
 # db 788
 nomifactory.quest.db.788.title=Smart Item Filter
-nomifactory.quest.db.788.desc=The §6Smart Item Filter§r from §3GregTech§r is an important tool when automating otherwise troublesome machines. It is a cover which filters item transfer based on whether a valid recipe exists for those items in a specified machine.%n%nThis is powerful in combination with movement covers like the §6Robot Arm§r. If you place this filter on the §eElectrolyzer§r mode in a Robot Arm set to §eSupply Exact§r mode, the Robot Arm will transfer precisely the right amounts of all valid items into an §3Electrolyzer§r so it will operate without clogging. There's no other way to accomplish this feat!%n%nThis filter also has §eSifter§r and §eCentrifuge§r§r modes for use with those machines (though §3Sifters§r are not in §5Nomifactory§r). It does not have modes for any other machines.%n%nThe §eDefault§r button lets you click it to §eIgnore Fluids§r, which is useful when you have recipes that also require fluids (like §9Hydrogen§r in an Electrolyzer). Since Robot Arms can't move fluids, it would otherwise prevent the cover from working.%n
+nomifactory.quest.db.788.desc=The §6Smart Item Filter§r from §3GregTech§r is an important tool when automating otherwise troublesome machines. It is a cover which filters item transfer based on whether a valid recipe exists for those items in a specified machine.%n%nThis is powerful in combination with movement covers like the §6Robot Arm§r. If you place this filter on the §eElectrolyzer§r mode in a Robot Arm set to §eSupply Exact§r mode, the Robot Arm will transfer precisely the right amounts of all valid items into an §3Electrolyzer§r so it will operate without clogging. There's no other way to accomplish this feat!%n%nThis filter also has §eSifter§r and §eCentrifuge§r§r modes for use with those machines. It does not have modes for any other machines.%n%nThe §eDefault§r button lets you click it to §eIgnore Fluids§r, which is useful when you have recipes that also require fluids (like §9Hydrogen§r in an Electrolyzer). Since Robot Arms can't move fluids, it would otherwise prevent the cover from working.%n
 
 # db 789
 nomifactory.quest.db.789.title=Filters
-nomifactory.quest.db.789.desc=§aFilters§r are a type of machine cover that controls what items or fluids are allowed to pass through it. They can be used directly on the side of a machine to affect external automation or the Machine's §aAuto-Output Functionality§r.%n%nYou can also §eplace filters inside of other covers§r to control what items or fluids that cover will interact with. When used in a §6Robot Arm§r, §aItem Filters§r make for a powerful automation tool for §ekeeping specific items in stock§r in specific quantities in Machines. With §6Fluid Regulators§r, similar behavior is possible with fluids using a §aFluid Filter§r. For §6Conveyors§r and §6Pumps§r, it simply limits what that cover will move.%n%n§aFilters§r all have 9 configurable slots and whitelist/blacklist modes, and can be applied to multiple sides of machines. When placed inside a §6Robot Arm§r in §eKeep Exact§r or §eSupply Exact§r mode§r, the item count in a filter can be incremented by §eRight Clicking§r and decremented by §eLeft Clicking§r. Holding §eShift§r causes the count to increase/decrease by a factor of 2. This controls the number of each type of item that will be kept in stock or moved at a time.%n%nSimilar controls are available for the §aFluid Filter§r when placed inside a §6Fluid Regulator§r.%n%nAdditionally, the §aOre Dictionary Filter§r§r is a powerful tool that has a specialized filter which uses ore dictionary entries and supports "*" as a wildcard, e. g. "§6ingotHot*§r" will match all hot ingots, "§6dustRegular*§r" will match all regular dusts, and "§6dustTiny*§r" will match all tiny piles.%n%nAll §bGregTech§r Filters can be configured using ghost items from §bJEI§r.
+nomifactory.quest.db.789.desc=§aFilters§r are a type of machine cover that controls what items or fluids are allowed to pass through it. They can be used directly on the side of a machine to affect external automation or the Machine's §aAuto-Output Functionality§r.%n%nYou can also §eplace filters inside of other covers§r to control what items or fluids that cover will interact with. When used in a §6Robot Arm§r, §aItem Filters§r make for a powerful automation tool for §ekeeping specific items in stock§r in specific quantities in Machines. With §6Fluid Regulators§r, similar behavior is possible with fluids using a §aFluid Filter§r. For §6Conveyors§r and §6Pumps§r, it simply limits what that cover will move.%n%n§aFilters§r all have 9 configurable slots and whitelist/blacklist modes, and can be applied to multiple sides of machines. When placed inside a §6Robot Arm§r in §eKeep Exact§r or §eSupply Exact§r mode§r, the item count in a filter can be incremented by §eRight Clicking§r and decremented by §eLeft Clicking§r. Holding §eShift§r causes the count to increase/decrease by a factor of 2. This controls the number of each type of item that will be kept in stock or moved at a time.%n%nSimilar controls are available for the §aFluid Filter§r when placed inside a §6Fluid Regulator§r.%n%nAdditionally, the §aOre Dictionary Filter§r§r is a powerful tool that has a specialized filter which uses ore dictionary entries and §2uses regular expressions (regex)§r, e. g. "§6ingotHot*§r" will match all hot ingots, "§6dustRegular*§r" will match all regular dusts, and "§6dustTiny*§r" will match all tiny piles.%n%nAll §bGregTech§r Filters can be configured using ghost items from §bJEI§r.
 
 # db 790
 nomifactory.quest.db.790.title=Machine Controllers
@@ -2504,7 +2504,7 @@ nomifactory.quest.db.790.desc=The §6Machine Controller§r is a cover that manag
 
 # db 791
 nomifactory.quest.db.791.title=Processing Array
-nomifactory.quest.db.791.desc=The §6Processing Array§r is a §bGregTech§r multiblock that allows for processing multiple recipes in parallel in a single stucture and is extremely useful for saving space.%n%nUp to 16 of the same recipe can be processed in parallel by placing the machines for the recipe in exactly one §aMachine Access Interface§r in the multiblock structure, as well as the ingredients and non-consumable items (like §6Integrated Circuits§r) for the recipe you want to process in one or more input buses. While a recipe is running, the Machine Access Interface is §elocked§r and machines cannot be added or removed.%n%nNote that each machine will still draw the full voltage required for the recipe, which may be more than a single §aEnergy Input Hatch§r can provide. This is why the §6Processing Array§r has an astounding Hatch limit, and can support up to §e8 Energy Inputs§r on the structure. This allows you to get the needed 16 Amps of power to the machine from a single tier-appropriate §3CEF§r.%n%nProcessing Arrays distribute their buffered power at the appropriate voltage, so there's no danger of your machines exploding if you, for example, operate 16 HV machines off one amp of IV power.%n%nBecause the required number of Inputs, Outputs, and Casings is highly variable, this quest only asks you to craft the §6Processing Array Controller§r and the §aMachine Access Interface§r. Make sure your buses and hatches are large enough to hold the ingredients and outputs for the number of parallel crafts you're attempting, and that you're providing enough power for all those machines!%n%nAn advanced feature of the Processing Array is §eDistinct Bus Mode§r. This makes the Processing Array only consider a single item input bus at a time when determining whether it can run a recipe. This is useful when recipes for a particular machine require different catalyst items, like §6Integrated Circuits§r on different configurations or §6Extruder Shapes§r.%n%nDistinct Bus Mode may be enabled or disabled via the Processing Array controller by clicking in the designated area.%n%n
+nomifactory.quest.db.791.desc=The §6Processing Array§r is a §bGregTech§r multiblock that allows for processing multiple recipes in parallel in a single stucture and is extremely useful for saving space.%n%nUp to 16 of the same recipe can be processed in parallel by placing the machines for the recipe in exactly one §aMachine Access Interface§r in the multiblock structure, as well as the ingredients and non-consumable items (like §6Integrated Circuits§r) for the recipe you want to process in one or more input buses. While a recipe is running, the Machine Access Interface is §elocked§r and machines cannot be added or removed.%n%nNote that each machine will still draw the full voltage required for the recipe, which may be more than a single §aEnergy Input Hatch§r can provide. This is why the §6Processing Array§r has an astounding Hatch limit, and can support up to §e4 Energy Inputs§r on the structure. This allows you to get the needed 16 Amps of power to the machine from a single tier-appropriate §3CEF§r.%n%nProcessing Arrays distribute their buffered power at the appropriate voltage, so there's no danger of your machines exploding if you, for example, operate 16 HV machines off one amp of IV power.%n%nBecause the required number of Inputs, Outputs, and Casings is highly variable, this quest only asks you to craft the §6Processing Array Controller§r and the §aMachine Access Interface§r. Make sure your buses and hatches are large enough to hold the ingredients and outputs for the number of parallel crafts you're attempting, and that you're providing enough power for all those machines!%n%nAn advanced feature of the Processing Array is §eDistinct Bus Mode§r. This makes the Processing Array only consider a single item input bus at a time when determining whether it can run a recipe. This is useful when recipes for a particular machine require different catalyst items, like §6Integrated Circuits§r on different configurations or §6Extruder Shapes§r.%n%nDistinct Bus Mode may be enabled or disabled via the Processing Array controller by clicking in the designated area.%n%n
 
 # db 792
 nomifactory.quest.db.792.title=Dynamite
@@ -2520,11 +2520,11 @@ nomifactory.quest.db.794.desc=Hidden placeholder OR quest
 
 # db 795
 nomifactory.quest.db.795.title=Advanced System-on-Chip
-nomifactory.quest.db.795.desc=The §6Advanced System-on-Chip§r (or §6ASoC§r) is the peak of component miniaturization. These are required for §6Wetware Circuits§r, and unlock the most efficient recipe for producing §6Quantum Circuits§r.%n%nHowever, unlike the §6SoC§r, these circuits must be made in a §aZPM Assembling Machine§r.
+nomifactory.quest.db.795.desc=The §6Advanced System-on-Chip§r (or §6ASoC§r) is the §2penultimate§r component miniaturization. These unlock the most efficient recipe for producing §2Nanocircuits and §6Quantum Circuits§r.%n%nThe latter circuits must be made in a §aZPM Assembling Machine§r.
 
 # db 796
 nomifactory.quest.db.796.title=Naquadah Boules
-nomifactory.quest.db.796.desc=The §6Naquadah-Doped Boule§r is the final boule type and produces the most wafers per boule. It also is relatively cheap, due to the abundance of Naqudah that is gained from the §eTier 5 Micro Miner Mission§r.%n%nThis boule also allows the production of §6System on Chip§r and §6§6Advanced System on Chip§r wafers, which are used to make the final forms of the circuits very cheaply. However, you might not be able to take advantage of the §6Advanced System on Chip§r yet, due to the power requirements.
+nomifactory.quest.db.796.desc=The §6Naquadah-Doped Boule§r produces even more wafers per boule. It also is relatively cheap, due to the abundance of Naquadah that is gained from the §eTier 5 Micro Miner Mission§r.%n%nThis boule also allows the production of §6Advanced System on Chip§r wafers, which are used to make the final forms of the circuits very cheaply. However, you might not be able to take advantage of the §6Advanced System on Chip§r yet, due to the power requirements.
 
 # db 797
 nomifactory.quest.db.797.title=System-on-Chip
@@ -2547,8 +2547,8 @@ nomifactory.quest.db.801.title=Pyrolyse Products
 nomifactory.quest.db.801.desc=The §6§3Pyrolyse Oven§r can make more interesting products than just §9Phenol§r.%n%n§a§9Charcoal Byproducts§r breaks down into various wood products, such as§9 Wood Tar§r,§9 Wood Gas§r, and §a§9Wood Vinegar§r, each of which can be further broken down into various useful chemical compounds, such as §a§9Toluene§r, §a§9Methanol§r, etc.%n%nHowever, to take full advantage of decomposing these wood products, a §6§3Distillation Tower§r is required, so that all possible outputs can be obtained. You will need more§e Distillation Tower Slices§r than requested in the§r Distillation Tower quest, so be prepared to spend some more §6Stainless Steel§r.
 
 # db 802
-nomifactory.quest.db.802.title=Fusion Coils
-nomifactory.quest.db.802.desc=§6Fusion Coils§r are the ninth and final coil material available, increasing your EBF's operating temperature to 9700K so it can process the most extreme materials.%n%nThese are also used as the core ring of the §3Mk2§r and §3Mk3 Fusion Reactor§r.
+nomifactory.quest.db.802.title=§2Fusion Coils
+nomifactory.quest.db.802.desc=§6Fusion Coils§r are §2no longer EBF coil materials, but they are used in the next Fusion Reactors.
 
 # db 803
 nomifactory.quest.db.803.title=Lost Cities and Registering Homes
@@ -2563,8 +2563,8 @@ nomifactory.quest.db.805.title=Genesis
 nomifactory.quest.db.805.desc=a quest
 
 # db 806
-nomifactory.quest.db.806.title=Allyl Chloride
-nomifactory.quest.db.806.desc=§9Allyl Chloride§r provides an alternative means of producing §9Epichlorohydrin§r for §9Epoxy§r.%n%nReacting §9Chlorine§r and §9Propene§r will produce Allyl Chloride. Propene is distilled in a §3Distillation Tower§r from any of various cracked petroleum products like §9Steam-Cracked Naphtha§r.
+nomifactory.quest.db.806.title=§2Allyl Chloride
+nomifactory.quest.db.806.desc=§2You only need this step if you are using normal Chemical Reactors. If you are using LCRs, the Allyl Chloride step is skipped.%n%n§9Allyl Chloride§r provides an alternative means of producing §9Epichlorohydrin§r for §9Epoxy§r.%n%nReacting §9Chlorine§r and §9Propene§r will produce Allyl Chloride. Propene is distilled in a §3Distillation Tower§r from any of various cracked petroleum products like §9Steam-Cracked Naphtha§r.
 
 # db 807
 nomifactory.quest.db.807.title=Seed Oil
@@ -2572,11 +2572,11 @@ nomifactory.quest.db.807.desc=Plant some crops, fluid extract some seeds, bam! �
 
 # db 808
 nomifactory.quest.db.808.title=Discord and GitHub
-nomifactory.quest.db.808.desc=§5Nomifactory§r has an official Discord server which serves as a useful community resource.%n%nOn the server, the dev team posts links to in-depth guides on a variety of topics related to the pack, makes development announcements, assists with tech support questions, and investigates possible bug reports.%n%nYou can also chat with many fellow players there if you like, who are largely willing to help with general questions one might have.%n%nTo join the server, you can use the button on the Main Menu to go to the join URL, or if you're not into Discord you can find our projects on GitHub at our organization page: §9https://github.com/Nomifactory§r.%n%nIssue tracking and development, including many community-submitted guides, is handled on our respective GitHub project repositories.
+nomifactory.quest.db.808.desc=§5Nomifactory§r has an official Discord server which serves as a useful community resource.%n%nOn the server, the dev team posts links to in-depth guides on a variety of topics related to the pack, makes development announcements, assists with tech support questions, and investigates possible bug reports.%n%nYou can also chat with many fellow players there if you like, who are largely willing to help with general questions one might have.%n%nTo join the server, you can use the button on the Main Menu to go to the join URL, or if you're not into Discord you can find our projects on GitHub at our organization page: §9https://github.com/Nomifactory§r.%n%nIssue tracking and development, including many community-submitted guides, is handled on our respective GitHub project repositories.%n%n§2This fork's GitHub page can be found at §9https://github.com/m2r1k5/nomi-ceu§2
 
 # db 809
-nomifactory.quest.db.809.title=Simulation Supercomputer
-nomifactory.quest.db.809.desc=The §3Simulation Supercomputer§r is a multiblock structure that performs §bDeep Mob Learning§r simulations like the §3Simulation Chamber§r, but is capable of overclocking these simulations to incredible speeds.%n%nOne of these structures can perform the equivalent work of hundreds of individual Simulation Chambers more efficiently. This will make it far easier to generate pristine matter you'll need for things like §6Dragon Lair Data§r. You'll probably need several §3Loot Fabricators§r to keep up with it.%n%nThe data model you place in the input bus will increment the iteration count and level up the same as if it were running in a regular Simulation Chamber. §eOverclocking does not alter the chances of pristines§r: those come at fixed rates per iteration based on the level of the data model. Training a fresh data model up to Self-Aware for 30%% rates can be done very quickly though.%n%nAs a §dCreative Tier§r structure, it is rather expensive to make. However, it is an investment that will easily pay for itself as you progress through the endgame. You should strongly consider making one of these with your second §dHeart of a Universe§r.%n
+nomifactory.quest.db.809.title=§2Simulation Supercomputer
+nomifactory.quest.db.809.desc=The §3Simulation Supercomputer§r is a multiblock structure that performs §bDeep Mob Learning§r simulations like the §3Simulation Chamber§r, but is capable of overclocking these simulations to incredible speeds.%n%nOne of these structures can perform the equivalent work of hundreds of individual Simulation Chambers more efficiently. This will make it far easier to generate pristine matter you'll need for things like §6Dragon Lair Data§r. You'll probably need several §3Loot Fabricators§r to keep up with it.%n%nThe data model you place in the input bus will §2have a fixed 30%% chance of producing Pristine matter regardless of its tier. §eOverclocking does not alter the chances of pristines§r: those come at fixed rates per iteration.%n%nAs a §dCreative Tier§r structure, it is rather expensive to make. However, it is an investment that will easily pay for itself as you progress through the endgame. You should strongly consider making one of these with your second §dHeart of a Universe§r.%n
 
 # db 810
 nomifactory.quest.db.810.title=Sulfur
@@ -2587,5 +2587,609 @@ nomifactory.quest.db.811.title=Sulfur Ore
 nomifactory.quest.db.811.desc=§6Sulfur Ore§r is the only source of §6Sulfur Dust§r that's currently available to you.%n%nYou may want to spend a few §dOmnicoins§r on the ore to jumpstart your power storage.%n%nOtherwise the ore is only available in §athe Nether§r, and the only way to get there is with a §6Nether Cake§r. Oh no!
 
 # db 812
-nomifactory.quest.db.812.title="Distillation Tower" or "I Don't Need No Stinkin' Tower"
-nomifactory.quest.db.812.desc=
+nomifactory.quest.db.812.title="Ethanol" and "Sulfuric Acid"
+nomifactory.quest.db.812.desc=No Description
+
+# db 813
+nomifactory.quest.db.813.title=§2Material Tree
+nomifactory.quest.db.813.desc=§2Check out the new Material Tree tab! It will show you nearly all the different forms of a GregTech material (Plates, Rods, Screws, Dusts...) on a single page. You can then click on those to see their recipes.
+
+# db 814
+nomifactory.quest.db.814.title=§2Arc Furnace
+nomifactory.quest.db.814.desc=§2Technically not new to CEu, but it was disabled in the original version, and it had much less functionality in CE.§r%n%nThe Arc Furnace allows you to make §6Annealed Copper§r, which will be used in the MV Age. It can also make 2 pieces of Glass from 1 Sand. Later, it can make §2Tempered Glass§r§r for use in higher-tier recipes.%n%nThe Arc Furnace also functions as a §auniversal recycling machine§r. Pretty much anything can be recycled into ingots and dusts of its base components.%n%nAll of its recipes require Oxygen.%n%nAll Arc Furnace recipes use exactly 30 EU/t, so you can get away with using LV Arc Furnaces for the whole pack!
+
+# db 815
+nomifactory.quest.db.815.title=§2LV Bending Machine
+nomifactory.quest.db.815.desc=§2The Bending Machine makes, depending on what Programmable Circuit it's given:%n- Plates from a single ingot (instead of the Compressor)%n- 4 Foils from a Plate (instead of the Cluster Mill, which is no more)%n- Double Plates from two Plates%n- Dense Plates from nine Plates%n- Small Springs from one Rod%n- Springs from one Long Rod.%n%nWhy was this removed?!
+
+# db 816
+nomifactory.quest.db.816.title=§2LV Circuit Assembler
+nomifactory.quest.db.816.desc=§3Circuit Assemblers§r are the linchpin of your factory, gating progression through the §6Circuits§r. %n%nEach time you upgrade to a new voltage of Circuit Assembler, you will be able to craft more advanced §ethemes§r of circuits. These use more complex ingredients and require new infrastructure to be in place, but are more efficient to craft overall than the same tier of circuit from the prior theme.%n%n§2The LV Circuit Assembler allows you to make Electronic Circuits far more easily.%n%nThe circuit progression has been largely replaced with the progression native to CEu, with a few minor changes to reflect the progression of this pack better.§r Check out the §dProgression quest book tab§r to see the flow of circuit progression.%n
+
+# db 817
+nomifactory.quest.db.817.title=§2Steam Grinder
+nomifactory.quest.db.817.desc=§2This Steam multiblock was intended for use in the Steam Age. This pack skips the Steam Age, but it may still be worth using.%n%nThe Steam Grinder functions as 5.3 LV Macerators in parallel. It requires an input of Steam through a Steam Hatch, but it uses very little Steam.%n%nYou may want to consider setting up a rudimentary ore-doubling setup with it. Point the output in the direction of several upgraded Furnaces.
+
+# db 818
+nomifactory.quest.db.818.title=LV Emitter
+nomifactory.quest.db.818.desc=An advanced component used for the Circuit Assembling Machine.
+
+# db 819
+nomifactory.quest.db.819.title=§2GregTech Drill
+nomifactory.quest.db.819.desc=§2With MV Batteries unlocked, you can make Power Units for electric GT tools. Most notable among them is the Drill, which at MV tier can mine a 3x3x3 area of blocks.%n%nHigher tier drills can mine 5x5x5, 7x7x7 and 9x9x9 areas! Shift-right-click to change the breaking area.%n%nCharge these with a Battery of appropriate tier, or in an appropriately tiered machine.%n%nYou may want to look into Chainsaws for mass tree felling as well. The other electric tools are probably not worth making.
+
+# db 820
+nomifactory.quest.db.820.title=§2Diodes
+nomifactory.quest.db.820.desc=§2Diodes are a component in the next Circuit tiers. They are made from liquid Glass, Fine Copper Wire and Gallium Arsenide, which is made in a Mixer with Gallium and Arsenic.%n%nLater, you will unlock better recipes for this.
+
+# db 821
+nomifactory.quest.db.821.title=§2Sodium Persulfate and Iron III Chloride
+nomifactory.quest.db.821.desc=§2Sodium Persulfate§r §2and Iron III Chloride§r are used to make cheaper §9Good Circuit Boards§r, as it cuts the Silver amount by a factor of four. They are also §drequired§r to make §9Plastic Circuit Boards§r.%n%nMaking §aSodium Persulfate§r will yield §aHydrochloric Acid§r as a coproduct, which you may re-use to make §aIron III Chloride§r. This should the best approach right now, but the decision is entirely yours. With more automation later in the game, Iron III Chloride will be the cheaper and more straight forward path.%n%nSodium Persulfate§r can also be used in §9Ore Processing§r in the §3Chemical Bath§r, to get various bonus outputs you would not normally obtain. It is completely optional, but pretty rewarding.
+
+# db 822
+nomifactory.quest.db.822.title=§2Good Circuit Boards
+nomifactory.quest.db.822.desc=§2Phenolic Substrates need to be turned into Circuit Boards with Silver before being usable in Circuit production.%n%nSodium Persulfate and Iron III Chloride are troublesome to get right now, but using them in making Circuit Boards will reduce the amount of Silver required by 4 times.
+
+# db 823
+nomifactory.quest.db.823.title=§2Sifter
+nomifactory.quest.db.823.desc=§2This quest accepts an LV or MV Sifter.%n%nThe Sifter gets you Flawless and Exquisite Gems from Crushed Purified Gem Ores. Overall it results in a higher yield. Higher tiers of Sifter increase the yield further.%n%nYou will need small quantities of Flawless Emeralds for MV Emitter and Sensor components.
+
+# db 824
+nomifactory.quest.db.824.title=§2Inductors
+nomifactory.quest.db.824.desc=§2The successor of Small Coils, Inductors are another circuit component you will need.%n%nFor the best results, use Nickel Zinc Ferrite and Annealed Copper to make these.%n%nBut depending on which setups you build first, you may not need to make many of the basic version over the SMD version.
+
+# db 825
+nomifactory.quest.db.825.title=§2Polytetrafluoroethylene
+nomifactory.quest.db.825.desc=§2Polytetrafluoroethylene (PTFE, or Teflon) is a polymer made from Carbon and Fluorine.%n%nThis polymer is most importantly used to make Large Chemical Reactors. It's also required for IV and LuV Machine Hulls, and can be substituted in some cases for higher yields.
+
+# db 826
+nomifactory.quest.db.826.title=§2Large Chemical Reactor
+nomifactory.quest.db.826.desc=§2The §3§2Large Chemical Reactor (LCR)§r §2is a multiblock §3§2Chemical Reactor§r §2with more input/output slots.§r%n%nThe §3LCR§r can perform some exclusive reactions which allow you to combine multiple normal §3Chemical Reactor§r steps into a §6single step§r, such as:%n- §aNitrogen Dioxide§r%n- §r§aSulfuric Acid§r%n-§r §aEpichlorohydrin§r, needed for...%n-§r §aEpoxy§r%n%nThe §3LCR§r also is required to perform some recipes, such as §aRaw Gasoline§r production.%n%nAny other recipe which could be done in a normal §9Chemical Reactor§r, as well as certain §9Mixer§r recipes, can also be done in an §3LCR§r.%n%nAll §dOverclocks§r in the §3LCR§r are §6100%% efficient§r; each overclock will §5quadruple the speed§r, as opposed to doubling it.
+
+# db 827
+nomifactory.quest.db.827.title=§2Platinum Group Processing
+nomifactory.quest.db.827.desc=§2A rudimentary version of Platinum Group Sludge (PGS) processing existed in the base pack. Here, it is a strong source of the Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum - as well as Gold. All of these elements will be used in IV-tier and above materials.%n%n§rYou will need to treat certain ores with §9Nitric Acid§r to yield §6PGS§r - §6Sheldonite§r is the best. Then, using an §3HV+ Centrifuge§r and §9Aqua Regia§r, break it down into the PGS salts, and reduce those salts to the metals.%n%nThis is still optional, and you can get §6Ruthenium§r and §6Rhodium§r from §6Osmiridium 80/20 Ore§r and §6Iridosmine 80/20 Ore§r from Microverse adventures instead.
+
+# db 828
+nomifactory.quest.db.828.title=§2Polybenzimidazole (PBI)
+nomifactory.quest.db.828.desc=§2This is the highest tier of polymer. It is used in crafting Advanced SMD components, ZPM+ Machine Hulls, among other things.%n%nThis polymer requires at least 14 processing steps to craft. Good luck!
+
+# db 829
+nomifactory.quest.db.829.title=§2Forge Hammer
+nomifactory.quest.db.829.desc=§2This isn't new in CEu either, but in this version, you will use this to break Cobblestone into Gravel and Gravel into Sand. It's also used to combine 2 Rods into 1 Long Rod.
+
+# db 830
+nomifactory.quest.db.830.title=HV Assembler
+nomifactory.quest.db.830.desc=§2The next tier of Assembling Machine. This one can make quite a few nice things - check the surrounding quests.
+
+# db 831
+nomifactory.quest.db.831.title=§2Greggy Infinite Water
+nomifactory.quest.db.831.desc=§2A more compact infinite Water source. Place this as a cover on any GT machine and it will insert 16B of water every second.
+
+# db 832
+nomifactory.quest.db.832.title=§2Super Ender Tanks
+nomifactory.quest.db.832.desc=§2Ender Fluid Link Covers are GTCEu's Ender Tanks§r. Each Cover sends their fluids through a frequency defined by an §68-digit hexadecimal number§r (0-9, then A-F for each digit). That gives you §64.29 billion§r channels to work with!%n%nEnder Fluid Link Covers work as long as their chunk is loaded - regardless of distance or dimension.%n%nSetting the mode to Import will §o§c§opull§r fluids from the world location it is attached to, while Export will §o§9§opush§r fluids to the world. You must turn the I/O to Enabled for it to start working. Each channel has a buffer of §d64 buckets§r.%n%nThe "Virtual Tank Viewer" app in your §4Terminal§r allows you to see the contents of all Ender Fluid Link channels. Regardless, I recommend you set up a system to organise all those channels. I would also advise against using the default channel (FFFFFFFF) in all cases.%n
+
+# db 833
+nomifactory.quest.db.833.title=§2Central Monitor
+nomifactory.quest.db.833.desc=§2The Central Monitor allows you to... monitor... parts of your factory. Coupled with Wireless Digital Interface Covers, you can see the status, capacity, and more of machines, and even access their GUI remotely!%n%nCheck out the GTCEu wiki on GitHub for more of its details.
+
+# db 834
+nomifactory.quest.db.834.title=§2Super Tanks
+nomifactory.quest.db.834.desc=§2Super Tanks are the high-tier GT Fluid storage solution.§r%n%nThe first tier holds §64,000 buckets§r, and higher tiers hold more. They can also be used like Drums to put fluids in and out of machines.%n%nYou can conveniently configure §cvoiding§r for them to always void, start voiding at 95%% capacity, or never void.%n%nThe item equivalent are §3Super Chests§r, which are used in certain §6Microminer§r recipes. Higher-tier versions of these are called §3Quantum Tanks§r and §3Quantum Chests§r. They all require their respective tier §3Hermetic Casings§r to craft.
+
+# db 835
+nomifactory.quest.db.835.title=§2Oil Cracking Unit
+nomifactory.quest.db.835.desc=§2The Oil Cracking Unit gives you higher yields from cracking organic substances.%n%nNew in GTCEu, many organic substances offer the option of being Severely or Lightly cracked, each one granting different ratios of distillates.
+
+# db 836
+nomifactory.quest.db.836.title=§2MV Mixer
+nomifactory.quest.db.836.desc=§2In GTCEu, higher-tier blends of dusts require higher-tier Mixers to mix. The MV Mixer is required for making Vanadiumsteel and Stainless Steel.%n%nThere will not be more mixer quests above this one. Remember this when making higher-tier dust blends.
+
+# db 837
+nomifactory.quest.db.837.title=§2Vanadiumsteel
+nomifactory.quest.db.837.desc=§2A bit of Vanadiumsteel is used for progression. It's also a very strong tool material.%n%n§6Vanadium§r is an element acquired by processing §6Vanadium Magnetite Ore§r.
+
+# db 838
+nomifactory.quest.db.838.title=§2Systems on Chip
+nomifactory.quest.db.838.desc=§2Systems on Chip can be engraved with HV power and Glowstone Boules. This unlocks the ultimate tier one circuit recipe in the EV Circuit Assembler.%n%nThe ultimate tier two circuit recipe requires an IV Circuit Assembler.
+
+# db 839
+nomifactory.quest.db.839.title=§2Crystal Growing
+nomifactory.quest.db.839.desc=§2Your first few Raw Crystal Chips must be grown in an Autoclave from liquid Enderium, or more efficiently with Europium, and Exquisite Emeralds or Exquisite Olivine.%n%nAfter the first few, you can smash them into pieces using a Forge Hammer, and duplicate them with Bacterial Sludge, Mutagen, or more Europium or Enderium.%n%nBacterial Sludge can later be obtained in the byproducts of getting Stem Cells.
+
+# db 840
+nomifactory.quest.db.840.title=§2Advanced Processing Array
+nomifactory.quest.db.840.desc=§2The Advanced Processing Array can handle up to 64 parallel recipes at once.%n%nYou may need some 4A or 16A Energy Hatches to keep up with its power draw.
+
+# db 841
+nomifactory.quest.db.841.title=High Speed Steel Type E
+nomifactory.quest.db.841.desc=Made by adding some Cobalt, Manganese and Silicon to your HSS-G.
+
+# db 842
+nomifactory.quest.db.842.title=§2Neuro Processing Unit
+nomifactory.quest.db.842.desc=§2Use the Stem Cells and more advanced materials to build a Neuro Processing Unit. This is used in the first Wetware Circuit.
+
+# db 843
+nomifactory.quest.db.843.title=§2Naquadah Processing
+nomifactory.quest.db.843.desc=§2There are 3 materials you will need from processing Naquadah: Enriched Naquadah (Nq+), Naquadria (Nq*), and Trinium (Ke). And there are 3 different ways to process Naquadah, each resulting in different materials.§r%n%nFirst is by §dprocessing ores§r from the §6Tier Five Micro Miner§r. §6Naquadah Ore§r yields §6Enriched Naquadah§r (through the §3Magnetic Separator§r) and §6Kaemanite Ore§r yields §6Trinium§r.%n%nSecond is by combining §6Naquadah Dust§r with certain heavy elements and EnderIO crystal grains. This can provide §6Enriched Naquadah§r and §6Naquadria§r.%n%nFinally, you can do the full CEu processing of §6Naquadah Dust§r with §9Fluoroantimonic Acid§r, the strongest acid known to man. This is a decently involved process, but not only does it yield all 3 Nq materials, it also grants byproducts of §6Titanium, Sulfur, Indium, Phosphorus, Barium, and Gallium§r.
+
+# db 844
+nomifactory.quest.db.844.title=§2Trinium Coils
+nomifactory.quest.db.844.desc=§2Trinium Coils§r are the eighth coil material available, increasing your EBF's operating temperature to 9001K so it can process more advanced materials.%n
+
+# db 845
+nomifactory.quest.db.845.title=§2Enriched Naquadah
+nomifactory.quest.db.845.desc=§2A heavy Naquadah isotope with more nuclear capability.%n%n§r§6Enriched Naquadah§r is meant to be used in as-of-yet-unimplemented CEu-native reactors. It's used in small amounts for §3Trinium Coil blocks§r, or in Nomi reactors, though Naquadria is better for that purpose.%n%nAt least it's the easiest to obtain, and you can get it by mixing, the full Naquadah chain, or by passing Purified Naquadah Dust through an Electromagnetic Separator.
+
+# db 846
+nomifactory.quest.db.846.title=§2Naquadria
+nomifactory.quest.db.846.desc=§2A lighter and unstable Naquadah isotope.%n%n§r§6Naquadria§o§r is used in the construction of §6UV components§r, the §3Fusion Reactor Mk2§r, and in fusing §6Neutronium§r. Each piece of Naquadria also makes §d4 times§r more power than §6Enriched Naquadah§r in §3Naquadah Reactors§r.
+
+# db 847
+nomifactory.quest.db.847.title=§2Trinium
+nomifactory.quest.db.847.desc=§2A strong heavy element obtained from the Naquadah chain.%n%n§r§6Trinium§r can come from §6Kaemanite Ore§r, but you will probably want to bolster its production with §6Naquadah Dust§r processing. It comes out at the second stage, so if you don't mind storing the intermediates and have Fluorine under control, you can hold off doing the full chain if you don't need to yet. You get §d1 Trinium per 6 Naquadah processed§r.%n%nThis will be required in large quantities for §6Trinium Coils§r, §6Superconducting Coil Blocks§r, §6Naquadah Alloy§r, among other things. You will need 14 stacks at least for a §3Fusion Reactor Mk1§r, so stock up on it.
+
+# db 848
+nomifactory.quest.db.848.title=§2Naquadah Alloy
+nomifactory.quest.db.848.desc=§2Naquadah Alloy is different in CEu, it requires Naquadah, Osmiridium and Trinium.
+
+# db 849
+nomifactory.quest.db.849.title=§2IV Assembling Machine
+nomifactory.quest.db.849.desc=§2Used for Advanced SMD components.
+
+# db 850
+nomifactory.quest.db.850.title=§2Advanced SMD Components
+nomifactory.quest.db.850.desc=§2Advanced SMD Components are new to CEu and are required for Crystal and Wetware circuits. They can also be substituted for the equivalent of 4 normal SMD components in Nano and Quantum circuits.%n%nAll of these components require IV power and liquid PBI.%n%nAdvanced SMD Transistor: Vanadium-Gallium Foil and Fine HSS-G Wire%n%nAdvanced SMD Resistor: Graphene Dust and Fine Platinum Wire%n%nAdvanced SMD Capacitor: Thin PBI Sheet and HSS-S Foil%n%nAdvanced SMD Diode: Small Pile of InGaP Dust and Fine Niobium-Titanium Wire%n%nAdvanced SMD Inductor: HSS-E Ring and Fine Palladium Wire%n%nAs with the normal SMD components, invest in an extremely robust automation system for these, as you won't stop needing them.
+
+# db 851
+nomifactory.quest.db.851.title=High Speed Steel Type S
+nomifactory.quest.db.851.desc=Made by adding some Iridium and Osmium to your HSS-G.
+
+# db 852
+nomifactory.quest.db.852.title=§2Americium Ingot
+nomifactory.quest.db.852.desc=You can get Americium from NuclearCraft progression, but you can also fuse it. First combine Lanthanum with Silicon to make Lutetium, then combine it with Chrome to get Americium.%n%n§2Americium is used in larger quantities in CEu progression. You cannot convert this form of Americium to NuclearCraft Americium isotopes.
+
+# db 853
+nomifactory.quest.db.853.title=§2Ruridit
+nomifactory.quest.db.853.desc=§2Ruridit is a Ruthenium-Iridium alloy used in LuV machine components.
+
+# db 854
+nomifactory.quest.db.854.title=§2Tritanium Coils
+nomifactory.quest.db.854.desc=§2Tritanium Coils are the final coil material. At 10800K, it's capable of smelting every material.
+
+# db 855
+nomifactory.quest.db.855.title=§2Neutronium Boules
+nomifactory.quest.db.855.desc=The final Boule. It grants the most wafers, and is required for Highly Advanced Systems-on-Chip.
+
+# db 856
+nomifactory.quest.db.856.title=§2Highly Advanced SoCs
+nomifactory.quest.db.856.desc=§2For making Wetware Circuits more easily. You need UV-tier power to make them that way.
+
+# db 857
+nomifactory.quest.db.857.title=§2Advanced Alloys
+nomifactory.quest.db.857.desc=§2Used in building the Alloy Blast Smelter.%n%n§r§6Tantalum§r is obtained from §6Tantalite Ore§r, or in small quantities from centrifuging §eLava§r.%n%n§6Molybdenum§r is obtained from §6Molybdenum, Molybdenite, Powellite, and Wulfenite ores§r. They spawn together in the §eNether§r rarely, or some of them come from §3Tier One§r and §3Five Micro Miners§r.%n%n§2Remember, you need an appropriately tiered Mixer (HV for HSLA Steel, and EV for the others).
+
+# db 858
+nomifactory.quest.db.858.title=§2Alloy Blast Smelter
+nomifactory.quest.db.858.desc=§2The Alloy Blast Smelter directly smelts dust combinations into molten Alloys, skipping the Mixer step. Some molten alloys may need to be cooled in a Vacuum Freezer before being usable.%n%n§rThis is the only way to create some of the advanced alloys used in multiblock machines. You can also use it for most normal alloys if you want. In particular, the yield of §6Energetic Alloy§r and §6Vibrant Alloy§r is §ddoubled§r.
+
+# db 859
+nomifactory.quest.db.859.title=§2Gregicality Multiblocks
+nomifactory.quest.db.859.desc=§2With advanced alloys from the Alloy Blast Smelter and IV Machines, you can make large versions of most GT machines.%n%n§rThese are formed like multiblocks. You can add a §3Parallel Control Hatch§r in order to allow them to process §dmore recipes§r at the same time, similarly to a §3Processing Array§r. The highest tier of Parallel Control Hatch can facilitate processing §d256 recipes§r at once!%n%nSearch "@gregicality" or look up the usages of Parallel Hatches in JEI to see details of all the multiblock machines.
+
+# db 860
+nomifactory.quest.db.860.title=§2Chemical Plant
+nomifactory.quest.db.860.desc=§2The ultimate reactor. It is compatible with Parallel Control Hatches and can be configured to run Large Chemical Reactor or normal Chemical Reactor recipes.
+
+# db 861
+nomifactory.quest.db.861.title=§2Upgraded EBF and Freezer
+nomifactory.quest.db.861.desc=§2Upgraded forms of the EBF and Vacuum Freezer. Can run up to 2,048 recipes in parallel.%n%nThe Rotary Hearth Furnace is quite big!
+
+# db 862
+nomifactory.quest.db.862.title=§2Element 041: Niobium
+nomifactory.quest.db.862.desc=§2This element is now required in Omnium. §e
+
+# db 863
+nomifactory.quest.db.863.title=§2Element 042: Molybdenum
+nomifactory.quest.db.863.desc=§2This element is now required in Omnium.
+
+# db 864
+nomifactory.quest.db.864.title=§2Element 044: Ruthenium
+nomifactory.quest.db.864.desc=§2This element is now required in Omnium.
+
+# db 865
+nomifactory.quest.db.865.title=§2Element 045: Rhodium
+nomifactory.quest.db.865.desc=§2This element is now required in Omnium.
+
+# db 866
+nomifactory.quest.db.866.title=§2Element 048: Cadmium
+nomifactory.quest.db.866.desc=§2This element is now required in Omnium.
+
+# db 867
+nomifactory.quest.db.867.title=§2Element 055: Caesium
+nomifactory.quest.db.867.desc=§2This element is now required in Omnium.
+
+# db 868
+nomifactory.quest.db.868.title=§2Element 056: Barium
+nomifactory.quest.db.868.desc=§2This element is now required in Omnium.
+
+# db 869
+nomifactory.quest.db.869.title=§2Element 058: Cerium
+nomifactory.quest.db.869.desc=§2This element is now required in Omnium.
+
+# db 870
+nomifactory.quest.db.870.title=§2Element 060: Neodymium
+nomifactory.quest.db.870.desc=§2This element is now required in Omnium.
+
+# db 871
+nomifactory.quest.db.871.title=§2Element 062: Samarium
+nomifactory.quest.db.871.desc=§2This element is now required in Omnium.
+
+# db 872
+nomifactory.quest.db.872.title=§2Element 063: Europium
+nomifactory.quest.db.872.desc=§2This element is now required in Omnium.
+
+# db 873
+nomifactory.quest.db.873.title=§2Element 071: Lutetium
+nomifactory.quest.db.873.desc=§2This element is now required in Omnium.
+
+# db 874
+nomifactory.quest.db.874.title=§2Element 073: Tantalum
+nomifactory.quest.db.874.desc=§2This element is now required in Omnium.
+
+# db 875
+nomifactory.quest.db.875.title=§2Element 082: Lead
+nomifactory.quest.db.875.desc=§2This element is now required in Omnium. (It wasn't before!)
+
+# db 876
+nomifactory.quest.db.876.title=§2Element 119: Tritanium
+nomifactory.quest.db.876.desc=§2This element is now required in Omnium.
+
+# db 877
+nomifactory.quest.db.877.title=§2Element 120: Duranium
+nomifactory.quest.db.877.desc=§2This element is now required in Omnium.
+
+# db 878
+nomifactory.quest.db.878.title=§2Element 125: Trinium
+nomifactory.quest.db.878.desc=§2This element is now required in Omnium.
+
+# db 879
+nomifactory.quest.db.879.title=§2Element 174: Naquadah
+nomifactory.quest.db.879.desc=§2This element is now required in Omnium.
+
+# db 880
+nomifactory.quest.db.880.title=§2Infinite GT EU Emitter
+nomifactory.quest.db.880.desc=§2Configurable to output any number of GT Volts and Amps.
+
+# db 881
+nomifactory.quest.db.881.title=§2Polyphenylene Sulfide
+nomifactory.quest.db.881.desc=§2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.
+
+# db 882
+nomifactory.quest.db.882.title="Enderium Ingot" or "Europium Ingot"
+nomifactory.quest.db.882.desc=Hidden gathering quest for Crystals
+
+# db 883
+nomifactory.quest.db.883.title=§2Element 110: Darmstadtium
+nomifactory.quest.db.883.desc=§2This element is now required in Omnium.
+
+# db 884
+nomifactory.quest.db.884.title=§2Element 149: Draconium
+nomifactory.quest.db.884.desc=§2This element is now required in Omnium.
+
+# db 885
+nomifactory.quest.db.885.title=§2Darmstadtium
+nomifactory.quest.db.885.desc=§2Do you remember Darmstadtium tools in CE? Well you can make their material now!%n%nIt is formed by fusing Arsenic and Ruthenium, and is the main material for UV machines.
+
+# db 886
+nomifactory.quest.db.886.title=§2Debug Scanner
+nomifactory.quest.db.886.desc=§2The Portable Scanner, or Tricorder, is GTCEu's debug tool. §rIt shows you a block's details, the details of the energy network, its current status and contents, and its impact on performance.%n%nUsing this anywhere will also display a percentage of fluid remaining in the fluid vein, for the §3Fluid Rigs§r.
+
+# db 887
+nomifactory.quest.db.887.title=§2Patriot's Plastic
+nomifactory.quest.db.887.desc=§2A new, oily path to Polyethylene is available in GTCEu. §rCrack §9Light Fuel§r to §9Severely Steam-Cracked Light Fuel§r in a §3Chemical Reactor§r, then distill it to §eEthylene§r.%n%nThe advantage of this path is that it requires §6no MV machines§r. You lose a few Oil byproducts, but you get so much Oil from future processes that the loss is insignificant.
+
+# db 888
+nomifactory.quest.db.888.title=§2Gasoline
+nomifactory.quest.db.888.desc=§2Gasoline is a powerful combustion fuel, generating 1600 EU per mB of fluid. It can also be substituted for Nitro Diesel in Draconium production.%n%nGasoline is made of:%n- 16 parts Naphtha%n- 2 parts Refinery Gas%n- 1 part Toluene%n- 1 part Methanol%n- 1 part Acetone%n%nTo get the most out of this, run it in an Extreme Combustion Engine with Liquid Oxygen.
+
+# db 889
+nomifactory.quest.db.889.title=Platinum Group Processing
+nomifactory.quest.db.889.desc=No Description
+
+# db 890
+nomifactory.quest.db.890.title=§2GT Power Management
+nomifactory.quest.db.890.desc=§dGregTech Power§r can be tricky to handle. Luckily, there are several tools you can use to tackle some of the problems.%n%n- §aDiode§r: A block which accepts energy on 5 sides, and outputs it on a single side. Its main purpose is to limit Amperage flow through it - adjust it by right-clicking it with a Soft Hammer. Not to be confused with the Diodes used as crafting components.%n%n- §aTransformer§r: A block which changes between 4A of a lower voltage and 1A of a voltage one tier higher.%n%n- §2Adjustable Transformer§r: Similar to the Transformer, but can be configured to transform up to 64A Low <-> 16A High.%n%n- §aBattery Buffer§r: A block which can hold GregTech Batteries. Each battery accepts up to 2A and can provide up to 1A. §2They have been reworked in CEu to not be as terrible to use.
+
+# db 891
+nomifactory.quest.db.891.title=§2Chemical Dyes
+nomifactory.quest.db.891.desc=§2Chemical Dyes are made with 1 unit of dye, 2 Salt and Sulfuric Acid. Each yields 4 dyes when solidified, so you can create an infinite loop of dyes with only 1 initial dye item.%n%nTheir main use is to dye Glass Lenses for production of advanced wafers. %n%nYou may also wish to make a Spray Can and fill it with Chemical Dye. This allows you to paint basically all GT tile entities.
+
+# db 892
+nomifactory.quest.db.892.title=§2Large Miners
+nomifactory.quest.db.892.desc=§2The Large Ore Drilling Plants mine ores from under them in a large radius. They require Drilling Fluid to operate.%n%nThey automatically macerate the ores, yielding 3 times more crushed ore than a normal Macerator, plus the normal amount of byproduct.
+
+# db 893
+nomifactory.quest.db.893.title=§2Maintenance and Muffler Mechanics
+nomifactory.quest.db.893.desc=§2Certain multiblocks in CEu will require a Maintenance Hatch and/or Muffler Hatch. These cannot be shared between multiblocks. If you knew Maintenance in GT5u, fret not - Maintenance mechanics are far less punishing in CEu.%n%n§r- §aMuffler§r: This hatch must be §cunobstructed§r so it can output its beautiful smoke particles. When a recipe is performed, there is a small chance for the §3Muffler Hatch§r to give bonus items, typically tiny Dusts of Ash. It voids excess when full, so do not worry about it stopping machines from running.%n%n- §aMaintenance§r: You will need to do Maintenance for the Multiblock to begin operating. This is done by having a §9Wrench§r, a §9Screwdriver§r, a §9Soft Mallet§r, a §9Hammer§r, a §9Wire Cutter§r, and a §9Crowbar§r in your inventory, opening the Maintenance Hatch and §eclicking the center spot once§r. §cNo need to move tools individually§r. Alternatively, you can fix problems by placing §9Tape§r in the Maintenance Hatch. %n%nMaintenance problems may occur after §d48 real hours of activity§r. Needless to say, they are very rare. Each problem increases the recipe durations by 10%%. Fixing the problems is done the same way as above.%n%nAt §6HV§r age, you will unlock other Maintenance Hatches that do not enforce fixing the problems manually. Both start with §6no Maintenance required§r:%n%n- §3Automatic Maintenance Hatch§r: Eliminates the need for Maintenance, §6forever§r.%n%n- §3Configurable Maintenance Hatch§r: You can configure it to cut off §a10%% duration§r on recipes, at the cost of making Maintenance issues happen three times as fast. That is §d16 real hours§r of activity. §9Tape§r can fix problems in this Hatch as well.%n
+
+# db 894
+nomifactory.quest.db.894.title=§2MV Assembling Machine
+nomifactory.quest.db.894.desc=§2With the MV Assembling Machine, you can assemble a few necessary parts for the next Circuit tier.
+
+# db 895
+nomifactory.quest.db.895.title=§2MV Energy Input
+nomifactory.quest.db.895.desc=§2The MV Assembling Machine allows you to craft Medium Voltage Coils, and your Precision Laser Engraver can make Ultra Low Power ICs with a Sapphire Lens.%n%nCombine them with some MV parts and you can finally craft an MV Energy Hatch.%n%nHigher tiers of energy hatch will require similar resources.%n%nNote: For extracting energy from GT multiblock generators, you will need Dynamo Hatches instead. Those are crafted similarly to Energy Hatches, but with Springs in place of 1x Cables.
+
+# db 896
+nomifactory.quest.db.896.title=§2Sodium Potassium
+nomifactory.quest.db.896.desc=§2Sodium Potassium is an alloy of... take a guess. %n%nIt's used in the construction of HV and above Energy and Dynamo hatches.
+
+# db 897
+nomifactory.quest.db.897.title=§2HV Energy Hatch
+nomifactory.quest.db.897.desc=§2With Silver, LPICs, NaK, and an HV Assembler, you can finally make HV Energy and Dynamo hatches.%n%nYou should get the gist of making these now, so there will not be further quests on Energy and Dynamo hatches.
+
+# db 898
+nomifactory.quest.db.898.title=§2HV Chemical Bath
+nomifactory.quest.db.898.desc=§2Required for staining Glass Lenses with Chemical Dyes.
+
+# db 899
+nomifactory.quest.db.899.title=§2Hydrofluoric Acid
+nomifactory.quest.db.899.desc=§2Hydrofluoric Acid is a dangerous acid made by mixing Hydrogen and Fluorine. It is used in the production of Polytetrafluoroethylene, and in Uranium and Naquadah processing.%n%nFluorine is best obtained from Topaz or Bastnasite Ore processing from their Microminer missions, or in small amounts from renewable Black Granite.
+
+# db 900
+nomifactory.quest.db.900.title=§2High-Octane Gasoline
+nomifactory.quest.db.900.desc=§2High-Octane Gasoline is the most powerful combustion fuel, generating 3200 EU per mB of fuel. It can also be used in Draconium production, using 75%% less fuel than Nitro Diesel or normal Gasoline. The trade-off is the very complex processing lines you must set up for it.%n%nTo refine Gasoline to High-Octane Gasoline, you will need:%n- 20 parts Gasoline%n- 2 parts Octane%n- 2 parts Nitrous Oxide%n- 1 part Toluene%n- 1 part Ethyl Tert-Butyl Ether%n%nTo get the most out of this, run it in an Extreme Combustion Engine with Liquid Oxygen.
+
+# db 901
+nomifactory.quest.db.901.title="Nitro Diesel" or "Gasoline"
+nomifactory.quest.db.901.desc=No Description
+
+# db 902
+nomifactory.quest.db.902.title=§2Terminal
+nomifactory.quest.db.902.desc=§2The Tablet device you spawned with is very valuable to do plenty of tasks in GregTech.§r%n%nThis Quest explains how you can use the §4Terminal§.. §bThis is merely basic information, you can skip this for a while as the Terminal isn't used much in the early game§r.%n%nThe Terminal runs on §4GregOS™§r (not an actual Trademark), an operating system which works with §5Applications§r.%n%n§9Machines Guides§r, §9Multiblock Guides§r, §9Item Guides§r, §9§9Tutorials§r are what they sound like. Note that they are currently still being worked on.%n%n§9System Settings§r changes... settings (duh) related to the Terminal. You can §bset your own background picture§r, remove the double confirmation on exit, and more. Most of the keybinds apply to the §5Home§r button. Double clicking by default exists any open Application.%n%n§9Multiblock Helper§r is split into two functionalities. The first one requires a requires a §dLV§r Battery and a §dCamera§r mounted to enable §bVR visualization§r of multiblock structures. The upgrade unlocked at §6HV§r allows you to §6debug§r and §6auto-build§r.%n%n§9Battery Manager§r, assuming you have a Battery mounted, checks the Energy level and indicates energy usage of other Apps.%n%n§9Hardware Manager§r is used to mount Hardwares, such as Battery, to enable other Apps.%n%n§9App Store§r (not exactly a Store) adds Apps to your collection, and allows upgrades for some of them. Keep in mind Apps may still require specific mounted devices to function.%n%n§9Ore Prospector§r works the same way as the portable §dProspector§r and can be upgraded several times.%n%n§9Fluid Prospector§r works the same way as the portable §dProspector§r (but for fluids!) and can be upgraded several times.%n%n§9Recipe Chart§r is a wonderful chart planner to build Recipe Chains and visualize them.%n%n§9GT Console§r configures machines as if you were using regular tools, but without using them! This is similar to the remote access from the §3Central Monitor§r.%n%n§9World Prospector§r is a §dX-Ray VR§r for filtered blocks.%n%n§9Virtual Tank Viewer§r is used in combination with §3Ender Fluid Covers§r. It stores information about all your §dVirtual Tanks§r.%n%n§9Cape Selector§r lets you become fancy! You can have your characters wear a fancy §dCape§r.",%n
+
+# db 903
+nomifactory.quest.db.903.title=§2Cupronickel Coils
+nomifactory.quest.db.903.desc=§2The coil recipes are harder in CEu, not only do they require their base material, they also need some extra material types and they must be made in Assembling Machines of their tier.%n%nFor Cupronickel Coils, you will need 8 Cupronickel, 2 Bronze, and 1 Tin Alloy for each coil. You need 16 for the Electric Blast Furnace and 16 for the Pyrolyse Oven. That totals to 176 Copper, 128 Nickel, 32 Tin, and 16 Iron.
+
+# db 904
+nomifactory.quest.db.904.title=§2Bacterial Sludge
+nomifactory.quest.db.904.desc=§2Bacterial Sludge will be used in the Crystal and Wetware processes.%n%nPlant matter in Plant Ball can be broken down to Bio Chaff, and broken down to Bacteria. Then, combine it with your Biomass to get Bacterial Sludge.%n%nYou will also get a bit back from growing Stem Cells later.
+
+# db 905
+nomifactory.quest.db.905.title=§2Mutagen
+nomifactory.quest.db.905.desc=§2Use Uranium-238 or more efficiently, Uranium-235 to enrich Bacterial Sludge, and distill it to Mutagen. Later, you can use Naquadria to double your Enriched Bacterial Sludge yield.%n%nMutagen is used in Growth Medium production.
+
+# db 906
+nomifactory.quest.db.906.title=§2Large Circuit Assembler
+nomifactory.quest.db.906.desc=§2Multiblock version of the Circuit Assembler. Can accept Parallel Control Hatches, and allows tiering it up more easily.
+
+# db 907
+nomifactory.quest.db.907.title=ZPM or Large Circuit Assembler
+nomifactory.quest.db.907.desc=No Description
+
+# db 908
+nomifactory.quest.db.908.title=Tritanium Ingot
+nomifactory.quest.db.908.desc=No Description
+
+# db 909
+nomifactory.quest.db.909.title=§2Primitive Steelworks
+nomifactory.quest.db.909.desc=A mixture of Clay and Brick produces large quantities of §6Firebricks§r, used in building the §3Primitive Blast Furnace§r. This allows you to make §6Steel§r from §6Wrought Iron§r, which forms the basis of LV Machine Hulls.%n%nThe §3PBF§r has been changed to be blazing fast - just 20 seconds per §6Steel Ingot§r! You will still want to keep it running, as you won't stop needing Steel.
+
+# db 910
+nomifactory.quest.db.910.title=§2Rhodium Plated Lumium-Palladium
+nomifactory.quest.db.910.desc=§2Rhodium Plated Lumium-Palladium is a mixture of Rhodium, Lumium and Palladium. It forms the basis of LuV Machine Hulls.
+
+# db 911
+nomifactory.quest.db.911.title=LV Battery Buffer
+nomifactory.quest.db.911.desc=The §6Battery Buffer§r is a machine which can hold §6Batteries§r for energy storage. Each Battery accepts up to 2 amps and outputs up to 1 amp.%n%nYou can also charge §6Electric tools§r in them.%n%n§cRF batteries such as Flux Capacitors cannot be drained by Battery Buffers!
+
+# db 912
+nomifactory.quest.db.912.title=Hard Mode
+nomifactory.quest.db.912.desc=The §2CEu§r§r version of Nomi is already slightly harder than the original, due to various progression changes CEu makes.%n%nBut if you want a §charder§r, or perhaps a more "§5true§r" §dGregTech§r experience, check out the §cExpert§r mode. This pack mode is based on the §bSelf-Torture Edition fork§r of the original pack.%n%nHighlights include:%n%n- No §bDML§r for easy infinite resources%n- §6Omnicoins§r can't be spent%n- The §7Steam Age§r%n- No §3Creative Tank§r; instead...%n- §6Stabilized Micro Miners§r for late-game infinite resources%n- Harder recipes for assorted things like §6Iridium§r, §3Numismatic Dynamos§r, and more%n%nTo enable §cExpert§r mode, change the pack mode (Options -> Pack Mode) to Expert, then run §e/bq_admin default load ExpertQuests§r. The same command should be used for updating the quest book on Expert mode.%nTo go back, change the pack mode to §aNormal§r and run §e/bq_admin default load§r.%n%nTo tune your challenge even further, check out the various recipe configs in the GregTech config file.
+
+# db 913
+nomifactory.quest.db.913.title=§2Machine Naming
+nomifactory.quest.db.913.desc=As you expand your production lines, it can get confusing where everything is real quickly.%n%nNew in GTCEu, you can §2name machines in an Anvil§r in order to display a hologram above them. This hologram can't be seen through walls, so you needn't worry about clogging your view with names.
+
+# db 3 ste
+nomifactory.quest.db.3.ste.title=§cSTE-§2Genesis
+nomifactory.quest.db.3.ste.desc=Welcome to §5Nomifactory§f §2GTCEu-§cSTE§r!%n%nThis pack is intended to be played in a §bLost Cities / Overworld dimension§f.%n%nIf you're playing with friends, don't forget to invite them to the §equestbook party§f.%n%n§fIf you wish to build your base in a skyblock world, place the §6Void World Cake§f down on the ground, and eat a slice to be sent to the void. Please note that you'll still need to return to the Lost Cities / Overworld dimension to mine, but you can freely build in complete safety in the §eVoid World§f.%n%nFeatures new to §2CEu§r and quests with new content will be highlighted in §2dark green (colour 2)§r.
+
+# db 4 ste
+nomifactory.quest.db.4.ste.title=Iron Supply
+nomifactory.quest.db.4.ste.desc=§c§rOres in §5Nomifactory§f exist in large clusters, or '§eveins§f'. These veins are scattered around the world, and are relatively common. §2The upgraded HV Electric Prospector's Scanner you were given will tell you the types of ores you can find within a 7x7 chunk area!§r%n%nWhile the Scanner requires energy to work, you are unlikely to deplete its battery. That said, the quest book will later guide you towards making §2an HV Battery§r to charge §aHV tools §rin your inventory.%n%nIn order to proceed, you'll need to locate a source of §6Iron§f. You have a few options. §6Magnetite§f veins are higher up and contain large amounts of iron, as well as some §6Vanadium§f and §6Gold§f. Another good source of iron is §6Limonite§f veins, which contain several types of iron. Finally, §6Pyrite§f can be found paired with §6Copper§f in several types of veins.%n%n§6Wrought Iron§f is obtained simply by §esmelting Iron §cNuggets§e a second time§f. It has more durability than Iron, so it is better for making tools, but §cdo not convert your entire Iron supply over to Wrought Iron§f. The two materials are not interchangeable and you'll need Iron or Wrought Iron as demanded by various recipes.
+
+# db 9 ste
+nomifactory.quest.db.9.ste.title=Ore Doubling?
+nomifactory.quest.db.9.ste.desc=In most expert packs, you want to try to process as little ore as possible before you get access to ore doubling. It's a habit most of us pick up.%n%n§eYou shouldn't feel any pressure to do that in Nomifactory, though§f. Ore veins are massive, and mining is extremely fast with §aMining Hammers§f. What's more, even once you get access to §3Macerators§f, they initially process ore slowly and require power to operate.%n%nObvious exceptions would be rare materials §fbecause you can't find it. Those are worth doubling, if possible.%n%nBut at least for now, you shouldn't feel any guilt about smelting the more common ores without doubling them! §eOre doubling can be safely ignored until you have Medium Voltage machines or even later.§r
+
+# db 10 ste
+nomifactory.quest.db.10.ste.title=§2Tier Two Micro Miner
+nomifactory.quest.db.10.ste.desc=The Second Micro Miner!%n%nThis uses an §bExtended Crafting§r table so it's not possible to automate the Miner itself with §bApplied Energistics 2§r just yet (this requires more advanced technology not easy to access until the Tier Four Micro Miner). You can make it semi-automatically by prestocking the components you need, and filling up the Extended Crafting Table with §bJEI§r!%n%nThis Micro Miner can get you:§6%n* Bauxite Ore%n§2* Pyrochlore Ore§6%n§c* Tantalite Ore§2%n* Copper Ore%n* Tungstate Ore%n* Scheelite Ore%n* Cassiterite Ore%n* Radium Salt§r%n%nAs well as the §6Stellar Creation Data§r, which will be useful much, much later.
+
+# db 11 ste
+nomifactory.quest.db.11.ste.title=§2Electronics Subcomponents
+nomifactory.quest.db.11.ste.desc=A "§esubstrate§f" is the "board" part of a circuit board... the backing that the circuit components and wires are laid into. A good substrate needs to not conduct electricity, for obvious reasons. §6Wood§r coated in §6Sticky Resin§r is a primitive but effective material to use as your first substrate.%n%n§2CEu circuit progression means you also have to put wires on your substrates for them to be usable. In this case, use some Copper Wires.§r%n%nYou'll also need to make §6Vacuum Tubes§f, as well as some primitive §6Resistors§r. §6Paper§r will work as a material for these, for now.%n%nMake sure to code these recipes into a §3Crafting Station§r... you'll be making a LOT of these things.
+
+# db 19 ste
+nomifactory.quest.db.19.ste.title=Benzene
+nomifactory.quest.db.19.ste.desc=§9Benzene§r is a common reagent which can be obtained from §9Wood Tar§r or §9Oil§r. Apart from that, it is a potent fuel which generates §d352 EU/mB§r in a §3Gas Turbine§r.%n%nLater, you can use an HV §3Chemical Reactor§r to upgrade it to §9Nitrobenzene§r, which has a greatly improved fuel density.
+
+# db 21 ste
+nomifactory.quest.db.21.ste.title=§2Steel
+nomifactory.quest.db.21.ste.desc=You already have §6Steel§r, but it can be made much faster in the §3Blast Furnace§r, at the cost of EU and §9Oxygen§r.
+
+# db 37 ste
+nomifactory.quest.db.37.ste.title=Rubber Sheets
+nomifactory.quest.db.37.ste.desc=Going out in search of a §6Rubber Tree§f is a viable option for sure. However, if this isn't appealing, you can also §eshear leaves§f and make §6Plantballs§f out of them. Plantballs smelt into §6Slime§f, and Slime smelts into §6Sticky Resin§r.%n%nYou'll want to transition to Rubber Trees at some point, though, since the §eratio of leaves to rubber is quite poor§f.%n%nUse the §3Steam Extractor§r to extract §6Raw Rubber Pulp§r from the resin, then "alloy" with §6Sulfur§r for the §6Rubber§r. It's quite inefficient to do it this way, but such is the life of early game §bGregTech§f. At least rubber isn't particularly hard to come by.
+
+# db 58 ste
+nomifactory.quest.db.58.ste.title=§2LV Power Storage
+nomifactory.quest.db.58.ste.desc=§6Batteries§r are §bGregTech §rpower storage for §aEU§r energy.%n%nThere are several types of rechargeable batteries you can make; §2Lithium Batteries§r are the best ones, followed by §6Cadmium§r and §6Sodium§r.%n%n§6Lithium§r is possible to find inside of §6Tungsten§r veins, however, they only spawn in §eThe End§r§r. §6Cadmium§r comes from various §6Refined Ores§r, and §6Sodium§r is the easiest - from §6Salt§r, §6Clay§r, and many other minerals.
+
+# db 65 ste
+nomifactory.quest.db.65.ste.title=§2Tier Three Micro Miner
+nomifactory.quest.db.65.ste.desc=The Third Micro Miner.%n%nThis one can get you:%n§6* Tetrahedrite Ore%n* Cassiterite Ore%n* Tungstate Ore%n* Scheelite Ore%n* Redstone Ore%n* Quartz Ore%n* Vanadium Magnetite Ore%n§2* Ilmenite Ore§6%n* Tin Ore%n* Sapphire Ore§r%n§6* Almandine Ore§r%n%nor:%n§6* Dense Magma Block§r%n%nWhen equipped with Gemstone Sensor:%n§6§2* Perfect Emeralds%n* Perfect Diamonds%n* Perfect Rubies%n* Perfect Topaz%n§6* Silver Ore%n* Gold Ore
+
+# db 66 ste
+nomifactory.quest.db.66.ste.title=From Dusts To Wires
+nomifactory.quest.db.66.ste.desc=§3Alloy Smelter§f%n%n§3Smelt§f it into ingots, §ahammer§f it into §6Plates§f, and §acut§f them into §6Wires§f.
+
+# db 69 ste
+nomifactory.quest.db.69.ste.title=§2Aluminium Ingots
+nomifactory.quest.db.69.ste.desc=With your EBF running, start to create a supply of §6Aluminium Ingots§r. These are crucial ingredients for MV machines, including §bApplied Energistics§r.%n%n§2With LV power, you can only get Aluminium Dust from electrolyzing Sapphire Dust or Green Sapphire Dust. Once you make an MV Electrolyzer, you can get it from a plethora of other raw resources.§r%n%nIf you find your power supply is faltering, you may want to make additional dynamos and turn them into steam boilers and turbines. Upgrading your dynamos is also advisable.%n%nHowever, you're also about to reach MV. You're bound to discover a better power source than steam before long.%n%n§2You can cut by a third the smelting time of Aluminium and some other smelting processes with Nitrogen gas. Higher-tier processes may take different gases.
+
+# db 79 ste
+nomifactory.quest.db.79.ste.title=§2Cutting Machine
+nomifactory.quest.db.79.ste.desc=Cuts things up.%n%nThe §3Cutting Machine§r is able to cut wafers, rods, wood, and various other things for you, making it a versatile crafting tool. Cutting blocks into 9 plates is much faster than using a §2Metal Bender §rto make them one at a time.%n%nThis quest accepts the LV or MV version. The LV version can cut §6Silicon Boules§r for easier §6Diodes§r, and can also cut plates and other components. The MV version is required for cutting §6Wafers§r.%n%nThe blade will require you to make §2Cobalt Brass§r (for LV) or §2Vanadiumsteel§r (for MV).%n%nCutting Machines work with plain §9Water§r for all recipes. You can also use §9Distilled Water§r which speeds up the processing somewhat, or §9Lubricant§r that speeds it up greatly (and uses very little per operation). These might be a little tricky to make right now, but are very worthwhile upgrades in the future.%n%nYou might consider waiting until you have §2Integrated Circuits§r before progressing too far down the path of MV machines, since these circuits are much easier to make than §2Electronic Circuits§r.
+
+# db 94 ste
+nomifactory.quest.db.94.ste.title=§2Sulfuric Acid
+nomifactory.quest.db.94.ste.desc=§2Sulfuric Acid is mainly produced in a 3-step process:§r%n-§6 Sulfur§o§r added to §9Oxygen§r to produce §9Sulfur Dioxide§r. §9SO₂§r also can come from treating certain §6Sulfur-containing Dusts§r with §9Oxygen§r in the EBF, or by processing §eNether Air§r.%n- §9Sulfur Dioxide§r added to more §9Oxygen§r, with §cVanadium Pentoxide§r catalyst, to produce §9Sulfur Trioxide§r.%n- §9Sulfur Trioxide§r added to §9Water§r, to produce §eSulfuric Acid§r.%n%nThe shortcut Sulfur + Water reaction is locked behind the Large Chemical Reactor, unlocked at EV.%n%n§rYou'll need huge amounts of this for a whole range of chemical reactions, as it is a very common ingredient.%n%nSulfur can be electrolyzed from many things, but is also easily available via §bDeep Mob Learning§r's §aBlaze Model§r.
+
+# db 95 ste
+nomifactory.quest.db.95.ste.title=§2Ethylene and Polyethylene
+nomifactory.quest.db.95.ste.desc=§9Ethylene§r is a hydrocarbon made from §2either cracking and distilling Light Fuel, or§r dehydrating §9Ethanol§r with §9Sulfuric Acid§r in a §3Chemical Reactor§r. It is an extremely important chemical in the production of plastics.%n%n§9Polyethylene (PE)§r is the most common category of plastic, made from polymers of §9Ethylene§r. Adding §9Oxygen§r in a §3Chemical Reactor§r recreates (with some artistic license) early accidental synthesis of Polyethylene.%n%nWhen you have large amounts of §6Rutile§r and §6Bauxite§r (probably after you visit the Moon) you can consider using §9Titanium Tetrachloride§r as a catalyst to improve your Polyethylene yields. For now it's not a great idea, as in addition to its Overworld rarity, you need it for §6Titanium§r.%n%n§cPhthalic Anhydride§r acts as an alternative to §9Titanium Tetrachloride§r for increasing plastic yields.
+
+# db 126 ste
+nomifactory.quest.db.126.ste.title=§2SMD Components
+nomifactory.quest.db.126.ste.desc=§6Surface Mounted Devices§r, or §6SMD§rs for short, are §2more efficient ways to produce the Circuit components you've been making. They will be used until the second-to-last theme of circuits.§r%n%nAll SMD components must be produced in at least a §2HV Assembling Machine§r, and they all will require liquid §9Polyethylene§r.%n%nStart off with the §6SMD Transistor§r. These are simply a §6Gallium §2Foil§r and §6Fine Annealed Copper Wire§r.%n%nNext up are §6SMD Resistors§r, which are also simple: §6Carbon Dust§r and §6Fine Electrum Wire§r.%n%nNext up are §6SMD Diodes§r, which are fairly simple. §2Gallium Arsenide Dust§r and §6Fine Platinum Wire§r net you half a stack.§r%n%nThen are §6SMD Capacitors§r. You'll need sheets of §6Polyvinyl Chloride§r to make these, or they can also be made more slowly with §6Silicone Rubber§r. §2Using Tantalum Foil in place of Aluminium doubles your yield.%n%nFinally, and new to CEu, SMD Inductors. Made with Nickel Zinc Ferrite and Fine Cupronickel Wire.§r%n%nInvest in a robust system of automation for SMD components and all of their ingredients, since you'll never stop needing them. They will also work in place of the non-SMD versions you've been using in all but the simplest of recipes.
+
+# db 141 ste
+nomifactory.quest.db.141.ste.title=Steam Production
+nomifactory.quest.db.141.ste.desc=Your initial method of §9Steam§r production, to fuel your first machines. They automatically output Steam on all faces except the bottom.%n%nOnce you get Steel, consider upgrading to HP Solar Boilers.
+
+# db 168 ste
+nomifactory.quest.db.168.ste.title=Diesel
+nomifactory.quest.db.168.ste.desc=§9Diesel§r is a mixture of §9Light Fuel§r and §9Heavy Fuel§r. Each mB of Diesel generates §d480 EU§r in §3Combustion Generators§r.%n%nOnce you get HV machinery, you can upgrade this to §9Cetane-Boosted Diesel§r.%n%n§2§rIt's more power efficient to use §3singleblock Distilleries§r over a §3Distillation Tower§r for Oil, due to the overclocking mechanics being different. For Diesel, the correct ratio is §d3 Distilleries for Light Oil and 2 Distilleries for Heavy Oil§r.
+
+# db 169 ste
+nomifactory.quest.db.169.ste.title=Kapton K
+nomifactory.quest.db.169.ste.desc=§cKapton K§r is now required for preparing §6Wetware Lifesupport Circuit Boards§r.%n%nYou went through §9Polybenzimidazole§r, this should be easy by now.
+
+# db 179 ste
+nomifactory.quest.db.179.ste.title=§2NITRO DIESEL!!
+nomifactory.quest.db.179.ste.desc=Mixing §9Diesel§r (or less efficiently, §9Bio Diesel§r) with §9Tetranitromethane§r in an §3HV Mixer§r produces §9Nitro Diesel§r, an extremely potent fuel. Burn it in the Large Combustion Engine and Extreme Combustion Engine, producing §2720 EU/mB of fuel.
+
+# db 214 ste
+nomifactory.quest.db.214.ste.title=§2Deuterium
+nomifactory.quest.db.214.ste.desc=The Moon is a barren, lifeless rock... So why did you want to come here?%n%nOne major draw is that §6Moon Turf§r, which makes up the surface of the Moon, is an efficient means of obtaining §9Deuterium§r. It will be useful for producing §9Microversium§r, §9Tritium§r, plasmas from fusion, and crystallizing §6Dilithium§r.%n%nThere are also several ores that are rare on the Overworld but exist in abundance on the Moon. Moreover, ores generate more densely on the Moon than in other realms.%n%nIn particular, the Moon contains large quantities of §6Titanium§r (in the form of §6Rutile Ore§r and §6Ilmenite Ore§r), §6Tungsten§r (in the form of §6Scheelite Ore§r and §6Tungstate Ore§r), §6Fluorine§r (in the form of §6Fluorite Ore§r), and §6Molybdenum§r (in the form of §6Wulfenite Ore§r and §6Molybdenite Ore§r).%n%n§2The Moon also contains fluid deposits of Deuterium and Helium-3, which you can harvest with a Fluid Rig. However, you will want to use the second Fluid Rig tier to extract it, as the amount of Deuterium and Helium-3 is too low to be anything appreciable from a first tier Fluid Rig.%n
+
+# db 220 ste
+nomifactory.quest.db.220.ste.title=Rocket Fuel
+nomifactory.quest.db.220.ste.desc=Mix §9Oxygen§r and §91,1-Dimethylhydrazine§r together to make §9Rocket Fuel§r.%n%nAwesome!%n%nWhen you have stable sourcing for Nitrogen and Oxygen, you can make and use §9Dinitrogen Tetroxide§r in the recipe instead of Oxygen. It doubles the efficiency of your §9UDMH§r when making Rocket Fuel.%n%nLater, when you have access to (non-methylated) §9Hydrazine§r, using that in place of §9N₂O₄ §rcan further increase your Rocket Fuel yield.
+
+# db 252 ste
+nomifactory.quest.db.252.ste.title=§2Tier Five Micro Miner
+nomifactory.quest.db.252.ste.desc=The Fifth Micro Miner.%n%nThe only source of §6Naquadah§r, in the form of §cSnowchestite Ore§r. Along with it, § §2Kaemanite Ore§r (for §6Trinium§r).%n%nWhen provided with §6Stabilized Uranium§r, brings:%n§6§2* Uraninite Ore§6%n* Molybdenite Ore%n* Bastnasite Ore%n* Sphalerite Ore%n* Palladium Ore%n* Beryllium Ore%n* Monazite Ore%n§2* Osmiridium 80/20 Ore%n* Realgar Ore§6§r%n§6* Enderpearl Blocks%n* Boron Dust§r
+
+# db 254 ste
+nomifactory.quest.db.254.ste.title=§2Tier Six Micro Miner
+nomifactory.quest.db.254.ste.desc=The Sixth Micro Miner.%n%nThe first decent source of §6Dragon Eggs§r and §6Stabilized Einsteinium§r.%n%nIs also useful for:%n§6§2* Uraninite Ore%n§c* Sheldonite Ore%n* Iridosmine 80/20 Ore
+
+# db 288 ste
+nomifactory.quest.db.288.ste.title=§2Draconium Ingots
+nomifactory.quest.db.288.ste.desc=You'll need at least §6Naquadah Coil Blocks§r in your blast furnace to smelt §6Draconium§r, as well as a healthy supply of §cHigh-Octane Gasoline§r to reach the immense heat it takes to liquefy.%n%nDraconium gets so hot that it requires the potent coolant §9Gelid Cryotheum§r to aid your §3Vacuum Freezer§r in turning it into usable ingots.%n%nThere are several ways to make Draconium: dust can be smelted into ingots, but you can also turn §6Ender Dragon Scales§r, which contain Draconium, directly into ingots. It uses a lot of§2 combustion fuel§r, but is the most efficient way to craft Draconium.%n%nYou've been stockpiling fuel, right?
+
+# db 309 ste
+nomifactory.quest.db.309.ste.title=Elemental Reduction Fluid
+nomifactory.quest.db.309.ste.desc=Once you gain access to §9Fluoroantimonic Acid§r, you can make this more efficiently with respect to §9Fluorine§r.
+
+# db 323 ste
+nomifactory.quest.db.323.ste.title=Naquadah Ingots
+nomifactory.quest.db.323.ste.desc=An otherworldly material exclusive to Microverses, §6Naquadah§r is an important material in the late game.%n%nFor its processing, you will need §9Aerotheum§r and §9Petrotheum§r to separate the §6Naquadah Oxide§r, and §9Neocryolite§r as the electrolyte to get the §6Naquadah§r out.%n%nIt can be alloyed and enriched to various forms, and is the eventual source of §6Neutronium§r in a §3Mark Three Fusion Reactor§r.
+
+# db 357 ste
+nomifactory.quest.db.357.ste.title=Infinity Ingot
+nomifactory.quest.db.357.ste.desc=This ingot is the most advanced basic material.%n%nWith all the automation you hopefully set up for your first §c§cInfinity Catalyst§r, these ingots should be easy.%n%nWell, not easy. But... Reasonable.%n%nFrom here, you are going to be crafting a multitude of Creative-Tier items from various mods. In addition to being useful for their regular functionality, they are needed for the final goal: the §dCreative Vending Upgrade§r.%n%n§bJEI§r is your friend: beyond noting a few more items, I will not be holding your hand anymore. I've taught you everything you need to know to beat the pack.%n%nYou can do it!
+
+# db 367 ste
+nomifactory.quest.db.367.ste.title=Stabilized Micro Miners
+nomifactory.quest.db.367.ste.desc=§dStabilized Micro Miners§r are the end game way of generating infinite resources.%n%n"Stabilization" is a process of injecting §6Micro Miners§r with a §6Heart of a Universe§r, which makes them reusable at a reasonable cost.%n%nMuch like regular Micro Miners, the stabilized versions must be inserted into appropriate §3Microverse Projectors§r. However, running stabilized missions doesn't require any catalysts.%n%nStabilized missions don't bring loot, but rather §dPristine Microverse Matter§r that can be exchanged for loot using an §3Actualization Chamber§r.%n%nIt's a good idea to invest into multiple chambers to be able to round-robin Pristine Matter between them, since you can't take integrated circuits out.%n%nThe §6Stabilized Tier Eight Micro Miner§r might be the best investment, but the final decision is down to you.
+
+# db 370 ste
+nomifactory.quest.db.370.ste.title=Coke Oven
+nomifactory.quest.db.370.ste.desc=§2For making Charcoal for smelting, and Creosote, which can be used as furnace fuel, boiler fuel, and for Treated Planks.%n%nUse up to 5 Coke Oven Hatches for automation.
+
+# db 391 ste
+nomifactory.quest.db.391.ste.title=Craftable Nether Stars
+nomifactory.quest.db.391.ste.desc=ASSEMBLE... TOO!%n%nYeah you get to craft §6Nether Stars§r. Cool huh?%n%nOver the course of the pack, Nether Stars are going to be needed in quantities that far exceed a reasonable player's ability to farm Withers. §eCraft them, don't bother trying to farm them.§r%n%nOnce you gain access to §6Tier 4.5 Micro Miners§r, they will become your best§6 Nether Star§r source.
+
+# db 394 ste
+nomifactory.quest.db.394.ste.title=Flux Capacitors
+nomifactory.quest.db.394.ste.desc=Basic §aFlux Capacitors§r hold a whopping lot of energy - §a1 million RF§r - and are useful for keeping your §aRF-powered§r equipment and tools charged.%n%nPut one into your newly crafted §3Battery Buffer§r to charge it. You can then put it in your inventory to charge your items with §aRF§r. %n§cRF batteries such as Flux Capacitors cannot be drained by Battery Buffers!§r%n%nFlux Capacitor is a §bBauble§r, open your inventory and look for the Baubles button, click it to reveal the additional bauble slots menu and put it into any slot you wish.%n%nFinally you can charge up all those depleted §6Dark Boots§r and §6The Ender§r swords you've looted.
+
+# db 497 ste
+nomifactory.quest.db.497.ste.title=Compacting Drawers
+nomifactory.quest.db.497.ste.desc=Great for automatically converting between Nuggets, Ingots, and Blocks of metals, or simply storing massive amounts of things.%n%nThe appearance can be customized by crafting the drawer into §aFramed Compacting Drawer§r and putting it into a §aFraming Table§r.
+
+# db 539 ste
+nomifactory.quest.db.539.ste.title=Phosphorus
+nomifactory.quest.db.539.ste.desc=§6Phosphorus§r can be obtained by processing §6Tricalcium Phosphate§r or §6Apatite§r with §6Sand§r and §6Coke§r in the §3Blast Furnace§r.
+
+# db 556 ste
+nomifactory.quest.db.556.ste.title=Tier 4.5 Micro Miner
+nomifactory.quest.db.556.ste.desc=The 4.5th Micro Miner.%n%nAll of the Tier Four missions require §68 Quantum Flux§r and a stack of §6Aerotheum Dust§r.%n%nThis miner will be your primary source of mob drops all the way until the end%n%nWhen equipped with a §6Sapling§r:%n§6* Creeper, Skeleton and Zombie skulls%n* Bone%n* Rotten Flesh%n* Gunpowder%n* Slime Block%n* Guardian Scale§r%n%nWhen equipped with a §6Block of Netherrack:%n* Wither Skeleton Skull and Bones%n* Blaze Rod%n* Ghast Tear%n* Magma Cream§r%n%nWhen equipped with a §6Block of Endstone:%n* Enderman Skull%n* Enderpearl Block%n* Shulker Shell§r%n%nWhen equipped with §6Ender Eyes:%n* Dragon Lair Data%n* Ender Dragon Head§r%n%nWhen equipped with §6Wither Bones§r:%n§6* Wither Realm Data%n* Nether Star Block%n
+
+# db 670 ste
+nomifactory.quest.db.670.ste.title=Steam Machines
+nomifactory.quest.db.670.ste.desc=Steam Machines can run recipes listed as up to §d32 EU/t§r. They need to have their vent side unobstructed. Use a Wrench to change the venting side.%n%n- §3Forge Hammer§r: Allows you to make §62 plates§r from §63 ingots§r.%n%n- §3Macerator§r: Allows you to grind §6Clay§r into §6Clay Dust§r.%n%n- §3Compressor§r: Allows you to make §6Compressed Fireclay§r and §6Rubber Sheets§r.%n%n- §3Alloy Smelter§r: Allows you to make §6Bronze§r more efficiently, as well as other useful alloys like §6Invar§r. Also allows you to cast §6Glass§r, and make components like §eGears§r more easily with Molds.%n%nYou can upgrade them to HP version with Steel, which doubles their speed.
+
+# db 687 ste
+nomifactory.quest.db.687.ste.title=§2Infinite Water
+nomifactory.quest.db.687.ste.desc=Feeding §3Steam producers§r with water by hand is a pretty silly idea.%n%nA §2Primitive Water Pump§r will take care of that for you.
+
+# db 690 ste
+nomifactory.quest.db.690.ste.title=Graphene
+nomifactory.quest.db.690.ste.desc=§6Graphene§r is the cable material required for §6IV Motors§r, and it's not trivial to make anymore.%n%nPresently, you can make it by reducing §6Graphene Oxide§r with §9Argon§r and §9Hydrazine§r. §9Hydrazine§r is produced in multiple steps using §9Ammonia§r and §9Hydrogen Peroxide§r with §9Acetone§r as a recycled reagent.%n%nLater, you can use a §6Magnetron§r to make it from §6Graphite§r directly. Note that the other recipe requires no §6Graphite§r.
+
+# db 752 ste
+nomifactory.quest.db.752.ste.title=Universal Crystallizer
+nomifactory.quest.db.752.ste.desc=The §3Universal Crystallizer§r can make §6Crystal Matrix Ingots§r at about a ninth of the §6Diamond§r cost, makes §6Wyvern§r and §6Awakened Cores§r and §6Awakened Draconium§r far faster than §3Fusion Crafting§r, and crafts §6Empowered Blocks§r without hassle.%n%nThis is the final machine you will make, and the most costly. You will need §d12 Hearts of a Universe§r and §d80 Chaos Shards§r, among others.%n%nIt requires a small amount of Enriched Naquadah to run, and an immense amount of power - but with §6Creative RF Source§r, it shouldn't be a problem.
+
+# db 756 ste
+nomifactory.quest.db.756.ste.title=Taranium
+nomifactory.quest.db.756.ste.desc=§6Taranium§r is an exotic material found in tiny quantities from... §6Stone Dust§r.%n%nProcess Stone Dust through a long chain (and enjoy the byproducts), and eventually, you'll reach the §6Taranium Dust§r. It's used in several powerful endgame tools, such as §6UV Field Generator§r and §3Advanced Ore Drilling Plant II§r.
+
+# db 779 ste
+nomifactory.quest.db.779.ste.title=§2Infinite Cobblestone
+nomifactory.quest.db.779.ste.desc=Cobblestone can be processed into many useful materials:%n%n§6Stone Dust§r is useful for small amounts of a whole host of useful materials.%n%n§6Gravel§r is useful for making conduits and §9Concrete§r.%n%n§6Sand§r is useful for §6Glass§r, which can be turned into §6Nether Quartz§r or §6Silicon Dioxide§r for §6Oxygen§r.%n%nFinally, §6Dust§r can be turned into §6Netherrack§r.%n%nSet up a §ecobbleworks§r soon, so you can stockpile all these useful materials.%n
+
+# db 780 ste
+nomifactory.quest.db.780.ste.title=§2To the Nether
+nomifactory.quest.db.780.ste.desc=The §eNether§r contains quite a few useful resources:%n- Some initial pieces of §6Sulfur§r%n- §6Glowstone§r and §6Soul Sand§r%n- §6Fluorine§r, §6Certus Quartz§r, §6Molybdenum§r, §6Antimony§r, and §6Gold§r-bearing ores%n- §9§2Nether Air§r, which can be distilled for useful gases%n- §eLava§r and §eNatural Gas§r from §2Fluid Rigs%n%n§rNether ores also contain §ddouble§r the resources per ore block compared to Overworld ores.
+
+# db 810 ste
+nomifactory.quest.db.810.ste.title=Vanadium Pentoxide
+nomifactory.quest.db.810.ste.desc=§6§6Vanadium Pentoxide§r is a catalyst used in the production of §9Sulfuric Acid§r and §9Phthalic Anhydride§r. It's also the way you get §6Vanadium§r metal.%n%nYou will need §6Salt§r, §9Ammonia§r, and §9Hydrochloric Acid§r for the multi-step processing of §6Vanadium Magnetite Ore§r into §6V₂O₅§r.
+
+# db 817 ste
+nomifactory.quest.db.817.ste.title=§2Steam Grinder
+nomifactory.quest.db.817.ste.desc=The Steam Grinder functions as 5.3 LV Macerators in parallel. It requires an input of Steam through a Steam Hatch, but it uses very little Steam.%n%nYou may want to consider setting up a rudimentary ore-doubling setup with it. Point the output in the direction of several upgraded Furnaces.%n%nYou may wish to wait until you have a Metal Bender at LV to reduce the cost.
+
+# db 839 ste
+nomifactory.quest.db.839.ste.title=§2Crystal Growing
+nomifactory.quest.db.839.ste.desc=§2Your first few Raw Crystal Chips must be grown in an Autoclave from liquid Europium, and Exquisite Emeralds or Exquisite Olivine.%n%nAfter the first few, you can smash them into pieces using a Forge Hammer, and duplicate them with Bacterial Sludge, Mutagen, or more Europium.%n%nBacterial Sludge can later be obtained in the byproducts of getting Stem Cells.
+
+# db 843 ste
+nomifactory.quest.db.843.ste.title=§2Naquadah Processing
+nomifactory.quest.db.843.ste.desc=§2There are 3 materials you will need from processing Naquadah: Enriched Naquadah (Nq+), Naquadria (Nq*), and Trinium (Ke). And there are 3 different ways to process Naquadah, each resulting in different materials.§r%n%nFirst is by §dprocessing ores§r from the §6Tier Five Micro Miner§r. §6Kaemanite Ore§r yields §6Trinium§r.%n%nSecond is by combining §6Naquadah Dust§r with certain heavy elements and EnderIO crystal grains. This can provide §6Enriched Naquadah§r and §6Naquadria§r.%n%nFinally, you can do the full CEu processing of §6Naquadah Dust§r with §9Fluoroantimonic Acid§r, the strongest acid known to man. This is a decently involved process, but not only does it yield all 3 Nq materials, it also grants byproducts of §6Titanium, Sulfur, Indium, Phosphorus, Barium, and Gallium§r.%n§2There are 3 materials you will need from processing Naquadah: Enriched Naquadah (Nq+), Naquadria (Nq*), and Trinium (Ke). And there are 3 different ways to process Naquadah, each resulting in different materials.§r%n%nFirst is by §dprocessing ores§r from the §6Tier Five Micro Miner§r. §6Kaemanite Ore§r yields §6Trinium§r.%n%nSecond is by combining §6Naquadah Dust§r with certain heavy elements and EnderIO crystal grains. This can provide §6Enriched Naquadah§r and §6Naquadria§r.%n%nFinally, you can do the full CEu processing of §6Naquadah Dust§r with §9Fluoroantimonic Acid§r, the strongest acid known to man. This is a decently involved process, but not only does it yield all 3 Nq materials, it also grants byproducts of §6Titanium, Sulfur, Indium, Phosphorus, Barium, and Gallium§r.
+
+# db 888 ste
+nomifactory.quest.db.888.ste.title=§2Gasoline
+nomifactory.quest.db.888.ste.desc=§2Gasoline is a powerful combustion fuel, generating 1600 EU per mB of fluid.%n%nGasoline is made of:%n- 16 parts Naphtha%n- 2 parts Refinery Gas%n- 1 part Toluene%n- 1 part Methanol%n- 1 part Acetone%n%nTo get the most out of this, run it in an Extreme Combustion Engine with Liquid Oxygen.
+
+# db 893 ste
+nomifactory.quest.db.893.ste.title=§2Maintenance and Muffler Mechanics
+nomifactory.quest.db.893.ste.desc=§2Certain multiblocks in CEu will require a Maintenance Hatch and/or Muffler Hatch. These cannot be shared between multiblocks. If you knew Maintenance in GT5u, fret not - Maintenance mechanics are far less punishing in CEu.%n%n§r- §aMuffler§r: This hatch must be §cunobstructed§r so it can output its beautiful smoke particles. When a recipe is performed, there is a small chance for the §3Muffler Hatch§r to give bonus items, typically tiny Dusts of Ash. It voids excess when full, so do not worry about it stopping machines from running.%n%n- §aMaintenance§r: You will need to do Maintenance for the Multiblock to begin operating. This is done by having a §9Wrench§r, a §9Screwdriver§r, a §9Soft Mallet§r, a §9Hammer§r, a §9Wire Cutter§r, and a §9Crowbar§r in your inventory, opening the Maintenance Hatch and §eclicking the center spot once§r. §cNo need to move tools individually§r. Alternatively, you can fix problems by placing §9Tape§r in the Maintenance Hatch. %n%nMaintenance problems may occur after §d48 real hours of activity§r. Needless to say, they are very rare. Each problem increases the recipe durations by 10%%. Fixing the problems is done the same way as above.%n%nLater, you will unlock other Maintenance Hatches that do not enforce fixing the problems manually. Both start with §6no Maintenance required§r:%n%n- §3Automatic Maintenance Hatch§r (§1IV§r): Eliminates the need for Maintenance, §6forever§r.%n%n- §3Configurable Maintenance Hatch§r (§6HV§r): You can configure it to cut off §a10%% duration§r on recipes, at the cost of making Maintenance issues happen three times as fast. That is §d16 real hours§r of activity. §9Tape§r can fix problems in this Hatch as well.%n
+
+# db 900 ste
+nomifactory.quest.db.900.ste.title=§2High-Octane Gasoline
+nomifactory.quest.db.900.ste.desc=§2High-Octane Gasoline is the most powerful combustion fuel, generating 3200 EU per mB of fuel. This is required for production of Draconium.%n%nTo refine Gasoline to High-Octane Gasoline, you will need:%n- 20 parts Gasoline%n- 2 parts Octane%n- 2 parts Nitrous Oxide%n- 1 part Toluene%n- 1 part Ethyl Tert-Butyl Ether%n%nTo get the most out of this, run it in an Extreme Combustion Engine with Liquid Oxygen.
+
+# db 905 ste
+nomifactory.quest.db.905.ste.title=§2Mutagen
+nomifactory.quest.db.905.ste.desc=§2Use §cCalifornium-252 §rto enrich Bacterial Sludge, and distill it to Mutagen.%n%nMutagen is used in Growth Medium production.


### PR DESCRIPTION
Transform expert quests to use language key with the following rules:
1. if the language key of the quest id has the same content as the quest, use that existing key;
2. otherwise, use new keys named nomifactory.quest.db.**_questid_**.**ste**.title and nomifactory.quest.db.**questid**.ste.desc;
3. move respective content to new keys.

So that:
1. makes sure expert and normal mode quest contents are unchanged (or at least, should be unchanged);
2. differences between expert and normal are in those ste keys;
3. other contents are shared with export and normal, in existing keys.

This PR changes [overrides/resources/questbook/lang/en_us.lang](https://github.com/tracer4b/nomi-ceu/blob/main/overrides/resources/questbook/lang/en_us.lang) which seems outdated, I don't know where the newest lang file lies. My new en_us.lang is based on the 1.3.5 release.

The zh_cn translation is pretty much unfinished, so I will PR that later, after language keys are handled appropriately.