### PR TITLE
Some quests requiring the wrong genesis quest

### DIFF
--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -705,7 +705,7 @@
     "9:10": {
       "preRequisites:11": [
         141,
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -9594,7 +9594,7 @@
     "141:10": {
       "preRequisites:11": [
         4,
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -25570,7 +25570,7 @@
     },
     "393:10": {
       "preRequisites:11": [
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -26274,7 +26274,7 @@
     },
     "405:10": {
       "preRequisites:11": [
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -44878,7 +44878,7 @@
     },
     "743:10": {
       "preRequisites:11": [
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -47451,7 +47451,7 @@
     },
     "786:10": {
       "preRequisites:11": [
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -48502,7 +48502,7 @@
     },
     "803:10": {
       "preRequisites:11": [
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -48800,7 +48800,7 @@
     },
     "808:10": {
       "preRequisites:11": [
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -48986,7 +48986,7 @@
     },
     "811:10": {
       "preRequisites:11": [
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -54866,7 +54866,7 @@
     },
     "902:10": {
       "preRequisites:11": [
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -55260,7 +55260,7 @@
     },
     "909:10": {
       "preRequisites:11": [
-        805
+        3
       ],
       "properties:10": {
         "betterquesting:10": {


### PR DESCRIPTION
There seem to be two genesis quests, one of which being nonfunctional, that is required by all of the checkmark quests (+ 2 others) in the first questbook section. 
![image](https://user-images.githubusercontent.com/74614475/187178241-c71ffde6-313d-41bc-a92e-1aa99fdc404c.png)
At a first look, this quest was probably not intended to be used so I just replaced all of the prerequisite quests with the normal genesis quest.
![image](https://user-images.githubusercontent.com/74614475/187178172-c3c02a08-fc81-4fb9-8b76-4827bb777578.png)
