### PR TITLE
Remove dustFerroboron recipe (no such item exists)

### DIFF
--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -583,19 +583,10 @@ alloy.recipeBuilder()
     .inputs([<nuclearcraft:fission_block>, <minecraft:glass>])
     .duration(50).EUt(16).buildAndRegister();
 
-
-
 alloy.recipeBuilder()
     .outputs([<nuclearcraft:alloy:1> * 2])
     .inputs([<ore:ingotFerroboron>, <ore:dustLithium>])
     .duration(300).EUt(16).buildAndRegister();
-
-alloy.recipeBuilder()
-    .outputs([<nuclearcraft:alloy:1> * 2])
-    .inputs([<ore:dustFerroboron>, <ore:dustLithium>])
-    .duration(300).EUt(16).buildAndRegister();
-
-
 
 alloy.recipeBuilder()
     .outputs([<nuclearcraft:alloy:6> * 2])


### PR DESCRIPTION
Prevents a script error with GTCEu 2.4.1 originating from an empty ore dictionary entry (because there is no such item)