### PR TITLE
Fix Nomicoins being called Omnicoins

### DIFF
--- a/overrides/resources/contenttweaker/lang/en_us.lang
+++ b/overrides/resources/contenttweaker/lang/en_us.lang
@@ -143,10 +143,10 @@ material.phosphorus_trichloride=Phosphorus Trichloride
 material.phosphoryl_chloride=Phosphoryl Chloride
 material.tributyl_phosphate=Tributyl Phosphate
 
-item.contenttweaker.omnicoin.name=Omnipenny [1]
-item.contenttweaker.omnicoin5.name=Omninickel [5]
-item.contenttweaker.omnicoin25.name=Omniquarter [25]
-item.contenttweaker.omnicoin100.name=Omnidollar [100]
+item.contenttweaker.omnicoin.name=Nomipenny [1]
+item.contenttweaker.omnicoin5.name=Nominickel [5]
+item.contenttweaker.omnicoin25.name=Nomiquarter [25]
+item.contenttweaker.omnicoin100.name=Nomidollar [100]
 
 item.contenttweaker.woodenwidget.name=Wooden Widget
 item.contenttweaker.stonewidget.name=Stone Widget


### PR DESCRIPTION
Changes en_us.lang in contenttweaker so that the coins are called Nomipenny, Nominickel, Nomiquarter and Nomidollar instead of Omnipenny, Omninickel, Omniquarter and Omnidollar.