### PR TITLE
Update README.md (-O instead of -o)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you want a harder, or perhaps a more "true" GregTech experience, check out th
 Installation instructions:
 - Install the hardmode config files from [here](https://github.com/tracer4b/nomi-ceu/tree/main/overrides). Restart the pack for this to take effect. 
   - Windows users may grab the utility [here](https://raw.githubusercontent.com/tracer4b/nomi-ceu/main/pack-mode-switcher.bat)(right click - save as), save it to the root directory of the pack (the same level as `\config`).   
-  - MacOS and GNU/Linux users can run `curl -o https://raw.githubusercontent.com/tracer4b/nomi-ceu/main/pack-mode-switcher.sh` then verify the contents with your editor of choice before running `chmod +x pack-mode-switcher.sh; sh pack-mode-switcher.sh` in the pack root directory (the one containing `/config`).
+  - MacOS and GNU/Linux users can run `curl -O https://raw.githubusercontent.com/tracer4b/nomi-ceu/main/pack-mode-switcher.sh` then verify the contents with your editor of choice before running `chmod +x pack-mode-switcher.sh; sh pack-mode-switcher.sh` in the pack root directory (the one containing `/config`).
 - If you are on an existing world, run `/bq_admin default load` to load the hard mode questbook.
 
 ## Credits


### PR DESCRIPTION
-o vs -O

-o specifies output file name -O specifies that it is downloading a file instead.

I missed this difference. Oops