### PR TITLE
Change crafting amount to base 8

### DIFF
--- a/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -108,13 +108,13 @@ client {
     I:craftAmtButton1=1
 
     # Controls buttons on Crafting Screen : Capped at 99
-    I:craftAmtButton2=10
+    I:craftAmtButton2=16
 
     # Controls buttons on Crafting Screen : Capped at 999
-    I:craftAmtButton3=100
+    I:craftAmtButton3=128
 
     # Controls buttons on Crafting Screen : Capped at 9999
-    I:craftAmtButton4=1000
+    I:craftAmtButton4=1024
     B:disableColoredCableRecipesInJEI=true
     B:enableEffects=true
 


### PR DESCRIPTION
According to Discord feedback, many players prefer base 8 settings because most recipes consume or produce at base 2, 4 or 8 instead of 10