### PR TITLE
Allow oredicted ingot to complete the Infinity Ingot quest

### DIFF
--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -23725,7 +23725,7 @@
             "0:10": {
               "Count:3": 1,
               "Damage:2": 32026,
-              "OreDict:8": "",
+              "OreDict:8": "ingotInfinity",
               "id:8": "gregtech:meta_ingot"
             }
           },


### PR DESCRIPTION
This commit, https://github.com/tracer4b/nomi-ceu/commit/01c36556e3e089b80123d677e263885869175d2e, changed the extended crafting recipe for infinity ingots to make Avaritia ingot rather than gregtech ones.  However, the betterquesting quest was not updated to reflect this change.

This PR makes the quest accept the oredict value "ingotInfinity" so that either type of infinity ingot is sufficient to complete the quest.