### PR TITLE
Add Wrench Script (from dev)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -211,7 +211,7 @@
     },
     {
       "projectID": 239197,
-      "fileID": 3587830,
+      "fileID": 4353149,
       "required": true
     },
     {

--- a/overrides/scripts/CustomWrench.zs
+++ b/overrides/scripts/CustomWrench.zs
@@ -1,0 +1,63 @@
+import crafttweaker.block.IBlock;
+import crafttweaker.player.IPlayer;
+import crafttweaker.block.IBlockPattern;
+import crafttweaker.event.PlayerInteractBlockEvent;
+
+<ore:wrenchCustom>.add(<thermalfoundation:wrench>,
+                       <enderio:item_yeta_wrench>,
+                       <redstonearsenal:tool.wrench_flux>,
+                       <redstonearsenal:tool.battlewrench_flux>);
+
+static wrenchables as IBlockPattern = <thermalexpansion:tank> as IBlock |
+                                      <thermalexpansion:cell> as IBlock |
+                                      <extrautils2:creativeenergy> as IBlock |
+                                      <extrautils2:passivegenerator:6> as IBlock |
+                                      <extrautils2:drum:4> as IBlock;
+
+function isNotWrenchable(block as IBlock) as bool {
+	return isNull(block) || // no block
+		!(wrenchables has block); // not wrenchable
+}
+
+function isNotWrenching(player as IPlayer) as bool {
+	return isNull(player) || // no player
+		!player.isSneaking || // not sneaking
+		isNull(player.currentItem) || // no item is held
+		!(<ore:wrenchCustom> has player.currentItem); // not a wrench
+}
+
+function playerIsNotWrenchingWrenchable(evt as PlayerInteractBlockEvent) as bool {
+	// gracefully handle unusual circumstances
+	if (isNull(evt) || isNull(evt.world) || evt.canceled || evt.useItem == "DENY")
+		return true;
+
+	return isNotWrenching(evt.player) || isNotWrenchable(evt.block);
+}
+
+function dropItem(evt as PlayerInteractBlockEvent) as bool {
+    if (evt.world.remote)
+        return true;
+
+    val stack = evt.world.getPickedBlock(evt.position, evt.player.getRayTrace(4, 0), evt.player);
+
+    if (isNull(stack) || !evt.world.setBlockState(<blockstate:minecraft:air>, evt.position))
+        return false;
+
+    // dummy entity to drop the item with
+    val dummy = <entity:minecraft:arrow>.createEntity(evt.world);
+    dummy.posX = evt.x as double + 0.5;
+    dummy.posY = evt.y as double + 0.5;
+    dummy.posZ = evt.z as double + 0.5;
+
+    dummy.dropItem(stack);
+}
+
+events.onPlayerInteractBlock(function(evt as PlayerInteractBlockEvent) as void {
+	if (playerIsNotWrenchingWrenchable(evt))
+		return;
+
+    if (dropItem(evt)) {
+        evt.cancellationResult = "SUCCESS";
+        evt.cancel();
+	}
+});

--- a/overrides/scripts/CustomWrench.zs
+++ b/overrides/scripts/CustomWrench.zs
@@ -8,11 +8,12 @@ import crafttweaker.event.PlayerInteractBlockEvent;
                        <redstonearsenal:tool.wrench_flux>,
                        <redstonearsenal:tool.battlewrench_flux>);
 
-static wrenchables as IBlockPattern = <thermalexpansion:tank> as IBlock |
-                                      <thermalexpansion:cell> as IBlock |
-                                      <extrautils2:creativeenergy> as IBlock |
+<ore:wrenchCustom>.addAll(<ore:gtceWrenches>);
+
+static wrenchables as IBlockPattern = <extrautils2:creativeenergy> as IBlock |
                                       <extrautils2:passivegenerator:6> as IBlock |
-                                      <extrautils2:drum:4> as IBlock;
+                                      <extrautils2:drum:4> as IBlock |
+                                      <draconicevolution:creative_rf_source> as IBlock;
 
 function isNotWrenchable(block as IBlock) as bool {
 	return isNull(block) || // no block

--- a/overrides/scripts/CustomWrench.zs
+++ b/overrides/scripts/CustomWrench.zs
@@ -10,10 +10,13 @@ import crafttweaker.event.PlayerInteractBlockEvent;
 
 <ore:wrenchCustom>.addAll(<ore:gtceWrenches>);
 
-static wrenchables as IBlockPattern = <extrautils2:creativeenergy> as IBlock |
+static wrenchables as IBlockPattern = <thermalexpansion:tank> as IBlock |
+                                      <thermalexpansion:cell> as IBlock |
+                                      <extrautils2:creativeenergy> as IBlock |
                                       <extrautils2:passivegenerator:6> as IBlock |
                                       <extrautils2:drum:4> as IBlock |
-                                      <draconicevolution:creative_rf_source> as IBlock;
+                                      <draconicevolution:creative_rf_source> as IBlock |
+                                      <appliedenergistics2:creative_energy_cell> as IBlock;
 
 function isNotWrenchable(block as IBlock) as bool {
 	return isNull(block) || // no block


### PR DESCRIPTION
Script is from dev.
This fixes the problem of some of Extra Utilities 2's creative items being unbreakable.

Changes from the dev script:
Thermal Creative Items were removed from list of wrenchable blocks as they are no longer obtainable, and they were known to cause problems when responding to GT Wrenches in https://github.com/Nomifactory/Nomifactory/pull/598.
Draconic Evolution Creative Energy Source was added to the list of wrenchable blocks.
GTCEu wrenches were added to the list of wrenches.