### PR TITLE
Steam Grinder Hard Mode Quest Fix

### DIFF
--- a/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
+++ b/overrides/config-overrides/expert/betterquesting/DefaultQuests.json
@@ -42767,7 +42767,7 @@
               "Count:3": 22,
               "Damage:2": 0,
               "OreDict:8": "",
-              "id:8": "gregtech:steam_casing"
+              "id:8": "gregtech:metal_casing"
             }
           },
           "taskID:8": "bq_standard:retrieval"


### PR DESCRIPTION
Fixes #189 to require retrieval of 22 Bronze Machine Casings instead of 22 Bronze Hulls.