### PR TITLE
Changed "Fluid Transport" quest text

### DIFF
--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -3470,7 +3470,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§b§2GTCEu Fluid Pipes have been reworked and work much better now. There are also Quadruple and Nonuple pipes for transporting multiple fluid types through the same block. Their advantage over EnderIO Fluid Conduits is their higher throughput - 414 mB/t for a low-tier (Normal Potin) pipe.\n\n§rHowever, EnderIO Fluid Conduits still have the advantage of being EnderIO Conduits, allowing them to fit in the same block as other Conduits. Pick your poison.",
+          "desc:8": "§b§2GTCEu Fluid Pipes have been reworked and work much better now. There are also Quadruple and Nonuple pipes for transporting multiple fluid types through the same block. Their advantage over EnderIO Fluid Conduits is their higher throughput - 800 mB/t for an Ender Fluid Conduit compared to 1800 mB/t for a Huge Steel Pipe.\n\n§rHowever, EnderIO Fluid Conduits still have the advantage of being EnderIO Conduits, allowing them to fit in the same block as other Conduits. Pick your poison.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -3470,7 +3470,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§b§2GTCEu Fluid Pipes have been reworked and work much better now. There are also Quadruple and Nonuple pipes for transporting multiple fluid types through the same block. Their advantage over EnderIO Fluid Conduits is their higher throughput - 800 mB/t for an Ender Fluid Conduit compared to 1800 mB/t for a Huge Steel Pipe.\n\n§rHowever, EnderIO Fluid Conduits still have the advantage of being EnderIO Conduits, allowing them to fit in the same block as other Conduits. Pick your poison.",
+          "desc:8": "§b§2GTCEu Fluid Pipes have been reworked and work much better now. There are also Quadruple and Nonuple pipes for transporting multiple fluid types through the same block. Their advantage over EnderIO Fluid Conduits is their higher throughput - 800 mB/t for an Ender Fluid Conduit compared to 1800 mB/t for a Huge Steel Fluid Pipe.\n\n§rHowever, EnderIO Fluid Conduits still have the advantage of being EnderIO Conduits, allowing them to fit in the same block as other Conduits. Pick your poison.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,


### PR DESCRIPTION
Changed quest text to:
1) provide a better example of increased pipe throughput vs EnderIO conduits
2) remove reference to incorrect transfer rate of Normal Potin Fluid Pipe.

Not sure if Small Potin Pipe retrieval task should be changed or removed? Really no reason to make it instead of the Pressurized Conduit early game. 